### PR TITLE
Allow simplifying to_subst

### DIFF
--- a/theories/DSub/unary_lr_binding.v
+++ b/theories/DSub/unary_lr_binding.v
@@ -52,7 +52,7 @@ Section logrel_binding_lemmas.
   Proof.
     iIntros (Hx) "* Hg".
     iInduction Γ as [|T' Γ'] "IHL" forall (x ρ Hx); simpl; first solve [inversion Hx].
-    destruct ρ; first by [iExFalso]; rewrite to_subst_cons.
+    destruct ρ; first by [iExFalso].
     case: x Hx => /= [|x] Hx.
     - move: Hx => [ -> ]. iClear "IHL". locAsimpl.
       by iDestruct "Hg" as "[_ $]".
@@ -66,7 +66,7 @@ Section logrel_binding_lemmas.
   Lemma interp_subst_all ρ τ v:
     cl_ρ ρ → ⟦ τ.|[to_subst ρ] ⟧ [] v ≡ ⟦ τ ⟧ ρ v.
   Proof.
-    elim: ρ τ => /= [|w ρ IHρ] τ Hwρcl /=.  by rewrite to_subst_nil hsubst_id.
+    elim: ρ τ => /= [|w ρ IHρ] τ Hwρcl /=. by rewrite hsubst_id.
     assert (nclosed_vl w 0 /\ Forall (λ v, nclosed_vl v 0) ρ) as [Hwcl Hρcl]. by inversion Hwρcl.
     specialize (IHρ (τ.|[w/]) Hρcl).
     asimpl in IHρ. move: IHρ.

--- a/theories/DSubSyn/unary_lr_binding.v
+++ b/theories/DSubSyn/unary_lr_binding.v
@@ -53,7 +53,7 @@ Section logrel_binding_lemmas.
   Proof.
     iIntros (Hx) "* Hg".
     iInduction Γ as [|T' Γ'] "IHL" forall (x ρ Hx); simpl; first solve [inversion Hx].
-    destruct ρ; first by [iExFalso]; rewrite to_subst_cons.
+    destruct ρ; first by [iExFalso].
     case: x Hx => /= [|x] Hx.
     - move: Hx => [ -> ]. iClear "IHL". locAsimpl.
       by iDestruct "Hg" as "[_ $]".
@@ -67,7 +67,7 @@ Section logrel_binding_lemmas.
   Lemma interp_subst_all ρ τ v:
     cl_ρ ρ → ⟦ τ.|[to_subst ρ] ⟧ [] v ≡ ⟦ τ ⟧ ρ v.
   Proof.
-    elim: ρ τ => /= [|w ρ IHρ] τ Hwρcl /=.  by rewrite to_subst_nil hsubst_id.
+    elim: ρ τ => /= [|w ρ IHρ] τ Hwρcl /=. by rewrite hsubst_id.
     assert (nclosed_vl w 0 /\ Forall (λ v, nclosed_vl v 0) ρ) as [Hwcl Hρcl]. by inversion Hwρcl.
     specialize (IHρ (τ.|[w/]) Hρcl).
     asimpl in IHρ. move: IHρ.

--- a/theories/Dot/examples.v
+++ b/theories/Dot/examples.v
@@ -116,7 +116,6 @@ Section ex.
       iSplit => //=.
       iIntros "!>" ([|v ρ]) "/= #H". done.
       iDestruct "H" as "[-> [[% HA] [[% HB] _]]]".
-      rewrite to_subst_cons to_subst_nil /=.
       rewrite -wp_value'; iSplit => //.
       iDestruct "HA" as (dA HlA φ) "[Hlφ HA]".
       iDestruct "HB" as (dB HlB w) "HB".

--- a/theories/Dot/experiments.v
+++ b/theories/Dot/experiments.v
@@ -252,14 +252,9 @@ Section Sec.
     nclosed_vl v 0 → PureExec True i (pth_to_tm p) (tv v) →
     True ⊢ WP (pth_to_tm p) {{ sem_singleton_path p [] }}.
   Proof.
