### PR TITLE
Switch to infinite substitutions as argument to logical relation

### DIFF
--- a/theories/DSub/adequacy.v
+++ b/theories/DSub/adequacy.v
@@ -19,7 +19,7 @@ Qed.
    instantiation pattern, from e.g.
    https://gitlab.mpi-sws.org/iris/examples/blob/a89dc12821b63eeb9b831d21629ac55ebd601f38/theories/logrel/F_mu_ref/soundness.v#L29-39. *)
 Corollary almost_type_soundness e e' thp σ σ' T:
-  (forall `{dlangG Σ} `{SwapProp (iPropSI Σ)}, True ⊢ ⟦ T ⟧ₑ [] e) →
+  (forall `{dlangG Σ} `{SwapProp (iPropSI Σ)}, True ⊢ ⟦ T ⟧ₑ ids e) →
   rtc erased_step ([e], σ) (thp, σ') → e' ∈ thp →
   is_Some (to_val e') ∨ reducible e' σ'.
 Proof.

--- a/theories/DSub/typeExtractionSem.v
+++ b/theories/DSub/typeExtractionSem.v
@@ -31,11 +31,11 @@ Section interp_equiv.
       σ in ρ. And the result is only equivalent for closed ρ with the expected length. *)
   Definition interp_extractedTy: (ty * vls) → envD Σ :=
     λ '(T, σ) ρ v,
-    (⟦ T ⟧ (subst_sigma σ ρ) v)%I.
+    (⟦ T ⟧ (to_subst σ.|[ρ]) v)%I.
   Notation "⟦ T ⟧ [ σ ]" := (interp_extractedTy (T, σ)).
 
   Definition envD_equiv n φ1 φ2: iProp Σ :=
-    (∀ ρ v, ⌜ length ρ = n ⌝ → ⌜ cl_ρ ρ ⌝ → φ1 ρ v ≡ φ2 ρ v)%I.
+    (∀ ρ v, ⌜ length ρ = n ⌝ → ⌜ cl_ρ ρ ⌝ → φ1 (to_subst ρ) v ≡ φ2 (to_subst ρ) v)%I.
   Notation "φ1 ≈[  n  ] φ2" := (envD_equiv n φ1 φ2) (at level 70).
 
   Lemma extraction_envD_equiv g s σ T n:

--- a/theories/DSub/unary_lr_binding.v
+++ b/theories/DSub/unary_lr_binding.v
@@ -10,8 +10,8 @@ Section logrel_binding_lemmas.
   Context `{!dlangG Σ}.
 
   Lemma interp_weaken ρ1 ρ2 ρ3 τ :
-    ⟦ τ.|[upn (length ρ1) (ren (+ length ρ2))] ⟧ (ρ1 ++ ρ2 ++ ρ3)
-    ≡ ⟦ τ ⟧ (ρ1 ++ ρ3).
+    ⟦ τ.|[upn (length ρ1) (ren (+ length ρ2))] ⟧ (to_subst (ρ1 ++ ρ2 ++ ρ3))
+    ≡ ⟦ τ ⟧ (to_subst (ρ1 ++ ρ3)).
   Proof.
     revert ρ1 ρ2 ρ3; induction τ=> ρ1 ρ2 ρ3 w /=; properness; try solve [
       trivial | apply IHτ | apply IHτ1 | apply IHτ2 | apply (IHτ2 (_ :: _)) | apply (IHτ (_ :: _)) |
@@ -19,19 +19,19 @@ Section logrel_binding_lemmas.
   Qed.
 
   Lemma interp_weaken_one v τ ρ:
-     ⟦ τ.|[ren (+1)] ⟧ (v :: ρ) ≡ ⟦ τ ⟧ ρ.
+     ⟦ τ.|[ren (+1)] ⟧ (v .: to_subst ρ) ≡ ⟦ τ ⟧ (to_subst ρ).
   Proof. apply (interp_weaken [] [v]). Qed.
 
   Lemma interp_subst_up ρ1 ρ2 τ v:
-    ⟦ τ.|[upn (length ρ1) (v.[ren (+length ρ2)] .: ids)] ⟧ (ρ1 ++ ρ2)
-    ≡ ⟦ τ ⟧ (ρ1 ++ v :: ρ2).
+    ⟦ τ.|[upn (length ρ1) (v.[ren (+length ρ2)] .: ids)] ⟧ (to_subst (ρ1 ++ ρ2))
+    ≡ ⟦ τ ⟧ (to_subst (ρ1 ++ v :: ρ2)).
   Proof.
     revert ρ1 ρ2; induction τ=> ρ1 ρ2 w /=; properness; try solve [
       trivial | apply IHτ | apply IHτ1 | apply IHτ2 | apply (IHτ2 (_ :: _)) | apply (IHτ (_ :: _)) |
       asimpl; rewrite ?to_subst_up //].
   Qed.
 
-  Lemma interp_subst ρ τ v1 v2 : ⟦ τ.|[v1.[ren (+length ρ)]/] ⟧ ρ v2 ≡ ⟦ τ ⟧ (v1 :: ρ) v2.
+  Lemma interp_subst ρ τ v1 v2 : ⟦ τ.|[v1.[ren (+length ρ)]/] ⟧ (to_subst ρ) v2 ≡ ⟦ τ ⟧ (v1 .: to_subst ρ) v2.
   Proof. apply (interp_subst_up []). Qed.
 
   Context Γ.
@@ -48,7 +48,7 @@ Section logrel_binding_lemmas.
 
   Lemma interp_env_lookup ρ T x:
     Γ !! x = Some T →
-    ⟦ Γ ⟧* ρ -∗ ⟦ T.|[ren (+x)] ⟧ ρ (to_subst ρ x).
+    ⟦ Γ ⟧* ρ -∗ ⟦ T.|[ren (+x)] ⟧ (to_subst ρ) (to_subst ρ x).
   Proof.
     iIntros (Hx) "* Hg".
     iInduction Γ as [|T' Γ'] "IHL" forall (x ρ Hx); simpl; first solve [inversion Hx].
@@ -56,7 +56,7 @@ Section logrel_binding_lemmas.
     case: x Hx => /= [|x] Hx.
     - move: Hx => [ -> ]. iClear "IHL". locAsimpl.
       by iDestruct "Hg" as "[_ $]".
-    - iAssert (⟦ T.|[ren (+x)] ⟧ ρ (to_subst ρ x)) with "[Hg]" as "Hv".
+    - iAssert (⟦ T.|[ren (+x)] ⟧ (to_subst ρ) (to_subst ρ x)) with "[Hg]" as "Hv".
       by iDestruct "Hg" as "[Hg _]"; iApply "IHL".
       iClear "IHL".
       iDestruct (interp_weaken_one v with "Hv") as "Hv".
@@ -64,7 +64,7 @@ Section logrel_binding_lemmas.
   Qed.
 
   Lemma interp_subst_all ρ τ v:
-    cl_ρ ρ → ⟦ τ.|[to_subst ρ] ⟧ [] v ≡ ⟦ τ ⟧ ρ v.
+    cl_ρ ρ → ⟦ τ.|[to_subst ρ] ⟧ ids v ≡ ⟦ τ ⟧ (to_subst ρ) v.
   Proof.
     elim: ρ τ => /= [|w ρ IHρ] τ Hwρcl /=. by rewrite hsubst_id.
     assert (nclosed_vl w 0 /\ Forall (λ v, nclosed_vl v 0) ρ) as [Hwcl Hρcl]. by inversion Hwρcl.
@@ -74,7 +74,7 @@ Section logrel_binding_lemmas.
   Qed.
 
   Lemma to_subst_interp T ρ v w: cl_ρ ρ → nclosed_vl v (length ρ) →
-    ⟦ T.|[v/] ⟧ ρ w ≡ ⟦ T.|[v.[to_subst ρ]/] ⟧ ρ w.
+    ⟦ T.|[v/] ⟧ (to_subst ρ) w ≡ ⟦ T.|[v.[to_subst ρ]/] ⟧ (to_subst ρ) w.
   Proof.
     intros Hclρ Hclv.
     rewrite -(interp_subst_all ρ (T.|[v/])) // -(interp_subst_all ρ (T.|[v.[to_subst ρ]/])) //; f_equiv.
@@ -88,12 +88,12 @@ Section logrel_binding_lemmas.
   Lemma ietp_closed_vl T v: (Γ ⊨ tv v : T → ⌜ nclosed_vl v (length Γ) ⌝)%I.
   Proof. rewrite ietp_closed; iPureIntro; exact: fv_tv_inv. Qed.
 
-  Lemma interp_subst_internal ρ τ v1 v2 : (⟦ τ.|[v1.[ren (+length ρ)]/] ⟧ ρ v2 ≡ ⟦ τ ⟧ (v1 :: ρ) v2)%I : iProp Σ.
+  Lemma interp_subst_internal ρ τ v1 v2 : (⟦ τ.|[v1.[ren (+length ρ)]/] ⟧ (to_subst ρ) v2 ≡ ⟦ τ ⟧ (v1 .: (to_subst ρ)) v2)%I : iProp Σ.
   Proof. rewrite (interp_subst ρ τ v1 v2). apply internal_eq_refl. Qed.
 
   Lemma interp_subst_closed T v w ρ:
     nclosed_vl v (length Γ) →
-    ⟦ Γ ⟧* ρ -∗ ⟦ T.|[v/] ⟧ ρ w ≡ ⟦ T ⟧ (v.[to_subst ρ] :: ρ) w.
+    ⟦ Γ ⟧* ρ -∗ ⟦ T.|[v/] ⟧ (to_subst ρ) w ≡ ⟦ T ⟧ (v.[to_subst ρ] .: to_subst ρ) w.
   Proof.
     iIntros (Hcl) "Hg".
     iDestruct (interp_env_props with "Hg") as %[Hclp Hlen]; rewrite <- Hlen in *.
@@ -107,7 +107,7 @@ Section logrel_binding_lemmas.
     nclosed T (length σ) →
     nclosed_σ σ (length ρ) →
     cl_ρ ρ →
-    ⟦ T.|[to_subst σ] ⟧ ρ v ≡ ⟦ T ⟧ σ.|[to_subst ρ] v.
+    ⟦ T.|[to_subst σ] ⟧ (to_subst ρ) v ≡ ⟦ T ⟧ (to_subst σ.|[to_subst ρ]) v.
   Proof.
     intros HclT Hclσ Hclρ.
     rewrite -(interp_subst_all ρ _ v) // -(interp_subst_all _ T v).

--- a/theories/DSubSyn/fundamental.v
+++ b/theories/DSubSyn/fundamental.v
@@ -31,8 +31,8 @@ Section swap_based_typing_lemmas.
       by iApply interp_v_closed.
     iIntros (Hclw).
     iSpecialize ("HsubT" $! ρ w Hclw with "Hg HwT2").
-    iAssert (□ ▷ ▷^i (∀ v0, ⟦ U1 ⟧ (w :: ρ) v0 →
-        ⟦ U2 ⟧ (w :: ρ) v0))%I as "#HsubU'". {
+    iAssert (□ ▷ ▷^i (∀ v0, ⟦ U1 ⟧ (w .: to_subst ρ) v0 →
+        ⟦ U2 ⟧ (w .: to_subst ρ) v0))%I as "#HsubU'". {
       iIntros (v0); rewrite -!mlaterN_impl -mlater_impl.
       iIntros "!> #HUv0".
       iApply (strip_pure_laterN_impl (S i) (nclosed_vl v0 0)); first last.

--- a/theories/DSubSyn/lr_lemma.v
+++ b/theories/DSubSyn/lr_lemma.v
@@ -103,7 +103,7 @@ Section Sec.
     iSplit; first by eauto using nclosed_tskip_i.
     iIntros "!>" (vs) "#Hg".
     rewrite tskip_subst tskip_n_to_fill -wp_bind.
-    iApply (wp_wand_cl _ (⟦ T1 ⟧ vs)) => //.
+    iApply (wp_wand_cl _ (⟦ T1 ⟧ (to_subst vs))) => //.
     - iApply ("HeT1" with "[//]").
     - by rewrite nclosed_subst_ρ.
     - iIntros (v) "#HvT1 %".
@@ -122,7 +122,7 @@ Section Sec.
     have Hclte: nclosed (iterate tskip i e) (length Γ) by eauto using nclosed_tskip_i. iFrame "%".
     move: Hclte => _. iIntros "!>" (vs) "#Hg".
     rewrite tskip_subst tskip_n_to_fill -wp_bind.
-    iApply (wp_wand_cl _ (⟦ T1 ⟧ vs)) => //.
+    iApply (wp_wand_cl _ (⟦ T1 ⟧ (to_subst vs))) => //.
     - iApply ("HeT1" with "[//]").
     - by rewrite nclosed_subst_ρ.
     - iIntros (v) "#HvT1 %".
@@ -148,7 +148,7 @@ Section Sec.
     iSplit. {
       iPureIntro. exact: (fv_to_subst_vl HclV).
     }
-    iExists (λ v, ⟦ T.|[to_subst vs ] ⟧ [] v)%I.
+    iExists (λ v, ⟦ T.|[to_subst vs] ⟧ ids v)%I.
     iSplit. by iExists (T.|[to_subst vs]).
     iModIntro; repeat iSplitL; iIntros (v Hclv) "#H";
       rewrite later_intuitionistically interp_subst_all //.
@@ -180,7 +180,7 @@ Section Sec.
     iSplit. {
       iPureIntro; exact: (fv_to_subst_vl HclV).
     }
-    iExists (λ v, ⟦ T.|[to_subst ρ ] ⟧ [] v)%I.
+    iExists (λ v, ⟦ T.|[to_subst ρ] ⟧ ids v)%I.
     iSplit. by iExists (T.|[to_subst ρ ]).
     iModIntro; repeat iSplitL; iIntros (v Hclv) "#H";
       rewrite later_intuitionistically interp_subst_all //.

--- a/theories/DSubSyn/unary_lr_binding.v
+++ b/theories/DSubSyn/unary_lr_binding.v
@@ -11,8 +11,8 @@ Section logrel_binding_lemmas.
   Context `{!dsubSynG Σ}.
 
   Lemma interp_weaken ρ1 ρ2 ρ3 τ :
-    ⟦ τ.|[upn (length ρ1) (ren (+ length ρ2))] ⟧ (ρ1 ++ ρ2 ++ ρ3)
-    ≡ ⟦ τ ⟧ (ρ1 ++ ρ3).
+    ⟦ τ.|[upn (length ρ1) (ren (+ length ρ2))] ⟧ (to_subst (ρ1 ++ ρ2 ++ ρ3))
+    ≡ ⟦ τ ⟧ (to_subst (ρ1 ++ ρ3)).
   Proof.
     revert ρ1 ρ2 ρ3; induction τ=> ρ1 ρ2 ρ3 w /=; unfold_interp; properness; try solve [
       trivial | apply IHτ | apply IHτ1 | apply IHτ2 | apply (IHτ2 (_ :: _)) | apply (IHτ (_ :: _)) |
@@ -20,19 +20,19 @@ Section logrel_binding_lemmas.
   Qed.
 
   Lemma interp_weaken_one v τ ρ:
-     ⟦ τ.|[ren (+1)] ⟧ (v :: ρ) ≡ ⟦ τ ⟧ ρ.
+     ⟦ τ.|[ren (+1)] ⟧ (v .: to_subst ρ) ≡ ⟦ τ ⟧ (to_subst ρ).
   Proof. apply (interp_weaken [] [v]). Qed.
 
   Lemma interp_subst_up ρ1 ρ2 τ v:
-    ⟦ τ.|[upn (length ρ1) (v.[ren (+length ρ2)] .: ids)] ⟧ (ρ1 ++ ρ2)
-    ≡ ⟦ τ ⟧ (ρ1 ++ v :: ρ2).
+    ⟦ τ.|[upn (length ρ1) (v.[ren (+length ρ2)] .: ids)] ⟧ (to_subst (ρ1 ++ ρ2))
+    ≡ ⟦ τ ⟧ (to_subst (ρ1 ++ v :: ρ2)).
   Proof.
     revert ρ1 ρ2; induction τ=> ρ1 ρ2 w /=; unfold_interp; properness; try solve [
       trivial | apply IHτ | apply IHτ1 | apply IHτ2 | apply (IHτ2 (_ :: _)) | apply (IHτ (_ :: _)) |
       asimpl; rewrite ?to_subst_up //].
   Qed.
 
-  Lemma interp_subst ρ τ v1 v2 : ⟦ τ.|[v1.[ren (+length ρ)]/] ⟧ ρ v2 ≡ ⟦ τ ⟧ (v1 :: ρ) v2.
+  Lemma interp_subst ρ τ v1 v2 : ⟦ τ.|[v1.[ren (+length ρ)]/] ⟧ (to_subst ρ) v2 ≡ ⟦ τ ⟧ (v1 .: to_subst ρ) v2.
   Proof. apply (interp_subst_up []). Qed.
 
   Context Γ.
@@ -49,7 +49,7 @@ Section logrel_binding_lemmas.
 
   Lemma interp_env_lookup ρ T x:
     Γ !! x = Some T →
-    ⟦ Γ ⟧* ρ -∗ ⟦ T.|[ren (+x)] ⟧ ρ (to_subst ρ x).
+    ⟦ Γ ⟧* ρ -∗ ⟦ T.|[ren (+x)] ⟧ (to_subst ρ) (to_subst ρ x).
   Proof.
     iIntros (Hx) "* Hg".
     iInduction Γ as [|T' Γ'] "IHL" forall (x ρ Hx); simpl; first solve [inversion Hx].
@@ -57,7 +57,7 @@ Section logrel_binding_lemmas.
     case: x Hx => /= [|x] Hx.
     - move: Hx => [ -> ]. iClear "IHL". locAsimpl.
       by iDestruct "Hg" as "[_ $]".
-    - iAssert (⟦ T.|[ren (+x)] ⟧ ρ (to_subst ρ x)) with "[Hg]" as "Hv".
+    - iAssert (⟦ T.|[ren (+x)] ⟧ (to_subst ρ) (to_subst ρ x)) with "[Hg]" as "Hv".
       by iDestruct "Hg" as "[Hg _]"; iApply "IHL".
       iClear "IHL".
       iDestruct (interp_weaken_one v with "Hv") as "Hv".
@@ -65,7 +65,7 @@ Section logrel_binding_lemmas.
   Qed.
 
   Lemma interp_subst_all ρ τ v:
-    cl_ρ ρ → ⟦ τ.|[to_subst ρ] ⟧ [] v ≡ ⟦ τ ⟧ ρ v.
+    cl_ρ ρ → ⟦ τ.|[to_subst ρ] ⟧ ids v ≡ ⟦ τ ⟧ (to_subst ρ) v.
   Proof.
     elim: ρ τ => /= [|w ρ IHρ] τ Hwρcl /=. by rewrite hsubst_id.
     assert (nclosed_vl w 0 /\ Forall (λ v, nclosed_vl v 0) ρ) as [Hwcl Hρcl]. by inversion Hwρcl.
@@ -75,7 +75,7 @@ Section logrel_binding_lemmas.
   Qed.
 
   Lemma to_subst_interp T ρ v w: cl_ρ ρ → nclosed_vl v (length ρ) →
-    ⟦ T.|[v/] ⟧ ρ w ≡ ⟦ T.|[v.[to_subst ρ]/] ⟧ ρ w.
+    ⟦ T.|[v/] ⟧ (to_subst ρ) w ≡ ⟦ T.|[v.[to_subst ρ]/] ⟧ (to_subst ρ) w.
   Proof.
     intros Hclρ Hclv.
     rewrite -(interp_subst_all ρ (T.|[v/])) // -(interp_subst_all ρ (T.|[v.[to_subst ρ]/])) //; f_equiv.
@@ -89,12 +89,12 @@ Section logrel_binding_lemmas.
   Lemma ietp_closed_vl T v: (Γ ⊨ tv v : T → ⌜ nclosed_vl v (length Γ) ⌝)%I.
   Proof. rewrite ietp_closed; iPureIntro; exact: fv_tv_inv. Qed.
 
-  Lemma interp_subst_internal ρ τ v1 v2 : (⟦ τ.|[v1.[ren (+length ρ)]/] ⟧ ρ v2 ≡ ⟦ τ ⟧ (v1 :: ρ) v2)%I : iProp Σ.
+  Lemma interp_subst_internal ρ τ v1 v2 : (⟦ τ.|[v1.[ren (+length ρ)]/] ⟧ (to_subst ρ) v2 ≡ ⟦ τ ⟧ (v1 .: (to_subst ρ)) v2)%I : iProp Σ.
   Proof. rewrite (interp_subst ρ τ v1 v2). apply internal_eq_refl. Qed.
 
   Lemma interp_subst_closed T v w ρ:
     nclosed_vl v (length Γ) →
-    ⟦ Γ ⟧* ρ -∗ ⟦ T.|[v/] ⟧ ρ w ≡ ⟦ T ⟧ (v.[to_subst ρ] :: ρ) w.
+    ⟦ Γ ⟧* ρ -∗ ⟦ T.|[v/] ⟧ (to_subst ρ) w ≡ ⟦ T ⟧ (v.[to_subst ρ] .: to_subst ρ) w.
   Proof.
     iIntros (Hcl) "Hg".
     iDestruct (interp_env_props with "Hg") as %[Hclp Hlen]; rewrite <- Hlen in *.
@@ -108,7 +108,7 @@ Section logrel_binding_lemmas.
     nclosed T (length σ) →
     nclosed_σ σ (length ρ) →
     cl_ρ ρ →
-    ⟦ T.|[to_subst σ] ⟧ ρ v ≡ ⟦ T ⟧ σ.|[to_subst ρ] v.
+    ⟦ T.|[to_subst σ] ⟧ (to_subst ρ) v ≡ ⟦ T ⟧ (to_subst σ.|[to_subst ρ]) v.
   Proof.
     intros HclT Hclσ Hclρ.
     rewrite -(interp_subst_all ρ _ v) // -(interp_subst_all _ T v).

--- a/theories/Dot/examples.v
+++ b/theories/Dot/examples.v
@@ -21,7 +21,7 @@ Section ex.
   Definition v := vobj [("A", dtysem [] s); ("n", dvl (vnat 2))].
 
   (** Yes, v has a valid type member. *)
-  Lemma vHasA0: Hs -∗ ⟦ TTMem "A" TBot TNat ⟧ [] v.
+  Lemma vHasA0: Hs -∗ ⟦ TTMem "A" TBot TNat ⟧ ids v.
   Proof.
     iIntros "#Hs". repeat (repeat iExists _; repeat iSplit; try done).
     iModIntro; repeat iSplit;
@@ -30,14 +30,14 @@ Section ex.
 
   (* Generic useful lemmas — not needed for fundamental theorem,
      but very useful for examples. *)
-  Lemma ietp_value T v: nclosed_vl v 0 → ⟦ T ⟧ [] v -∗ [] ⊨ tv v : T.
+  Lemma ietp_value T v: nclosed_vl v 0 → ⟦ T ⟧ ids v -∗ [] ⊨ tv v : T.
   Proof.
     iIntros (?) "#H /="; iSplit; first by auto using fv_tv.
     iIntros "!>" (?->).
     rewrite -wp_value' to_subst_nil subst_id. iApply "H".
   Qed.
 
-  Lemma ietp_value_inv T v: [] ⊨ tv v : T -∗ ⟦ T ⟧ [] v.
+  Lemma ietp_value_inv T v: [] ⊨ tv v : T -∗ ⟦ T ⟧ ids v.
   Proof.
     iIntros "/= [% H]".
     iDestruct ("H" $! [] with "[//]") as "H".
@@ -60,7 +60,7 @@ Section ex.
   Lemma vHasA1: Hs -∗
     ⟦ TMu (TAnd
           (TTMem "A" TBot TNat)
-          (TAnd (TVMem "n" (TSel (pv (ids 0)) "A")) TTop)) ⟧ [] v.
+          (TAnd (TVMem "n" (TSel (pv (ids 0)) "A")) TTop)) ⟧ ids v.
   Proof.
     rewrite -ietp_value_inv -(TMu_I [] _ v).
     iIntros "#Hs".
@@ -90,7 +90,7 @@ Section ex.
   Lemma vHasA1': Hs -∗
     ⟦ TMu (TAnd
           (TTMem "A" TBot TNat)
-          (TAnd (TVMem "n" (TSel (pv (ids 0)) "A")) TTop)) ⟧ [] v.
+          (TAnd (TVMem "n" (TSel (pv (ids 0)) "A")) TTop)) ⟧ ids v.
   Proof.
     iIntros "#Hs".
     iDestruct (T_New_I [] _ with "[]") as "[% #H]"; first last.

--- a/theories/Dot/experiments.v
+++ b/theories/Dot/experiments.v
@@ -7,7 +7,7 @@ From D.Dot Require Import unary_lr_binding synLemmas rules
 
 Implicit Types
          (L T U: ty) (v: vl) (e: tm) (d: dm) (ds: dms) (p : path)
-         (Γ : ctx) (ρ : vls).
+         (Γ : ctx).
 
 Section Sec.
   Context `{HdlangG: dlangG Σ}.

--- a/theories/Dot/fundamental.v
+++ b/theories/Dot/fundamental.v
@@ -34,8 +34,8 @@ Section swap_based_typing_lemmas.
       by rewrite interp_v_closed.
     iIntros (Hclw).
     iSpecialize ("HsubT" $! ρ w Hclw with "Hg HwT2").
-    iAssert (□ ▷ ▷^i (∀ v0, ⟦ U1 ⟧ (w :: ρ) v0 →
-        ⟦ U2 ⟧ (w :: ρ) v0))%I as "#HsubU'". {
+    iAssert (□ ▷ ▷^i (∀ v0, ⟦ U1 ⟧ (w .: to_subst ρ) v0 →
+        ⟦ U2 ⟧ (w .: to_subst ρ) v0))%I as "#HsubU'". {
       iIntros (v0); rewrite -!mlaterN_impl -mlater_impl.
       iIntros "!> #HUv0".
       iApply (strip_pure_laterN_impl (S i) (nclosed_vl v0 0)); first last.

--- a/theories/Dot/lr_lemma.v
+++ b/theories/Dot/lr_lemma.v
@@ -26,7 +26,7 @@ Section Sec.
     iSplit; first by eauto using nclosed_tskip_i.
     iIntros "!>" (vs) "#Hg".
     rewrite tskip_subst tskip_n_to_fill -wp_bind.
-    iApply (wp_wand_cl _ (⟦ T1 ⟧ vs)) => //.
+    iApply (wp_wand_cl _ (⟦ T1 ⟧ (to_subst vs))) => //.
     - iApply ("HeT1" with "[//]").
     - by iApply interp_env_cl_app.
     - iIntros (v) "#HvT1 %".
@@ -50,7 +50,7 @@ Section Sec.
      Γ ⊨ mu x: T <: T    Γ ⊨ T <: mu(x: T)
   *)
 
-  Lemma interp_TMu_ren T ρ v: ⟦ TMu T.|[ren (+1)] ⟧ ρ v ≡ ⟦ T ⟧ ρ v.
+  Lemma interp_TMu_ren T ρ v: ⟦ TMu T.|[ren (+1)] ⟧ (to_subst ρ) v ≡ ⟦ T ⟧ (to_subst ρ) v.
   Proof. by rewrite /= (interp_weaken_one v T ρ v). Qed.
 
   (*

--- a/theories/Dot/noRussell.v
+++ b/theories/Dot/noRussell.v
@@ -3,7 +3,7 @@ From D.Dot Require Import unary_lr.
 
 Implicit Types
          (L T U: ty) (v: vl) (e: tm) (d: dm) (ds: dms)
-         (Γ : ctx) (ρ : vls).
+         (Γ : ctx).
 
 Section Russell.
   Context `{HdlangG: dlangG Σ}.
@@ -15,7 +15,7 @@ Section Russell.
     paradoxical without Iris, because (informally) [v.A] points to [λ u, ¬ (u.A u)],
     hence [v.A v] is equivalent to ▷¬ (u.A u).
     *)
