### PR TITLE
Fix compilation speed regression: Replace Include by Export

### DIFF
--- a/theories/DSub/operational.v
+++ b/theories/DSub/operational.v
@@ -1,7 +1,7 @@
 From D Require Import dlang.
 From D.DSub Require Export syn.
 
-Include LiftWp syn.
+Include LiftWp VlSorts.
 
 (**
 Possible future plan.

--- a/theories/DSub/syn.v
+++ b/theories/DSub/syn.v
@@ -305,7 +305,7 @@ Proof. done. Qed.
 
 Include Sorts.
 End VlSorts.
-Include VlSorts.
+Export VlSorts.
 
 Instance sort_ty : Sort ty := {}.
 

--- a/theories/Dot/operational.v
+++ b/theories/Dot/operational.v
@@ -1,4 +1,4 @@
 From D Require Import dlang.
 From D.Dot Require Export syn.
 
-Include LiftWp syn.
+Include LiftWp VlSorts.

--- a/theories/Dot/syn.v
+++ b/theories/Dot/syn.v
@@ -471,7 +471,7 @@ Proof. done. Qed.
 
 Include Sorts.
 End VlSorts.
-Include VlSorts.
+Export VlSorts.
 
 Instance sort_dm : Sort dm := {}.
 Instance sort_path : Sort path := {}.

--- a/theories/hoInterps_experiments.v
+++ b/theories/hoInterps_experiments.v
@@ -144,7 +144,7 @@ End HoSemTypes.
 Import mapsto.
 Notation "s ↝[ n ] φ" := (∃ γ, (s ↦ γ) ∗ (γ ⤇[ n ] φ))%I  (at level 20) : bi_scope.
 
-Include HoSemTypes syn.
+Include HoSemTypes VlSorts.
 
 Section bar.
   Context `{!savedHoSemTypeG Σ} `{!dlangG Σ}.


### PR DESCRIPTION
Fix compilation time regression from b55869449338570f182640d702331e5603bee47d.

We ended up with an expensive hint (`solve_inv_fv_congruence_auto`) registered
twice; weirdly, it was used twice even if it *succeeded* and dispatched the
goal.

This happens because, per
https://coq.inria.fr/refman/proof-engine/tactics.html#hint-locality, Coq uses
Hints from all required modules, not just imported ones, and interactive modules
count here as required.

I tried `Global Set Loose Hint Behavior "Strict".`, but that breaks Iris.

This makes `Include` useless for modules (not for functors), but luckily we can
use `Export`.