### PR TITLE
Fix #23: Restrict conjunction rule to provable form

### DIFF
--- a/theories/Dot/lr_lemma.v
+++ b/theories/Dot/lr_lemma.v
@@ -33,10 +33,10 @@ Section Sec.
       iFrame "Hg". by iApply interp_weaken_one.
   Qed.
 
-  Lemma TAnd_I e T1 T2:
-    Γ ⊨ e : T1 -∗
-    Γ ⊨ e : T2 -∗
-    Γ ⊨ e : TAnd T1 T2.
+  Lemma TAnd_I v T1 T2:
+    Γ ⊨ tv v : T1 -∗
+    Γ ⊨ tv v : T2 -∗
+    Γ ⊨ tv v : TAnd T1 T2.
   Proof.
     iIntros "#HT1 #HT2 /=".
     (* iDestruct "HT1" as "[% #HT1]". *) (* Works *)
@@ -44,7 +44,7 @@ Section Sec.
     iDestruct "HT1" as "[$ #HT1']". iClear "HT1".
     iDestruct "HT2" as "[_ #HT2]".
     iIntros "!>" (ρ) "#Hg".
-    iApply wp_and; by [> iApply "HT1'" | iApply "HT2"].
+    iApply wp_and_val; by [> iApply "HT1'" | iApply "HT2"].
   Qed.
 
 

--- a/theories/Dot/typing.v
+++ b/theories/Dot/typing.v
@@ -69,10 +69,10 @@ Inductive typed Γ : tm → ty → Prop :=
     Γ ⊢ₜ iterate tskip i e : T2
 (* A bit surprising this is needed, but appears in the DOT papers, and this is
    only admissible if t has a type U that is a proper subtype of TAnd T1 T2. *)
-| TAndI_typed T1 T2 t:
-    Γ ⊢ₜ t : T1 →
-    Γ ⊢ₜ t : T2 →
-    Γ ⊢ₜ t : TAnd T1 T2
+| TAndI_typed T1 T2 v:
+    Γ ⊢ₜ tv v : T1 →
+    Γ ⊢ₜ tv v : T2 →
+    Γ ⊢ₜ tv v : TAnd T1 T2
 where "Γ ⊢ₜ e : T " := (typed Γ e T)
 with dms_typed Γ : ty → dms → ty → Prop :=
 | dnil_typed V : Γ |ds V ⊢ [] : TTop

--- a/theories/fullwp_extra.v
+++ b/theories/fullwp_extra.v
@@ -1,0 +1,19 @@
+From iris.proofmode Require Import tactics.
+
+From iris.program_logic Require Import language lifting.
+
+Section wp_extra.
+  Context `{!irisG Λ Σ}.
+  Implicit Types P : val Λ → iProp Σ.
+  Implicit Types v : val Λ.
+
+  Lemma wp_and_val P1 P2 v:
+    WP of_val v {{ P1 }} -∗ WP of_val v {{ P2 }} -∗
+                            WP of_val v {{ v, P1 v ∧ P2 v }}.
+  Proof.
+    iIntros "H1 H2".
+    iMod (wp_value_inv' with "H1") as "H1'".
+    iMod (wp_value_inv' with "H2") as "H2'".
+    iApply wp_value'; by iSplit.
+  Qed.
+End wp_extra.

--- a/theories/proofmode_extra.v
+++ b/theories/proofmode_extra.v
@@ -148,6 +148,16 @@ Section wp_extra.
     iIntros (HwfE Hpres) "Hwp HΦ". iApply (wp_strong_mono_wf with "Hwp"); eauto.
   Qed.
 
+  Lemma wp_and_val P1 P2 v:
+    WP of_val v {{ P1 }} -∗ WP of_val v {{ P2 }} -∗
+      WP of_val v {{ v, P1 v ∧ P2 v }}.
+  Proof.
+    iIntros "H1 H2".
+    iDestruct (wp_value_inv' with "H1") as "H1'".
+    iDestruct (wp_value_inv' with "H2") as "H2'".
+    iApply wp_value'; by iSplit.
+  Qed.
+
   Lemma wp_and `{∀ σ κ n, Persistent (state_interp σ κ n)} (P1 P2: val Λ → iProp Σ) e:
     WP e {{ P1 }} -∗ WP e {{ P2 }} -∗ WP e {{ v, P1 v ∧ P2 v }}.
   Proof.


### PR DESCRIPTION
DOT calculi only ever require the conjunction rule for variables.
And we can prove this rule for arbitrary values, even for the standard weakest
precondition.