-  Definition uAu u := ⟦TSel (pv u) "A"⟧ [] u.
+  Definition uAu u := ⟦TSel (pv u) "A"⟧ ids u.
   Instance uauP: Persistent (uAu u) := _.
 
   Definition russell_p : envD Σ := λ ρ v, (□ (uAu v -∗ False))%I.
@@ -29,9 +29,9 @@ Section Russell.
   Definition v := vobj [("A", dtysem [] s)].
 
   (** Yes, v has a valid type member. *)
-  Lemma vHasA: Hs ⊢ ⟦ TTMem "A" TBot TTop ⟧ [] v.
+  Lemma vHasA: Hs ⊢ ⟦ TTMem "A" TBot TTop ⟧ ids v.
   Proof.
-    iIntros "#Hs". repeat (repeat iExists _; repeat iSplit; try done).
+    iIntros "#Hs". repeat (repeat iExists _; repeat iSplit; try by [|iApply idm_proj_intro]).
     iModIntro; repeat iSplit; by iIntros "** !>".
   Qed.
 
@@ -40,7 +40,7 @@ Section Russell.
     iIntros "#Hs #HuauV".
     iPoseProof "HuauV" as (_ φ d Hl) "[Hs1 #Hvav]".
     iPoseProof "Hs1" as (s' σ φ' [_ ->]) "H".
