### PR TITLE
Prove fundamental theorem for **definition** typing (fix #11)

### DIFF
--- a/theories/Dot/fundamental.v
+++ b/theories/Dot/fundamental.v
@@ -98,9 +98,9 @@ Section fundamental.
 
   (* XXX these statements point out we need to realign the typing judgemnts. *)
   Lemma fundamental_dm_typed Γ V d T (HT: Γ |d V ⊢ d : T):
-    wellMapped getStampTable -∗ TLater V :: Γ ⊨d d : T with
+    wellMapped getStampTable -∗ Γ |L V ⊨d d : T with
   fundamental_dms_typed Γ V ds T (HT: Γ |ds V ⊢ ds : T):
-    wellMapped getStampTable -∗ TLater V :: Γ ⊨ds ds : T with
+    wellMapped getStampTable -∗ Γ |L V ⊨ds ds : T with
   fundamental_subtype Γ T1 i1 T2 i2 (HT: Γ ⊢ₜ T1, i1 <: T2, i2):
     wellMapped getStampTable -∗ Γ ⊨ [T1, i1] <: [T2, i2] with
   fundamental_typed Γ e T (HT: Γ ⊢ₜ e : T):
@@ -113,8 +113,10 @@ Section fundamental.
         last by iApply extraction_to_leadsto_envD_equiv.
         by iApply fundamental_subtype.
         by iApply fundamental_subtype.
-      + iApply idtp_vmem_i. by iApply fundamental_typed.
-    - admit.
+      + iApply TVMem_I. by iApply fundamental_typed.
+    - iIntros "#Hm"; iInduction HT as [] "IHT".
+      + by iApply DNil_I.
+      + iApply DCons_I => //. by iApply fundamental_dm_typed.
     - iIntros "#Hm"; iInduction HT as [] "IHT".
       + by iApply Sub_Refl.
       + by iApply Sub_Trans.

--- a/theories/Dot/lr_lemmasDefs.v
+++ b/theories/Dot/lr_lemmasDefs.v
@@ -2,18 +2,104 @@ From iris.proofmode Require Import tactics.
 From D Require Import tactics.
 From D.Dot Require Import unary_lr_binding rules.
 
+Implicit Types (L T U: ty) (v: vl) (e: tm) (d: dm) (ds: dms) (Γ : ctx).
+
+From D Require Import locAsimpl.
+
+Lemma norm_selfSubst ds s: selfSubst ds.|[up s] = ds.|[(vobj ds).[s] .: s].
+Proof. by rewrite /selfSubst /=; asimpl. Qed.
+
+Lemma dms_hasnt_map_mono ds l f:
+  dms_hasnt ds l →
+  dms_hasnt (map (mapsnd f) ds) l.
+Proof.
+  elim: ds => //; rewrite /dms_hasnt/mapsnd/= => [[l' d] ds IHds H].
+  by case_decide; eauto 2.
+Qed.
+
+Lemma dms_lookup_head l d ds: dms_lookup l ((l, d) :: ds) = Some d.
+Proof. by cbn; case_decide. Qed.
+
+Lemma dms_lookup_mono l l' d d' ds:
+  dms_hasnt ds l →
+  dms_lookup l' ds = Some d' →
+  dms_lookup l' ((l, d) :: ds) = Some d'.
+Proof.
+  rewrite /dms_hasnt /= => Hlds Hl; by case_decide; simplify_eq.
+Qed.
+
 Section Sec.
   Context `{HdotG: dotG Σ}.
 
-  Context (Γ: list ty).
-  Implicit Types (L T U: ty) (v: vl) (e: tm) (d: dm) (ds: dms) (Γ : list ty).
+  Lemma lift_dinterp_dms_vl_commute T ds ρ l:
+    nclosed_vl (vobj ds) 0 →
+    label_of_ty T = Some l →
+    lift_dinterp_dms T ρ (selfSubst ds) -∗
+    lift_dinterp_vl l (def_interp T) ρ (vobj ds).
+  Proof.
+    rewrite /lift_dinterp_dms => /= ? ->; iIntros "H".
+    iDestruct "H" as (?l d (?&?&?)) "?"; simplify_eq.
+    iSplit => //. iExists d; iFrame; iPureIntro. by eexists _.
+  Qed.
+
+  Lemma lift_dsinterp_dms_vl_commute T ds ρ:
+    nclosed_vl (vobj ds) 0 →
+    defs_interp T ρ (selfSubst ds) -∗
+    interp T ρ (vobj ds).
+  Proof.
+    iIntros (Hcl) "#H".
+    iPoseProof (defs_interp_v_closed with "H") as "%". move: H => Hclds.
+    iInduction T as [] "IHT"; cbn;
+    try by [| iDestruct "H" as (???) "?"].
+    - iDestruct "H" as "[#H1 #H2]".
+      by iSplit; [> iApply "IHT"| iApply "IHT1"].
+    - by iApply (lift_dinterp_dms_vl_commute (TVMem _ _)).
+    - by iApply (lift_dinterp_dms_vl_commute (TTMem _ _ _)).
+  Qed.
+
+  Lemma def2defs_head T l ρ d ds:
+    label_of_ty T = Some l →
+    nclosed ((l, d) :: ds) 0 →
+    def_interp T ρ d -∗
+    lift_dinterp_dms T ρ ((l, d) :: ds).
+  Proof. iIntros; iExists l, d. eauto using dms_lookup_head. Qed.
+
+  Lemma fv_pair_cons_dms l d ds n:
+    nclosed ds n → nclosed d n → nclosed ((l, d) :: ds) n.
+  Proof. by apply fv_pair_cons. Qed.
+  Hint Resolve fv_pair_cons_dms.
+
+  Lemma lift_dinterp_dms_mono T l ρ d ds:
+    dms_hasnt ds l → nclosed d 0 → nclosed ds 0 →
+    lift_dinterp_dms T ρ ds -∗
+    lift_dinterp_dms T ρ ((l, d) :: ds).
+  Proof.
+    iIntros (???) "#HT"; iDestruct "HT" as (l' d' (?&?&?)) "#H".
+    iExists _, _; iSplit; eauto 6 using dms_lookup_mono.
+  Qed.
+
+  Lemma defs_interp_mono T l ρ d ds:
+    dms_hasnt ds l → nclosed d 0 → nclosed ds 0 →
+    defs_interp T ρ ds -∗
+    defs_interp T ρ ((l, d) :: ds).
+  Proof.
+    iIntros (Hlds Hcls Hclds) "#HT".
+    iInduction T as [] "IHT" => //=;
+      try by [iDestruct "HT" as (???) "?" | iApply lift_dinterp_dms_mono | auto].
+    iDestruct "HT" as "[HT1 HT2]"; iSplit; by [>iApply "IHT"|iApply "IHT1"].
+  Qed.
+
+  Context Γ.
+
+  Local Arguments lift_dinterp_vl: simpl never.
+  Local Arguments lift_dinterp_dms: simpl never.
+  Local Arguments def_interp_tmem: simpl never.
+  Local Arguments def_interp_vmem: simpl never.
 
   (** Lemmas about definition typing. *)
-  (* TODO: replace [TLater V :: Γ ⊨d dvl v : TVMem l T] by
-    [Γ | V ⊨d dvl v : TVMem l T]. *)
-  Lemma idtp_vmem_i V T v l:
+  Lemma TVMem_I (V: ty) T v l:
     V :: Γ ⊨ tv v : T -∗
-    TLater V :: Γ ⊨d dvl v : TVMem l T.
+    Γ |L V ⊨d dvl v : TVMem l T.
   Proof.
     iIntros "/= #[% #Hv]". move: H => Hclv. apply fv_tv_inv in Hclv.
     iSplit. by auto using fv_dvl.
@@ -26,96 +112,6 @@ Section Sec.
     iNext. iApply wp_value_inv'; iApply "Hv"; by iSplit.
   Qed.
 
-  (* Lemma dtp_tand_i T U ρ d ds l: *)
-  (*   defs_interp T ρ ds -∗ *)
-  (*   def_interp U ρ d -∗ *)
-  (*   defs_interp (TAnd T U) ρ (cons (l, d) ds). *)
-  (* Proof. naive_solver. Qed. *)
-
-  Lemma def_interp_to_interp T d ds ρ s l:
-    let v0 := (vobj ((l, d) :: ds)).[s] in
-    nclosed_vl v0 0 →
-    label_of_ty T = Some l →
-    def_interp T ρ (d.|[v0 .: s]) ⊢
-    interp T ρ v0.
-  Proof.
-    intros * Hfvv0 HTlabel. asimpl.
-    set (d' := d.|[up s]); set (ds' := ds.|[up s]).
-    assert (nclosed_vl (vobj ((l, d') :: ds')) 0) as Hfv'. {
-      revert v0 Hfvv0.
-      asimpl.
-      by subst d' ds'.
-    }
-    assert (length ds = length ds') as Hlen'. by rewrite /ds' /hsubst map_length.
-    assert (vobj ((l, d') :: ds') @ l ↘ d'.|[vobj ((l, d') :: ds')/]) as Hlookup.
-      by eexists _; split => //=; case_match.
-      (* XXX we need to rewrite this lemma for the new lookup relation, after fixing typing.
-        by rewrite Hlen'; apply obj_lookup_cons. *)
-    induction T => //=; try (by iIntros "**").
-    all: cbn in HTlabel; injectHyps; iIntros "[% #H]"; move: H => Hvd.
-    - iDestruct "H" as (vmem) "[#H1 #H2]".
-      iSplit => //.
-      iExists (d'.|[vobj ((l, d') :: ds')/]).
-      subst d' ds'; iSplit => //.
-      asimpl; trivial.
-      (* subst d' ds'. asimpl. apply Hlookup. *)
-      (* subst; eauto. *)
-      (* subst d'. asimpl. *)
-      iSplit => //. iExists _. iSplit => //.
-    - iDestruct "H" as (φ) "[#Hl [#? #?]]".
-      iSplit => //.
-      iExists (d'.|[vobj ((l, d') :: ds')/]). iSplit => //.
-      subst d'; asimpl.
-      iSplit => //. iExists φ; iSplit => //.
-      iModIntro. repeat iSplitL; naive_solver.
-  Qed.
-
-  (* Formerly wip_hard. *)
-  Lemma defs_interp_to_interp T ds ρ s:
-    let v0 := (vobj ds).[s] in
-    nclosed_vl v0 0 →
-    defs_interp T ρ (ds.|[v0 .: s]) ⊢
-    interp T ρ v0.
-  Proof.
-    (* induction ds; asimpl; iIntros (Hcl) "H". *)
-    (* - destruct T => //=. *)
-    (* - simpl in IHds. *)
-    (*   destruct T => //=. *)
-    (*   Fail iApply dtp_tand_i. *)
-    (*   Fail iApply IHds. *)
-    (*   Restart. *)
-
-    simpl; iIntros (Hcl) "#H".
-    iPoseProof (defs_interp_v_closed with "H") as "%". move: H => Hclds.
-    iInduction T as [] "IHT" forall (ds Hcl Hclds) => //=; try iDestruct "H" as (l1 d) "[% H']"; trivial.
-
-    (* destruct ds => //=. rewrite map_length. *)
-    (* iDestruct "H" as "[#H1 #H2]". *)
-    (* iSplit. *)
-    (* 2: { by iApply (def_interp_to_interp T2 d ds ρ s). } *)
-    (* - asimpl. *)
-    (*   iAssert (⟦ T1 ⟧ ρ (vobj (ds.|[up s]))) as "#H3". { *)
-    (*     iApply ("IHT" $! ds) => //. *)
-    (*     admit. *)
-    (*     admit. *)
-    (*     asimpl. *)
-    (*     Fail iApply "H1". *)
-    (*     admit. *)
-    (*   } *)
-    (*   (* We could probably go from H3 to the thesis... *) *)
-    (*   iApply ("IHT" $! (d :: ds)) => //. *)
-    (*   admit. *)
-
-    (*   (* iApply (IHT1 (d :: ds)). *) *)
-    (*   (* set (d' := d.|[up (to_subst ρ)]). *) *)
-    (*   (* set (ds' := ds.|[up (to_subst ρ)]). *) *)
-    (*   (* change (ds.|[up (to_subst ρ)]) with ds'. *) *)
-
-    (* (* simpl. *) *)
-    (* (* induction T; rewrite /defs_interp => //=; fold defs_interp; *) *)
-    (* (* try solve [iIntros; try done]. *) *)
-  Admitted.
-
   (* Check that Löb induction works as expected for proving introduction of
    * objects. Using Löb induction works easily.
    *
@@ -124,21 +120,42 @@ Section Sec.
    * Γ ⊨ nu x. ds : μ x. T
    *)
   Lemma T_New_I T ds:
-     (TLater T :: Γ ⊨ds ds : T →
-     Γ ⊨ tv (vobj ds) : TMu T)%I.
+     Γ |L T ⊨ds ds : T -∗
+     Γ ⊨ tv (vobj ds) : TMu T.
   Proof.
-    iIntros "/= #[% Hds]". move: H => Hclds. iSplit; auto using fv_tv, fv_vobj. iIntros " !> * #Hρ /=".
-    iApply wp_value.
+    iIntros "/= #[% #Hds]"; move: H => Hclds.
+    iSplit; auto using fv_tv, fv_vobj.
+    iIntros " !> * #Hρ /="; iApply wp_value.
     iPoseProof (interp_env_ρ_closed with "Hρ") as "%". move: H => Hclρ.
-    iPoseProof (interp_env_len_agree with "Hρ") as "%". move: H => Hlen. rewrite <- Hlen in *.
-    assert (nclosed_vl (vobj ds).[to_subst ρ] 0) as Hclvds. {
-      eapply (fv_to_subst_vl (vobj ds)) => //. by apply fv_vobj.
-    }
-
+    iPoseProof (interp_env_len_agree with "Hρ") as "%". move: H => Hlen.
+    have Hclvds: nclosed_vl (vobj ds).[to_subst ρ] 0.
+      by eapply (fv_to_subst_vl (vobj ds)); rewrite // Hlen; apply fv_vobj.
     iLöb as "IH".
-    iApply defs_interp_to_interp. exact Hclvds.
-    iPoseProof ("Hds" $! (vobj ds.|[up (to_subst ρ)] :: ρ)) as "#H".
-    asimpl. iApply "H". repeat iSplit => //.
+    iApply lift_dsinterp_dms_vl_commute;
+      rewrite // norm_selfSubst -to_subst_cons.
+      iApply "Hds"; by iFrame "IH Hρ".
   Qed.
 
+  Lemma DNil_I : Γ ⊨ds [] : TTop.
+  Proof. iSplit => //. by iIntros "!> **". Qed.
+
+  Lemma DCons_I d ds l T1 T2:
+    dms_hasnt ds l →
+    label_of_ty T1 = Some l →
+    Γ  ⊨d d : T1 -∗ Γ  ⊨ds ds : T2 -∗
+    Γ  ⊨ds (l, d) :: ds : TAnd T1 T2.
+  Proof.
+    iIntros (Hlds Hl) "[% #H1] [% #H2]". move: H H0 => Hcld Hclds.
+    have Hclc: nclosed ((l, d) :: ds) (length Γ). by auto.
+    iSplit => //; iIntros "!>" (ρ) "#HG /=".
+    iSpecialize ("H1" with "HG"); iSpecialize ("H2" with "HG").
+    iPoseProof (interp_env_ρ_closed with "HG") as "%". move: H => Hclρ.
+    iPoseProof (interp_env_len_agree with "HG") as "%". move: H => Hlen. rewrite <-Hlen in *.
+    have Hclsd: nclosed d.|[to_subst ρ] 0. by eapply fv_to_subst.
+    have Hclsds: nclosed ds.|[to_subst ρ] 0. by eapply fv_to_subst.
+    have Hclsc: nclosed ((l, d) :: ds).|[to_subst ρ] 0. by eapply fv_to_subst.
+    iSplit.
+    - destruct T1; simplify_eq; by iApply def2defs_head.
+    - iApply defs_interp_mono => //; by apply dms_hasnt_map_mono.
+  Qed.
 End Sec.

--- a/theories/Dot/typeExtractionSem.v
+++ b/theories/Dot/typeExtractionSem.v
@@ -141,7 +141,7 @@ Section interp_equiv.
 End interp_equiv.
 
 Section typing_type_member_defs.
-  Context `{!dotG Σ} Γ.
+  Context `{!dotG Σ}.
 
   Definition leadsto_envD_equiv (sσ: extractedTy) n (φ : envD Σ) : iProp Σ :=
     let '(s, σ) := sσ in
@@ -169,13 +169,13 @@ Section typing_type_member_defs.
   (** XXX In fact, this lemma should be provable for any φ,
       not just ⟦ T ⟧, but we haven't actually defined the
       necessary notation to state it:
-  Lemma D_Typ_Sem L U s σ l φ:
+  Lemma D_Typ_Sem Γ L U s σ l φ:
     Γ ⊨ [φ, 1] <: [U, 1] -∗
     Γ ⊨ [L, 1] <: [φ, 1] -∗
     (s, σ) ↝[ length Γ ] φ -∗
     Γ ⊨d dtysem σ s : TTMem l L U.
     *)
-  Lemma D_Typ T L U s σ l:
+  Lemma D_Typ Γ T L U s σ l:
     Γ ⊨ [T, 1] <: [U, 1] -∗
     Γ ⊨ [L, 1] <: [T, 1] -∗
     (s, σ) ↝[ length Γ ] ⟦ T ⟧ -∗
@@ -200,8 +200,8 @@ Section typing_type_member_defs.
       by repeat iModIntro; iApply (internal_eq_iff with "Hγφ").
   Qed.
 
-  Lemma D_Typ_Concr T s σ l:
-    (s, σ) ↝[ (length Γ) ] ⟦ T ⟧ -∗
+  Lemma D_Typ_Concr Γ T s σ l:
+    (s, σ) ↝[ length Γ ] ⟦ T ⟧ -∗
     Γ ⊨d dtysem σ s : TTMem l T T.
   Proof. iIntros "#Hs"; iApply D_Typ; by [| iIntros "!> **"]. Qed.
 End typing_type_member_defs.


### PR DESCRIPTION
I revised all relevant proof scripts and definitions.
T_New_I is still proved by Löb induction in the same way.

The commit on path typing that was here is now in master (0cb27f08282153396aa69b7e1733254c057f8afb).
Fix #11.