### PR TITLE
Add binding lemmas for terms, and refactorings

### DIFF
--- a/theories/DSub/syn.v
+++ b/theories/DSub/syn.v
@@ -3,7 +3,7 @@ From D Require Import asubst_intf asubst_base.
 From iris.program_logic Require ectx_language ectxi_language.
 
 (** This module is included right away. Its only point is asserting explicitly
-    that it implements [VlSortsSig]. *)
+    what interface it implements. *)
 Module VlSorts <: VlSortsFullSig.
 
 Inductive tm : Type :=
@@ -300,11 +300,13 @@ Canonical Structure dlang_ectxi_lang := ectxi_language.EctxiLanguage lang.dsub_l
 Canonical Structure dlang_ectx_lang := ectxi_language.EctxLanguageOfEctxi dlang_ectxi_lang.
 Canonical Structure dlang_lang := ectx_language.LanguageOfEctx dlang_ectx_lang.
 
+Lemma hsubst_of_val (v : vl) s : (of_val v).|[s] = of_val (v.[s]).
+Proof. done. Qed.
+
 Include Sorts.
 End VlSorts.
 Include VlSorts.
 
-Instance sort_tm : Sort tm := {}.
 Instance sort_ty : Sort ty := {}.
 
 (** After instantiating Autosubst, a few binding-related syntactic definitions

--- a/theories/DSub/synLemmas.v
+++ b/theories/DSub/synLemmas.v
@@ -92,6 +92,3 @@ Qed.
 
 Lemma tskip_subst i e s: (iterate tskip i e).|[s] = iterate tskip i e.|[s].
 Proof. elim: i => [|i IHi]; by rewrite ?iterate_0 ?iterate_S //= IHi. Qed.
-
-Lemma lookup_fv Γ x T: Γ !! x = Some T → nclosed (tv (ids x)) (length Γ).
-Proof. move =>/lookup_ids_fv /fv_tv //. Qed.

--- a/theories/Dot/syn.v
+++ b/theories/Dot/syn.v
@@ -4,7 +4,7 @@ From D Require Import asubst_intf asubst_base.
 From iris.program_logic Require ectx_language ectxi_language.
 
 (** This module is included right away. Its only point is asserting explicitly
-    that it implements [VlSortsSig]. *)
+    what interface it implements. *)
 Module VlSorts <: VlSortsFullSig.
 
 Definition label := string.
@@ -466,11 +466,13 @@ Canonical Structure dlang_ectxi_lang := ectxi_language.EctxiLanguage lang.dot_la
 Canonical Structure dlang_ectx_lang := ectxi_language.EctxLanguageOfEctxi dlang_ectxi_lang.
 Canonical Structure dlang_lang := ectx_language.LanguageOfEctx dlang_ectx_lang.
 
+Lemma hsubst_of_val (v : vl) s : (of_val v).|[s] = of_val (v.[s]).
+Proof. done. Qed.
+
 Include Sorts.
 End VlSorts.
 Include VlSorts.
 
-Instance sort_tm : Sort tm := {}.
 Instance sort_dm : Sort dm := {}.
 Instance sort_path : Sort path := {}.
 Instance sort_ty : Sort ty := {}.

--- a/theories/Dot/synLemmas.v
+++ b/theories/Dot/synLemmas.v
@@ -134,9 +134,6 @@ Qed.
 Lemma tskip_subst i e s: (iterate tskip i e).|[s] = iterate tskip i e.|[s].
 Proof. elim: i => [|i IHi]; by rewrite ?iterate_0 ?iterate_S //= IHi. Qed.
 
-Lemma lookup_fv Γ x T: Γ !! x = Some T → nclosed (tv (ids x)) (length Γ).
-Proof. move =>/lookup_ids_fv /fv_tv //. Qed.
-
 Lemma fv_head l d ds n: nclosed ((l, d) :: ds) n → nclosed d n.
 Proof. exact: fv_cons_pair_inv_head. Qed.
 