-    iAssert (d ↗ russell_p []) as "#Hs2".
+    iAssert (d ↗ russell_p ids) as "#Hs2".
     - iExists s, [], russell_p; iFrame "Hs"; iPureIntro.
       move: Hl => [ds] [[<- /=] ?]. by simplify_eq.
     - iPoseProof (stored_pred_agree d _ _ v with "Hs1 Hs2") as "#Hag".
@@ -54,7 +54,7 @@ Section Russell.
   Proof.
     iIntros "#Hs"; iSplit.
     - iIntros "#HnotVAV"; iSplit => //.
-      iExists (russell_p []), (dtysem [] s).
+      iExists (russell_p ids), (dtysem [] s).
       repeat (repeat iSplit => //; repeat iExists _).
       iIntros "!>!>!> #Hvav". iApply ("HnotVAV" with "Hvav").
     - iIntros "#Hvav".
@@ -75,5 +75,5 @@ Section Russell.
     by iApply uauEquiv.
   Qed.
 
-  Definition notRussellV: Hs ⊢ russell_p [] v → False := notNotVAV.
+  Definition notRussellV: Hs ⊢ russell_p ids v → False := notNotVAV.
 End Russell.

--- a/theories/Dot/typeExtractionSem.v
+++ b/theories/Dot/typeExtractionSem.v
@@ -31,11 +31,11 @@ Section interp_equiv.
       σ in ρ. And the result is only equivalent for closed ρ with the expected length. *)
   Definition interp_extractedTy: (ty * vls) → envD Σ :=
     λ '(T, σ) ρ v,
