### PR TITLE
Abandoned: Swap modalities in definitions of type members

### DIFF
--- a/theories/DSubSyn/lr_lemma.v
+++ b/theories/DSubSyn/lr_lemma.v
@@ -151,7 +151,7 @@ Section Sec.
     iExists (λ v, ⟦ T.|[to_subst vs] ⟧ ids v)%I.
     iSplit. by iExists (T.|[to_subst vs]).
     iModIntro; repeat iSplitL; iIntros (v Hclv) "#H";
-      rewrite later_intuitionistically interp_subst_all //.
+      rewrite interp_subst_all //.
     - iIntros "!>"; by iApply "HLT".
     - by iApply "HTU".
   Qed.
@@ -183,7 +183,7 @@ Section Sec.
     iExists (λ v, ⟦ T.|[to_subst ρ] ⟧ ids v)%I.
     iSplit. by iExists (T.|[to_subst ρ ]).
     iModIntro; repeat iSplitL; iIntros (v Hclv) "#H";
-      rewrite later_intuitionistically interp_subst_all //.
+      rewrite interp_subst_all //.
     - iIntros "!>"; by iApply "HLT".
     - by iApply "HTU".
   Qed.
@@ -240,7 +240,7 @@ Section Sec.
 
     (* To conclude, show that both types fetched from va coincide - but later! *)
     iPoseProof (vl_has_semtype_agree with "HT0 HT1") as "Hag".
-    iNext. by iRewrite ("Hag" $! v).
+    iModIntro. iNext. by iRewrite ("Hag" $! v).
   Qed.
 
   Lemma T_Nat_I n:

--- a/theories/DSubSyn/unary_lr.v
+++ b/theories/DSubSyn/unary_lr.v
@@ -103,8 +103,8 @@ Section logrel.
     (ty -d> envD Σ) -n> envD Σ -n> envD Σ -n> envD Σ :=
     λne rinterp interpL interpU, λ ρ v,
     (⌜ nclosed_vl v 0 ⌝ ∗  ∃ φ, [ rinterp ] v ↗ φ ∗
-       □ ((∀ v, ⌜ nclosed_vl v 0 ⌝ → ▷ interpL ρ v → ▷ □ φ v) ∗
-          (∀ v, ⌜ nclosed_vl v 0 ⌝ → ▷ □ φ v → ▷ interpU ρ v)))%I.
+       □ ((∀ v, ⌜ nclosed_vl v 0 ⌝ → ▷ interpL ρ v → □ ▷ φ v) ∗
+          (∀ v, ⌜ nclosed_vl v 0 ⌝ → □ ▷ φ v → ▷ interpU ρ v)))%I.
   Solve All Obligations with solve_proper_ho.
   Global Arguments interp_tmem /.
 
@@ -113,7 +113,7 @@ Section logrel.
 
   Program Definition interp_sel: (ty -d> envD Σ) -n> vl -d> envD Σ :=
     λne rinterp, λ w ρ v,
-    (⌜ nclosed_vl v 0 ⌝ ∧ (∃ ϕ, [rinterp] w.[ρ] ↗ ϕ ∧ ▷ □ ϕ v))%I.
+    (⌜ nclosed_vl v 0 ⌝ ∧ (∃ ϕ, [rinterp] w.[ρ] ↗ ϕ ∧ □ ▷ ϕ v))%I.
   Solve All Obligations with solve_proper_ho.
   Global Arguments interp_sel /.
   Global Instance interp_sel_contractive : Contractive interp_sel.

--- a/theories/Dot/examples.v
+++ b/theories/Dot/examples.v
@@ -25,7 +25,7 @@ Section ex.
   Proof.
     iIntros "#Hs". repeat (repeat iExists _; repeat iSplit; try done).
     iModIntro; repeat iSplit;
