### PR TITLE
Notations: coherent levels to allow auto-left-factoring

### DIFF
--- a/theories/DSubSyn/unary_lr.v
+++ b/theories/DSubSyn/unary_lr.v
@@ -257,7 +257,7 @@ Notation "Γ ⊨ e : T" := (ietp Γ T e) (at level 74, e, T at next level).
 (** Indexed expression typing *)
 Notation "Γ ⊨ e : T , i" := (step_indexed_ietp Γ T e i) (at level 74, e, T at next level).
 
-Notation "Γ '⊨' '[' T1 ',' i ']' '<:' '[' T2 ',' j ']'" := (step_indexed_ivstp Γ T1 T2 i j) (at level 74, T1, T2 at next level).
+Notation "Γ ⊨ [ T1 , i ]  <: [ T2 , j ]" := (step_indexed_ivstp Γ T1 T2 i j) (at level 74, T1, T2, i, j at next level).
 Notation "Γ ⊨[ i  ] T1 <: T2" := (delayed_ivstp Γ T1 T2 i) (at level 74, T1, T2 at next level).
 
 Section logrel_lemmas.

--- a/theories/Dot/unary_lr.v
+++ b/theories/Dot/unary_lr.v
@@ -264,15 +264,15 @@ Notation "⟦ Γ ⟧*" := (interp_env Γ).
 Notation "⟦ T ⟧ₑ" := (interp_expr ⟦ T ⟧).
 
 (** Single-definition typing *)
-Notation "Γ ⊨d{ l := d  } : T" := (idtp Γ T l d) (at level 64, d, l, T at next level).
+Notation "Γ ⊨d{ l := d  } : T" := (idtp Γ T l d) (at level 74, d, l, T at next level).
 (** Multi-definition typing *)
 Notation "Γ ⊨ds ds : T" := (idstp Γ T ds) (at level 74, ds, T at next level).
 (** Expression typing *)
 Notation "Γ ⊨ e : T" := (ietp Γ T e) (at level 74, e, T at next level).
 
-Notation "Γ ⊨p p : T , i" := (iptp Γ T p i) (at level 74, p, T at next level).
+Notation "Γ ⊨p p : T , i" := (iptp Γ T p i) (at level 74, p, T, i at next level).
 
-Notation "Γ ⊨ [ T1 , i ]  <: [ T2 , j ]" := (step_indexed_ivstp Γ T1 T2 i j) (at level 74, T1, T2 at next level).
+Notation "Γ ⊨ [ T1 , i ]  <: [ T2 , j ]" := (step_indexed_ivstp Γ T1 T2 i j) (at level 74, T1, T2, i, j at next level).
 
 (** Context extension for use with definition typing, as in
     [Γ |L V ⊨d d : T] and [Γ |L V ⊨ds ds : T]. *)

--- a/theories/olty.v
+++ b/theories/olty.v
@@ -242,7 +242,7 @@ End judgments.
 
 Notation "Γ ⊨ e : τ" := (ietp Γ τ e) (at level 74, e, τ at next level).
 Notation "Γ ⊨ e : τ , i" := (step_indexed_ietp Γ τ e i) (at level 74, e, τ at next level).
-Notation "Γ ⊨ [ τ1 , i ]  <: [ τ2 , j ]" := (step_indexed_ivstp Γ τ1 τ2 i j) (at level 74, τ1, τ2 at next level).
+Notation "Γ ⊨ [ τ1 , i ]  <: [ τ2 , j ]" := (step_indexed_ivstp Γ τ1 τ2 i j) (at level 74, τ1, τ2, i, j at next level).
 
 Section typing.
   Context `{dlangG Σ}.

--- a/theories/olty_experiments.v
+++ b/theories/olty_experiments.v
@@ -70,7 +70,7 @@ Program Definition nosubj_judgment_to_judgment {Σ} : nosubj_judgment Σ → jud
 Definition ivstp τ1 τ2 : nosubj_judgment Σ := (λ ρ, ∀ v, oClose τ1 ρ v → oClose τ2 ρ v)%I.
 Program Definition step_indexed_ivstp τ1 i1 τ2 i2 := nosubj_judgment_to_judgment (Σ := Σ)
   (λ ρ, ∀ v, ▷^i1 oClose τ1 ρ v → ▷^i2 oClose τ2 ρ v)%I.
-Notation "[ τ1 , i1 ] <: [ τ2 , i2 ]" := (step_indexed_ivstp τ1 i1 τ2 i2) (at level 73).
+Notation "[ τ1 , i1 ] <: [ τ2 , i2 ]" := (step_indexed_ivstp τ1 i1 τ2 i2) (at level 73, τ2, i1, i2 at next level).
 
 Lemma equiv_vstp Γ τ1 τ2 i1 i2: Γ ⊨ [τ1 , i1] <: [τ2 , i2] ⊣⊢
     (□∀ ρ v, env_oltyped Γ ρ → ▷^i1 oClose τ1 ρ v → ▷^i2 oClose τ2 ρ v)%I.


### PR DESCRIPTION
The manual even documents that sharing levels is needed to enable automatic left-factorization:
https://coq.inria.fr/refman/user-extensions/syntax-extensions.html#simple-factorization-rules.