### PR TITLE
Old: Fix Hint behavior and compilation speed regression

### DIFF
--- a/theories/prelude.v
+++ b/theories/prelude.v
@@ -11,6 +11,15 @@ From D Require Export tactics.
   ourselves: *)
 Obligation Tactic := idtac.
 
+(**
+  This is the correct setting for this flag, even if it's not the default, per
+  https://coq.inria.fr/refman/proof-engine/tactics.html#hint-locality.
+  With the old behavior, after `Module Foo. Hint Extern bla. End Foo. Include
+  Foo.`, the Hint is available twice; we hit this an expensive hint,
+  so it's crucial to set this globally.
+ *)
+Global Set Loose Hint Behavior "Strict".
+
 Tactic Notation "locAsimpl'" uconstr(e1) :=
   remember (e1) as __e' eqn:__Heqe';
   progress asimpl in __Heqe'; subst __e'.


### PR DESCRIPTION
Superseded by #89. This breaks Iris badly.

==
This fixes a compilation speed regression introduced in
b55869449338570f182640d702331e5603bee47d. We ended up with a hint registered
twice; weirdly, it was used twice even if it *succeeded* and dispatched the goal.