-    iIntros (v Hcl); rewrite -?even_nat /=; iIntros ">#% //".
+    iIntros (v Hcl); rewrite -?even_nat /=; iIntros "#H !> // !> //".
   Qed.
 
   (* Generic useful lemmas — not needed for fundamental theorem,
@@ -108,7 +108,7 @@ Section ex.
       repeat (repeat iExists _; repeat iSplit; try done).
       iModIntro; repeat iSplit;
       iIntros (w Hcl); rewrite -?even_nat /=.
-      by iIntros ">?".
+      by iIntros "#? !>!>".
       rewrite even_nat.
       by iIntros ">?".
     - iApply DCons_I => //; last by iApply DNil_I.

--- a/theories/Dot/lr_lemma_nobinding.v
+++ b/theories/Dot/lr_lemma_nobinding.v
@@ -64,12 +64,12 @@ Section Sec.
     objLookupDet.
     iExists d; repeat iSplit => //.
     iExists φ; repeat iSplit => //.
-    iModIntro; iSplitL; iIntros (w Hclw) "Hw".
+    iModIntro; iSplitL; iIntros (w Hclw) "#Hw".
     - by iApply "HLφ1".
     - iDestruct (stored_pred_agree d _ _ w with "Hsφ1 Hsφ2") as "#Hag".
       iClear "Hsφ1 Hsφ2 HLφ1".
-      iSplit; [iApply "HφU1" | iApply "HφU2"] => //.
-      iNext. by iRewrite -"Hag".
+      iSplit; [iApply "HφU1" | iApply ("HφU2")] => //.
+      iModIntro. iNext. by iRewrite -"Hag".
   Qed.
 
   Lemma TAnd_I v T1 T2:

--- a/theories/Dot/lr_lemmasTSel.v
+++ b/theories/Dot/lr_lemmasTSel.v
@@ -42,7 +42,7 @@ Section Sec.
     iDestruct "Hφ" as (φ1 d1 Hva) "[Hγ #HΦ1v]".
     objLookupDet.
     iDestruct (stored_pred_agree d _ _ v with "Hlφ Hγ") as "#Hag".
-    iApply "HφU" => //. iNext. by iRewrite "Hag".
+    iApply "HφU" => //. iModIntro. iNext. by iRewrite "Hag".
   Qed.
 
   Lemma P_Val v T:

--- a/theories/Dot/noRussell.v
+++ b/theories/Dot/noRussell.v
@@ -32,7 +32,7 @@ Section Russell.
   Lemma vHasA: Hs ⊢ ⟦ TTMem "A" TBot TTop ⟧ ids v.
   Proof.
     iIntros "#Hs". repeat (repeat iExists _; repeat iSplit; try by [|iApply idm_proj_intro]).
-    iModIntro; repeat iSplit; by iIntros "** !>".
+    iModIntro; repeat iSplit; by iIntros "** !> // !> //".
   Qed.
 
   Lemma later_not_UAU: Hs ⊢ uAu v -∗ ▷ False.
@@ -55,8 +55,9 @@ Section Russell.
     iIntros "#Hs"; iSplit.
     - iIntros "#HnotVAV"; iSplit => //.
       iExists (russell_p ids), (dtysem [] s).
-      repeat (repeat iSplit => //; repeat iExists _).
-      iIntros "!>!>!> #Hvav". iApply ("HnotVAV" with "Hvav").
+      iSplit; last iSplit.
+      1-2: repeat (repeat iSplit => //; repeat iExists _).
+      rewrite /russell_p. done.
     - iIntros "#Hvav".
       by iDestruct (later_not_UAU with "Hs Hvav") as "#>[]".
   Qed.

--- a/theories/Dot/typeExtractionSem.v
+++ b/theories/Dot/typeExtractionSem.v
@@ -182,8 +182,7 @@ Section typing_type_member_defs.
     iDestruct "Hs" as (φ) "[Hγ Hγφ]".
     repeat iSplit => //; iExists (φ (to_subst σ.|[to_subst ρ]));
       iSplit; first by repeat iExists _; iSplit.
-    iModIntro; repeat iSplitL; iIntros (v Hclv) "#HL";
-      rewrite later_intuitionistically.
+    iModIntro; repeat iSplitL; iIntros (v Hclv) "#HL".
     - iIntros "!>"; iApply (internal_eq_iff with "(Hγφ [#//] [#//])").
       by iApply "HLT".
     - iApply "HTU" => //.

--- a/theories/Dot/unary_lr.v
+++ b/theories/Dot/unary_lr.v
@@ -60,8 +60,8 @@ Section logrel.
   Definition def_interp_tmem interp1 interp2 : envPred dm :=
     λ ρ d,
     (∃ φ, (d ↗ φ) ∗
-       □ ((∀ v, ⌜ nclosed_vl v 0 ⌝ → ▷ interp1 ρ v → ▷ □ φ v) ∗
-          (∀ v, ⌜ nclosed_vl v 0 ⌝ → ▷ □ φ v → ▷ interp2 ρ v)))%I.
+       □ ((∀ v, ⌜ nclosed_vl v 0 ⌝ → ▷ interp1 ρ v → □ ▷ φ v) ∗
+          (∀ v, ⌜ nclosed_vl v 0 ⌝ → □ ▷ φ v → ▷ interp2 ρ v)))%I.
   Global Arguments def_interp_tmem /.
 
   Definition lift_dinterp_vl l (dinterp: envPred dm): envD Σ :=
@@ -125,7 +125,7 @@ Section logrel.
 
   Definition interp_sel p (l: label) : envD Σ :=
     λ ρ v, (⌜ nclosed_vl v 0 ⌝ ∧ path_wp p.|[ρ]
-      (λ vp, ∃ ϕ d, ⌜vp @ l ↘ d⌝ ∧ d ↗ ϕ ∧ ▷ □ ϕ v))%I.
+      (λ vp, ∃ ϕ d, ⌜vp @ l ↘ d⌝ ∧ d ↗ ϕ ∧ □ ▷ ϕ v))%I.
   Global Arguments interp_sel /.
 
   Fixpoint interp (T: ty) : envD Σ :=


### PR DESCRIPTION
That's what I used with semantic typing in olty_typing, but overall it doesn't
seem the improvement I saw there.