--- a/theories/asubst_base.v
+++ b/theories/asubst_base.v
@@ -1,3 +1,4 @@
+From iris.program_logic Require Import language.
 From D Require Import prelude asubst_intf.
 
 Module Type Sorts (Import V : ValuesSig) <: SortsSig V.
@@ -7,6 +8,7 @@ Class Sort (s : Type)
   {ids_s : Ids s} {ren_s : Rename s} {hsubst_vl_s : HSubst vl s}
   {hsubst_lemmas_vl_s : HSubstLemmas vl s} := {}.
 
+Global Instance sort_tm : Sort tm := {}.
 Global Instance sort_vls : Sort vls := {}.
 Global Instance sort_list `{Sort X} : Sort (list X) := {}.
 Global Instance sort_pair_snd `{Sort X} `{Inhabited A} : Sort (A * X) := {}.
@@ -432,6 +434,15 @@ Qed.
 End sort_lemmas_2.
 
 Hint Resolve nclosed_σ_to_subst nclosed_ren_shift @nclosed_sub_shift nclosed_ren_up @nclosed_sub_up.
+
+Lemma fv_of_val v n: nclosed_vl v n → nclosed (of_val v) n.
+Proof. intros Hclv s1 s2 Heqs. rewrite !hsubst_of_val. f_equiv. exact: Hclv. Qed.
+
+Lemma fv_of_val_inv v n: nclosed (of_val v) n → nclosed_vl v n.
+Proof. intros Hclt s1 s2 Heqs. apply (inj of_val). rewrite -!hsubst_of_val. exact: Hclt. Qed.
+
+Lemma lookup_fv {X} {Γ : list X} {x} {T : X} : Γ !! x = Some T → nclosed (of_val (ids x : vl)) (length Γ).
+Proof. move => /lookup_ids_fv /fv_of_val //. Qed.
 
 End Sorts.
 

--- a/theories/asubst_intf.v
+++ b/theories/asubst_intf.v
@@ -1,4 +1,4 @@
-(* Basic interfaces. *)
+(** Basic interfaces for Iris languages with Autosubst substitution operations. *)
 
 From iris.program_logic Require Import language.
 From D Require Import prelude.
@@ -14,6 +14,17 @@ Module Type ValuesSig.
   Declare Instance rename_vl : Rename vl.
   Declare Instance subst_vl : Subst vl.
   Declare Instance subst_lemmas_vl : SubstLemmas vl.
+
+  Notation tm := (expr dlang_lang).
+  Declare Instance inh_tm : Inhabited tm.
+  Declare Instance ids_tm : Ids tm.
+
+  Declare Instance rename_tm : Rename tm.
+
+  Declare Instance hsubst_tm : HSubst vl tm.
+  Declare Instance hsubst_lemmas_tm : HSubstLemmas vl tm.
+
+  Parameter hsubst_of_val : ∀ (v : vl) s, (of_val v).|[s] = of_val (v.[s]).
 End ValuesSig.
 
 Module Type SortsSig (Import V : ValuesSig).
@@ -21,6 +32,8 @@ Module Type SortsSig (Import V : ValuesSig).
     {inh_s : Inhabited s}
     {ids_s : Ids s} {ren_s : Rename s} {hsubst_vl_s : HSubst vl s}
     {hsubst_lemmas_vl_s : HSubstLemmas vl s} := {}.
+
+  Instance sort_tm : Sort tm := {}.
 
   Definition eq_n_s (s1 s2 : var → vl) n := ∀ x, x < n → s1 x = s2 x.
   Global Arguments eq_n_s /.


### PR DESCRIPTION
Here we mnove `lookup_fv` to the generic layer, enabling a generic proof of `T_Var` in #81.
Cons: must add terms to the language interface. Pros: I've been expecting for a while we'd want that.