### PR TITLE
Restructure basic modules as `Module Type`

### DIFF
--- a/theories/DSub/operational.v
+++ b/theories/DSub/operational.v
@@ -1,7 +1,7 @@
 From D Require Import dlang.
 From D.DSub Require Export syn.
 
-Include LiftWp syn syn.
+Include LiftWp syn.
 
 (**
 Possible future plan.

--- a/theories/Dot/operational.v
+++ b/theories/Dot/operational.v
@@ -1,4 +1,4 @@
 From D Require Import dlang.
 From D.Dot Require Export syn.
 
-Include LiftWp syn syn.
+Include LiftWp syn.

--- a/theories/asubst_base.v
+++ b/theories/asubst_base.v
@@ -1,7 +1,7 @@
 From D Require Import prelude asubst_intf.
 
-Module Type SortsLemmas (Import values : Values) <: SortsIntf values.
-
+Module Type SortsLemmas (V : Values) <: SortsIntf.
+Module Import values := V.
 Class Sort (s : Type)
   {inh_s : Inhabited s}
   {ids_s : Ids s} {ren_s : Rename s} {hsubst_vl_s : HSubst vl s}

--- a/theories/asubst_intf.v
+++ b/theories/asubst_intf.v
@@ -20,8 +20,8 @@ Module Type Values.
   Declare Instance subst_lemmas_vl : SubstLemmas vl.
 End Values.
 
-Module Type SortsIntf (values: Values).
-  Import values.
+Module Type SortsIntf.
+  Declare Module Export values : Values.
 
   Class Sort (s : Type)
     {inh_s : Inhabited s}

--- a/theories/dlang.v
+++ b/theories/dlang.v
@@ -18,7 +18,7 @@ Section mapsto_stamp_gname.
 End mapsto_stamp_gname.
 End mapsto.
 
-Module Type LiftWp (Import values: Values) (Import sorts: SortsIntf values).
+Module Type LiftWp (Import sorts: SortsIntf).
   Export mapsto saved_interp weakestpre.
   Implicit Types (v : vl) (ρ vs : vls) (Σ : gFunctors).
 

--- a/theories/olty.v
+++ b/theories/olty.v
@@ -4,11 +4,11 @@ From iris.program_logic Require Import language.
 From D.pure_program_logic Require Import lifting adequacy.
 From D Require Export gen_iheap saved_interp.
 
-Module Type OLty (Import values: Values) (Import sorts: SortsIntf values).
+Module Type OLty (Import sorts: SortsIntf).
 
 (* Instead of duplicating [envD], Include LiftWp: *)
 (* Notation envD Σ := (vls -d> vl -d> iProp Σ). *)
-Include LiftWp values sorts.
+Include LiftWp sorts.
 
 Section olty_limit_preserving.
   Context `{Σ : gFunctors}.
@@ -105,12 +105,12 @@ End OLty.
     while reusing as much as possible.
 *)
 
-Module Type OLty_judge (Import values: Values) (Import sorts: SortsIntf values).
+Module Type OLty_judge (Import sorts: SortsIntf).
 (* TODO Eventually switch to: *)
 
 (* Include (LiftWp values sorts). *)
 (* Or just inline this code there. *)
-Include OLty values sorts.
+Include OLty sorts.
 
 Class Closeable s := nclosed_s : s → nat → Prop.
 Instance closeable_sort s `{Sort s} : Closeable s := nclosed.


### PR DESCRIPTION
This way, a module can depend on another one without either creating a separate instance, or redeclaring all needed definitions in a separate interface.

The pattern is the one explained in https://stackoverflow.com/a/56378580/53974. I actually realized this would work here, after seeing it used extensively in the Coq stdlib for numbers.