-    iIntros (Hcl Hpure) "_ /=". rewrite to_subst_nil /=.
-    iApply wp_pure_step_later => //.
-    iNext.
-    iApply wp_value. iModIntro.
-    asimpl.
-    iApply wp_pure_step_later => //.
-    iNext.
-    by iApply wp_value.
+    iIntros (Hcl Hpure) "_ /=".
+    rewrite -wp_pure_step_later // -wp_value hsubst_id.
+    rewrite -wp_pure_step_later // -wp_value //.
   Qed.
 
 

--- a/theories/Dot/unary_lr_binding.v
+++ b/theories/Dot/unary_lr_binding.v
@@ -52,7 +52,7 @@ Section logrel_binding_lemmas.
   Proof.
     iIntros (Hx) "* Hg".
     iInduction Γ as [|T' Γ'] "IHL" forall (x ρ Hx); simpl; first solve [inversion Hx].
-    destruct ρ; first by [iExFalso]; rewrite to_subst_cons.
+    destruct ρ; first by [iExFalso].
     case: x Hx => /= [|x] Hx.
     - move: Hx => [ -> ]. iClear "IHL". locAsimpl.
       by iDestruct "Hg" as "[_ $]".
@@ -66,7 +66,7 @@ Section logrel_binding_lemmas.
   Lemma interp_subst_all ρ τ v:
     cl_ρ ρ → ⟦ τ.|[to_subst ρ] ⟧ [] v ≡ ⟦ τ ⟧ ρ v.
   Proof.
-    elim: ρ τ => /= [|w ρ IHρ] τ Hwρcl /=.  by rewrite to_subst_nil hsubst_id.
+    elim: ρ τ => /= [|w ρ IHρ] τ Hwρcl /=. by rewrite hsubst_id.
     assert (nclosed_vl w 0 /\ Forall (λ v, nclosed_vl v 0) ρ) as [Hwcl Hρcl]. by inversion Hwρcl.
     specialize (IHρ (τ.|[w/]) Hρcl).
     asimpl in IHρ. move: IHρ.

--- a/theories/asubst_base.v
+++ b/theories/asubst_base.v
@@ -36,9 +36,6 @@ Proof. trivial. Qed.
 
 Lemma to_subst_cons v ρ : to_subst (v :: ρ) = v .: to_subst ρ.
 Proof. trivial. Qed.
-Global Hint Rewrite to_subst_nil to_subst_cons : autosubst.
-
-Global Arguments to_subst: simpl never.
 
 Definition push_var (σ : vls) : vls := ids 0 :: σ.|[ren (+1)].
 Arguments push_var /.
@@ -277,7 +274,7 @@ Section to_subst_idsσ_is_id.
   Lemma idsσ_eq_ids n: eq_n_s (to_subst (idsσ n)) ids n.
   Proof.
     elim: n => [|n IHn] [|i] // /lt_S_n Hle.
-    rewrite /= to_subst_cons /= to_subst_map_commute // IHn // id_subst //.
+    rewrite /= to_subst_map_commute // IHn // id_subst //.
   Qed.
 
   Lemma closed_subst_idsρ x n :

--- a/theories/hoInterps_experiments.v
+++ b/theories/hoInterps_experiments.v
@@ -237,8 +237,7 @@ Section bar.
   Lemma to_subst_inv_spec ρ : to_subst_inv (length ρ) (to_subst ρ) = ρ.
   Proof.
     rewrite /to_subst_inv; elim: ρ => /= [//|v ρ IH].
-    rewrite to_subst_cons /= -seq_shift; f_equal.
-    by rewrite map_map.
+    rewrite /= -seq_shift; f_equal. by rewrite map_map.
   Qed.
 
   Program Fixpoint typeSem {n} (T : htype n): hoEnvND n Σ :=


### PR DESCRIPTION
Turned out to be needed for #80 and #83. Was also a long-standing annoyance.