-    (⟦ T ⟧ (subst_sigma σ ρ) v)%I.
+    (⟦ T ⟧ (to_subst σ.|[ρ]) v)%I.
   Notation "⟦ T ⟧ [ σ ]" := (interp_extractedTy (T, σ)).
 
   Definition envD_equiv n φ1 φ2: iProp Σ :=
-    (∀ ρ v, ⌜ length ρ = n ⌝ → ⌜ cl_ρ ρ ⌝ → φ1 ρ v ≡ φ2 ρ v)%I.
+    (∀ ρ v, ⌜ length ρ = n ⌝ → ⌜ cl_ρ ρ ⌝ → φ1 (to_subst ρ) v ≡ φ2 (to_subst ρ) v)%I.
   Notation "φ1 ≈[  n  ] φ2" := (envD_equiv n φ1 φ2) (at level 70).
 
   Lemma extraction_envD_equiv g s σ T n:
@@ -140,7 +140,7 @@ Section typing_type_member_defs.
 
   Definition leadsto_envD_equiv (sσ: extractedTy) n (φ : envD Σ) : iProp Σ :=
     let '(s, σ) := sσ in
-    (⌜nclosed_σ σ n⌝ ∧ ∃ (φ' : envD Σ), s ↝ φ' ∗ envD_equiv n φ (λ ρ, φ' (subst_sigma σ ρ)))%I.
+    (⌜nclosed_σ σ n⌝ ∧ ∃ (φ' : envD Σ), s ↝ φ' ∗ envD_equiv n φ (λ ρ, φ' (to_subst σ.|[ρ])))%I.
   Arguments leadsto_envD_equiv /.
   Notation "sσ ↝[  n  ] φ" := (leadsto_envD_equiv sσ n φ) (at level 20).
 
@@ -180,7 +180,7 @@ Section typing_type_member_defs.
     iIntros "!>" (ρ) "#Hg".
     iDestruct (interp_env_props with "Hg") as %[Hclp Hlen]; rewrite <- Hlen in *.
     iDestruct "Hs" as (φ) "[Hγ Hγφ]".
-    repeat iSplit => //; iExists (φ (σ.|[to_subst ρ]));
+    repeat iSplit => //; iExists (φ (to_subst σ.|[to_subst ρ]));
       iSplit; first by repeat iExists _; iSplit.
     iModIntro; repeat iSplitL; iIntros (v Hclv) "#HL";
       rewrite later_intuitionistically.

--- a/theories/Dot/unary_lr_binding.v
+++ b/theories/Dot/unary_lr_binding.v
@@ -10,8 +10,8 @@ Section logrel_binding_lemmas.
   Context `{!dlangG Σ}.
 
   Lemma interp_weaken ρ1 ρ2 ρ3 τ :
-    ⟦ τ.|[upn (length ρ1) (ren (+ length ρ2))] ⟧ (ρ1 ++ ρ2 ++ ρ3)
-    ≡ ⟦ τ ⟧ (ρ1 ++ ρ3).
+    ⟦ τ.|[upn (length ρ1) (ren (+ length ρ2))] ⟧ (to_subst (ρ1 ++ ρ2 ++ ρ3))
+    ≡ ⟦ τ ⟧ (to_subst (ρ1 ++ ρ3)).
   Proof.
     revert ρ1 ρ2 ρ3; induction τ=> ρ1 ρ2 ρ3 w /=; properness; try solve [
       trivial | apply IHτ | apply IHτ1 | apply IHτ2 | apply (IHτ2 (_ :: _)) | apply (IHτ (_ :: _)) |
@@ -19,19 +19,19 @@ Section logrel_binding_lemmas.
   Qed.
 
   Lemma interp_weaken_one v τ ρ:
-     ⟦ τ.|[ren (+1)] ⟧ (v :: ρ) ≡ ⟦ τ ⟧ ρ.
+     ⟦ τ.|[ren (+1)] ⟧ (v .: to_subst ρ) ≡ ⟦ τ ⟧ (to_subst ρ).
   Proof. apply (interp_weaken [] [v]). Qed.
 
   Lemma interp_subst_up ρ1 ρ2 τ v:
-    ⟦ τ.|[upn (length ρ1) (v.[ren (+length ρ2)] .: ids)] ⟧ (ρ1 ++ ρ2)
-    ≡ ⟦ τ ⟧ (ρ1 ++ v :: ρ2).
+    ⟦ τ.|[upn (length ρ1) (v.[ren (+length ρ2)] .: ids)] ⟧ (to_subst (ρ1 ++ ρ2))
+    ≡ ⟦ τ ⟧ (to_subst (ρ1 ++ v :: ρ2)).
   Proof.
     revert ρ1 ρ2; induction τ=> ρ1 ρ2 w /=; properness; try solve [
       trivial | apply IHτ | apply IHτ1 | apply IHτ2 | apply (IHτ2 (_ :: _)) | apply (IHτ (_ :: _)) |
       asimpl; rewrite ?to_subst_up //].
   Qed.
 
-  Lemma interp_subst ρ τ v1 v2 : ⟦ τ.|[v1.[ren (+length ρ)]/] ⟧ ρ v2 ≡ ⟦ τ ⟧ (v1 :: ρ) v2.
+  Lemma interp_subst ρ τ v1 v2 : ⟦ τ.|[v1.[ren (+length ρ)]/] ⟧ (to_subst ρ) v2 ≡ ⟦ τ ⟧ (v1 .: to_subst ρ) v2.
   Proof. apply (interp_subst_up []). Qed.
 
   Context Γ.
@@ -48,7 +48,7 @@ Section logrel_binding_lemmas.
 
   Lemma interp_env_lookup ρ T x:
     Γ !! x = Some T →
-    ⟦ Γ ⟧* ρ -∗ ⟦ T.|[ren (+x)] ⟧ ρ (to_subst ρ x).
+    ⟦ Γ ⟧* ρ -∗ ⟦ T.|[ren (+x)] ⟧ (to_subst ρ) (to_subst ρ x).
   Proof.
     iIntros (Hx) "* Hg".
     iInduction Γ as [|T' Γ'] "IHL" forall (x ρ Hx); simpl; first solve [inversion Hx].
@@ -56,7 +56,7 @@ Section logrel_binding_lemmas.
     case: x Hx => /= [|x] Hx.
     - move: Hx => [ -> ]. iClear "IHL". locAsimpl.
       by iDestruct "Hg" as "[_ $]".
-    - iAssert (⟦ T.|[ren (+x)] ⟧ ρ (to_subst ρ x)) with "[Hg]" as "Hv".
+    - iAssert (⟦ T.|[ren (+x)] ⟧ (to_subst ρ) (to_subst ρ x)) with "[Hg]" as "Hv".
       by iDestruct "Hg" as "[Hg _]"; iApply "IHL".
       iClear "IHL".
       iDestruct (interp_weaken_one v with "Hv") as "Hv".
@@ -64,7 +64,7 @@ Section logrel_binding_lemmas.
   Qed.
 
   Lemma interp_subst_all ρ τ v:
-    cl_ρ ρ → ⟦ τ.|[to_subst ρ] ⟧ [] v ≡ ⟦ τ ⟧ ρ v.
+    cl_ρ ρ → ⟦ τ.|[to_subst ρ] ⟧ ids v ≡ ⟦ τ ⟧ (to_subst ρ) v.
   Proof.
     elim: ρ τ => /= [|w ρ IHρ] τ Hwρcl /=. by rewrite hsubst_id.
     assert (nclosed_vl w 0 /\ Forall (λ v, nclosed_vl v 0) ρ) as [Hwcl Hρcl]. by inversion Hwρcl.
@@ -74,7 +74,7 @@ Section logrel_binding_lemmas.
   Qed.
 
   Lemma to_subst_interp T ρ v w: cl_ρ ρ → nclosed_vl v (length ρ) →
-    ⟦ T.|[v/] ⟧ ρ w ≡ ⟦ T.|[v.[to_subst ρ]/] ⟧ ρ w.
+    ⟦ T.|[v/] ⟧ (to_subst ρ) w ≡ ⟦ T.|[v.[to_subst ρ]/] ⟧ (to_subst ρ) w.
   Proof.
     intros Hclρ Hclv.
     rewrite -(interp_subst_all ρ (T.|[v/])) // -(interp_subst_all ρ (T.|[v.[to_subst ρ]/])) //; f_equiv.
@@ -88,12 +88,12 @@ Section logrel_binding_lemmas.
   Lemma ietp_closed_vl T v: (Γ ⊨ tv v : T → ⌜ nclosed_vl v (length Γ) ⌝)%I.
   Proof. rewrite ietp_closed; iPureIntro; exact: fv_tv_inv. Qed.
 
-  Lemma interp_subst_internal ρ τ v1 v2 : (⟦ τ.|[v1.[ren (+length ρ)]/] ⟧ ρ v2 ≡ ⟦ τ ⟧ (v1 :: ρ) v2)%I : iProp Σ.
+  Lemma interp_subst_internal ρ τ v1 v2 : (⟦ τ.|[v1.[ren (+length ρ)]/] ⟧ (to_subst ρ) v2 ≡ ⟦ τ ⟧ (v1 .: (to_subst ρ)) v2)%I : iProp Σ.
   Proof. rewrite (interp_subst ρ τ v1 v2). apply internal_eq_refl. Qed.
 
   Lemma interp_subst_closed T v w ρ:
     nclosed_vl v (length Γ) →
-    ⟦ Γ ⟧* ρ -∗ ⟦ T.|[v/] ⟧ ρ w ≡ ⟦ T ⟧ (v.[to_subst ρ] :: ρ) w.
+    ⟦ Γ ⟧* ρ -∗ ⟦ T.|[v/] ⟧ (to_subst ρ) w ≡ ⟦ T ⟧ (v.[to_subst ρ] .: to_subst ρ) w.
   Proof.
     iIntros (Hcl) "Hg".
     iDestruct (interp_env_props with "Hg") as %[Hclp Hlen]; rewrite <- Hlen in *.
@@ -107,7 +107,7 @@ Section logrel_binding_lemmas.
     nclosed T (length σ) →
     nclosed_σ σ (length ρ) →
     cl_ρ ρ →
-    ⟦ T.|[to_subst σ] ⟧ ρ v ≡ ⟦ T ⟧ σ.|[to_subst ρ] v.
+    ⟦ T.|[to_subst σ] ⟧ (to_subst ρ) v ≡ ⟦ T ⟧ (to_subst σ.|[to_subst ρ]) v.
   Proof.
     intros HclT Hclσ Hclρ.
     rewrite -(interp_subst_all ρ _ v) // -(interp_subst_all _ T v).

--- a/theories/dlang.v
+++ b/theories/dlang.v
@@ -21,17 +21,17 @@ End mapsto.
 
 Module Type LiftWp (Import sorts: SortsIntf).
   Export mapsto saved_interp.
-  Implicit Types (v : vl) (ρ vs : vls) (Σ : gFunctors).
+  Implicit Types (v : vl) (Σ : gFunctors).
 
-  Notation envD Σ := (vls -d> vl -d> iProp Σ).
+  Notation envD Σ := ((var → vl) -d> vl -d> iProp Σ).
   Instance Inhϕ: Inhabited (envD Σ).
   Proof. constructor. exact (λ _ _, False)%I. Qed.
 
   Class TyInterp ty Σ :=
-    ty_interp : ty -> vls -> vl -> iProp Σ.
+    ty_interp : ty -> (var → vl) -> vl -> iProp Σ.
 
   Class dlangG Σ := DLangG {
-    dlangG_savior :> savedInterpG Σ vls vl;
+    dlangG_savior :> savedInterpG Σ (var → vl) vl;
     dlangG_interpNames :> gen_iheapG stamp gname Σ;
   }.
 
@@ -71,10 +71,10 @@ Module Type LiftWp (Import sorts: SortsIntf).
 
   Module dlang_adequacy.
     Class dlangPreG Σ := DLangPreG {
-      dlangPreG_savior :> savedInterpG Σ vls vl;
+      dlangPreG_savior :> savedInterpG Σ (var → vl) vl;
       dlangPreG_interpNames :> gen_iheapPreG stamp gname Σ;
     }.
-    Definition dlangΣ := #[savedInterpΣ vls vl; gen_iheapΣ stamp gname].
+    Definition dlangΣ := #[savedInterpΣ (var → vl) vl; gen_iheapΣ stamp gname].
 
     Instance subG_dlangΣ {Σ} : subG dlangΣ Σ → dlangPreG Σ.
     Proof. solve_inG. Qed.

--- a/theories/hoInterps_experiments.v
+++ b/theories/hoInterps_experiments.v
@@ -230,19 +230,9 @@ Section bar.
     | TLam n : hoEnvND 0 Σ → htype n → htype (S n).
   (* Now I need substitution. *)
 
-  (** This takes the first [n] elements from ρ *)
-  Definition to_subst_inv (n : nat) (ρ : var → vl) : vls :=
-    map ρ (seq 0 n).
-
-  Lemma to_subst_inv_spec ρ : to_subst_inv (length ρ) (to_subst ρ) = ρ.
-  Proof.
-    rewrite /to_subst_inv; elim: ρ => /= [//|v ρ IH].
-    rewrite /= -seq_shift; f_equal. by rewrite map_map.
-  Qed.
-
   Program Fixpoint typeSem {n} (T : htype n): hoEnvND n Σ :=
     match T with
-    | TWrap n T' => λ _ ρ, ⟦ T' ⟧ (to_subst_inv n ρ)
+    | TWrap n T' => λ _ ρ, ⟦ T' ⟧ ρ
     | TLam n φ T' => tUncurry (λ v, typeSem T')
     end.
 


### PR DESCRIPTION
As discussed in #80, this is necessary to allow using semantic types.

Environment validity keeps using `vls`, so semantic judgments must call
`to_subst` more.

Most of this PR replaces list operations by cons operations, and shifts around
calls to `to_subst`.

Now, in some files I distinguish `ρ : var → vl` and `vs : vls`, but not always.