### PR TITLE
Dot: Index typing judgment properly, avoid stampTable nonsense

### DIFF
--- a/theories/DSub/stamping/stampingDefsCore.v
+++ b/theories/DSub/stamping/stampingDefsCore.v
@@ -6,7 +6,6 @@ From D.DSub Require Import syn traversals.
 Set Implicit Arguments.
 
 Notation stys := (gmap stamp ty).
-Class stampTable := getStampTable : stys.
 
 Import Trav1.
 Set Implicit Arguments.

--- a/theories/Dot/examples/typingExInfra.v
+++ b/theories/Dot/examples/typingExInfra.v
@@ -54,11 +54,11 @@ Hint Extern 5 (is_stamped_dm _ _ _) => try_once is_stamped_weaken_dm : core.
 Hint Extern 5 (is_stamped_ty _ _ _) => cbn : core.
 
 Ltac typconstructor := match goal with
-  | |- typed _ _ _ => constructor
-  | |- dms_typed _ _ _ _ => constructor
-  | |- dm_typed _ _ _ _ _ => constructor
-  | |- path_typed _ _ _ _ => constructor
-  | |- subtype _ _ _ _ _ => constructor
+  | |- typed _ _ _ _ => constructor
+  | |- dms_typed _ _ _ _ _ => constructor
+  | |- dm_typed _ _ _ _ _ _ => constructor
+  | |- path_typed _ _ _ _ _ => constructor
+  | |- subtype _ _ _ _ _ _ => constructor
   end.
 (** [tcrush] is the safest automation around. *)
 Ltac tcrush := repeat typconstructor; stcrush; try solve [ done |
@@ -83,8 +83,7 @@ Hint Resolve is_stamped_idsσ_ren : core.
 (*******************)
 
 Section examples_lemmas.
-(* From D Require Import typeExtraction *)
-Context `{hasStampTable: stampTable}.
+Context {g : stys}.
 
 Lemma Appv_typed' T2 {Γ e1 v2 T1 T3} :
   Γ ⊢ₜ[ g ] e1: TAll T1 T2 →                        Γ ⊢ₜ[ g ] tv v2 : T1 →
@@ -115,8 +114,8 @@ Proof. rewrite -(iterate_0 tskip e). eauto. Qed.
 Hint Resolve Subs_typed_nocoerce : core.
 
 Lemma Sub_later_shift {Γ T1 T2 i j}
-  (Hs1: is_stamped_ty (length Γ) getStampTable T1)
-  (Hs2: is_stamped_ty (length Γ) getStampTable T2)
+  (Hs1: is_stamped_ty (length Γ) g T1)
+  (Hs2: is_stamped_ty (length Γ) g T2)
   (Hsub: Γ ⊢ₜ[ g ] T1, S i <: T2, S j):
   Γ ⊢ₜ[ g ] TLater T1, i <: TLater T2, j.
 Proof.
@@ -125,8 +124,8 @@ Proof.
 Qed.
 
 Lemma Sub_later_shift_inv {Γ T1 T2 i j}
-  (Hs1: is_stamped_ty (length Γ) getStampTable T1)
-  (Hs2: is_stamped_ty (length Γ) getStampTable T2)
+  (Hs1: is_stamped_ty (length Γ) g T1)
+  (Hs2: is_stamped_ty (length Γ) g T2)
   (Hsub: Γ ⊢ₜ[ g ] TLater T1, i <: TLater T2, j):
   Γ ⊢ₜ[ g ] T1, S i <: T2, S j.
 Proof.
@@ -142,12 +141,12 @@ Lemma Var_typed_sub Γ x T1 T2 :
 Proof. intros; eapply Subs_typed_nocoerce; by [exact: Var_typed|]. Qed.
 
 Lemma LSel_stp' Γ U {p l L i}:
-  is_stamped_ty (length Γ) getStampTable L →
+  is_stamped_ty (length Γ) g L →
   Γ ⊢ₚ[ g ] p : TTMem l L U, i →
   Γ ⊢ₜ[ g ] L, i <: TSel p l, i.
-Proof. intros; eapply Trans_stp; last exact: (LSel_stp _ p); tcrush. Qed.
+Proof. intros; eapply Trans_stp; last exact: (LSel_stp _ _ p); tcrush. Qed.
 
-Lemma AddI_stp Γ T i (Hst: is_stamped_ty (length Γ) getStampTable T) :
+Lemma AddI_stp Γ T i (Hst: is_stamped_ty (length Γ) g T) :
   Γ ⊢ₜ[ g ] T, 0 <: T, i.
 Proof.
   elim: i => [|n IHn]; first tcrush.
@@ -163,15 +162,15 @@ Proof.
   exact: TMono_stp.
 Qed.
 
-Lemma is_stamped_pvar i n : i < n → is_stamped_path n getStampTable (pv (var_vl i)).
+Lemma is_stamped_pvar i n : i < n → is_stamped_path n g (pv (var_vl i)).
 Proof. eauto. Qed.
-Lemma is_stamped_pvars i n l : i < n → is_stamped_ty n getStampTable (pv (var_vl i) @; l).
+Lemma is_stamped_pvars i n l : i < n → is_stamped_ty n g (pv (var_vl i) @; l).
 Proof. eauto using is_stamped_pvar. Qed.
 
 Lemma Let_typed Γ t u T U :
   Γ ⊢ₜ[ g ] t : T →
   T.|[ren (+1)] :: Γ ⊢ₜ[ g ] u : U.|[ren (+1)] →
-  is_stamped_ty (length Γ) getStampTable T →
+  is_stamped_ty (length Γ) g T →
   Γ ⊢ₜ[ g ] lett t u : U.
 Proof. move=> Ht Hu HsT. apply /App_typed /Ht /Lam_typed /Hu /HsT. Qed.
 
@@ -180,15 +179,15 @@ Proof. move=> Ht Hu HsT. apply /App_typed /Ht /Lam_typed /Hu /HsT. Qed.
 Definition packTV n s := (ν {@ type "A" = ((idsσ n).|[ren (+1)]; s)}).
 
 Lemma packTV_typed' s T n Γ :
-  getStampTable !! s = Some T →
-  is_stamped_ty n getStampTable T →
+  g !! s = Some T →
+  is_stamped_ty n g T →
   n <= length Γ →
   Γ ⊢ₜ[ g ] tv (packTV n s) : typeEq "A" T.
 Proof.
   move => Hlp HsT1 Hle; move: (Hle) (HsT1) => /le_n_S Hles /is_stamped_ren1_ty HsT2.
   move: (is_stamped_nclosed_ty HsT1) => Hcl.
   apply (Subs_typed_nocoerce (μ {@ typeEq "A" T.|[ren (+1)] }));
-    last (eapply Trans_stp; first apply (Mu_stp _ ({@ typeEq "A" T })); tcrush).
+    last (eapply Trans_stp; first apply (Mu_stp _ _ ({@ typeEq "A" T })); tcrush).
   apply VObj_typed; tcrush.
   apply (dty_typed T.|[ren (+1)]); auto 2; tcrush.
   apply /(@extraction_inf_subst _ (length _)); auto 3;
@@ -196,19 +195,19 @@ Proof.
 Qed.
 
 Lemma packTV_typed s T Γ :
-  getStampTable !! s = Some T →
-  is_stamped_ty (length Γ) getStampTable T →
+  g !! s = Some T →
+  is_stamped_ty (length Γ) g T →
   Γ ⊢ₜ[ g ] tv (packTV (length Γ) s) : typeEq "A" T.
 Proof. intros; exact: packTV_typed'. Qed.
 
 Lemma val_LB T U Γ i v :
   Γ ⊢ₜ[ g ] tv v : type "A" >: T <: U →
   Γ ⊢ₜ[ g ] ▶ T, i <: (pv v @; "A"), i.
-Proof. intros; apply /AddIB_stp /(LSel_stp _ (pv _)); tcrush. Qed.
+Proof. intros; apply /AddIB_stp /(LSel_stp _ _ (pv _)); tcrush. Qed.
 
 Lemma packTV_LB s T n Γ i :
-  getStampTable !! s = Some T →
-  is_stamped_ty n getStampTable T →
+  g !! s = Some T →
+  is_stamped_ty n g T →
   n <= length Γ →
   Γ ⊢ₜ[ g ] ▶ T, i <: (pv (packTV n s) @; "A"), i.
 Proof. intros; by apply /val_LB /packTV_typed'. Qed.
@@ -219,8 +218,8 @@ Lemma val_UB T L Γ i v :
 Proof. intros; eapply AddIB_stp, SelU_stp; tcrush. Qed.
 
 Lemma packTV_UB s T n Γ i :
-  is_stamped_ty n getStampTable T →
-  getStampTable !! s = Some T →
+  is_stamped_ty n g T →
+  g !! s = Some T →
   n <= length Γ →
   Γ ⊢ₜ[ g ] (pv (packTV n s) @; "A"), i <: ▶ T, i.
 Proof. intros; by apply /val_UB /packTV_typed'. Qed.
@@ -234,9 +233,9 @@ Lemma typeApp_typed s Γ T U V t :
     for ML and Scala: that is, producing a type [V] that does not refer to
     variables bound by let in the expression. *)
   (∀ L, typeEq "A" T.|[ren (+2)] :: L :: Γ ⊢ₜ[ g ] U.|[up (ren (+1))], 0 <: V.|[ren (+2)], 0) →
-  is_stamped_ty (length Γ) getStampTable T →
-  is_stamped_ty (S (length Γ)) getStampTable U →
-  getStampTable !! s = Some T.|[ren (+1)] →
+  is_stamped_ty (length Γ) g T →
+  is_stamped_ty (S (length Γ)) g U →
+  g !! s = Some T.|[ren (+1)] →
   Γ ⊢ₜ[ g ] tApp Γ t s : V.
 Proof.
   move => Ht Hsub HsT1 HsU1 Hl; move: (HsT1) => /is_stamped_ren1_ty HsT2.

--- a/theories/Dot/fundamental.v
+++ b/theories/Dot/fundamental.v
@@ -19,18 +19,17 @@ Notation "Γ ⊨[ gφ  ] T1 , i <: T2 , j" := (wellMappedφ gφ -∗ step_indexe
 
 Section fundamental.
   Context `{!dlangG Σ} `{!SwapPropI Σ}.
-  Context `{hasStampTable: stampTable}.
 
-  Fixpoint fundamental_dm_typed Γ V l d T (HT: Γ |d V ⊢[ g ]{ l := d } : T) { struct HT }:
-    Γ |L V ⊨[ ⟦ getStampTable ⟧g ] { l := d } : T with
-  fundamental_dms_typed Γ V ds T (HT: Γ |ds V ⊢[ g ] ds : T) { struct HT }:
-    Γ |L V ⊨[ ⟦ getStampTable ⟧g ]ds ds : T with
-  fundamental_subtype Γ T1 i1 T2 i2 (HT: Γ ⊢ₜ[ g ] T1, i1 <: T2, i2) { struct HT }:
-    Γ ⊨[ ⟦ getStampTable ⟧g ] T1, i1 <: T2, i2 with
-  fundamental_typed Γ e T (HT: Γ ⊢ₜ[ g ] e : T) { struct HT }:
-    Γ ⊨[ ⟦ getStampTable ⟧g ] e : T with
-  fundamental_path_typed Γ p T i (HT : Γ ⊢ₚ[ g ] p : T, i) { struct HT }:
-    Γ ⊨[ ⟦ getStampTable ⟧g ]p p : T, i.
+  Fixpoint fundamental_dm_typed Γ g V l d T (HT: Γ |d V ⊢[ g ]{ l := d } : T) { struct HT }:
+    Γ |L V ⊨[ ⟦ g ⟧g ] { l := d } : T with
+  fundamental_dms_typed Γ g V ds T (HT: Γ |ds V ⊢[ g ] ds : T) { struct HT }:
+    Γ |L V ⊨[ ⟦ g ⟧g ]ds ds : T with
+  fundamental_subtype Γ g T1 i1 T2 i2 (HT: Γ ⊢ₜ[ g ] T1, i1 <: T2, i2) { struct HT }:
+    Γ ⊨[ ⟦ g ⟧g ] T1, i1 <: T2, i2 with
+  fundamental_typed Γ g e T (HT: Γ ⊢ₜ[ g ] e : T) { struct HT }:
+    Γ ⊨[ ⟦ g ⟧g ] e : T with
+  fundamental_path_typed Γ g p T i (HT : Γ ⊢ₚ[ g ] p : T, i) { struct HT }:
+    Γ ⊨[ ⟦ g ⟧g ]p p : T, i.
   Proof.
     - iIntros "#Hm"; induction HT.
       + iApply D_Typ_Abs; by [> iApply fundamental_subtype .. |
@@ -111,11 +110,11 @@ Proof.
   iIntros (??) "Hs"; iApply Hlog. by iApply transfer_empty.
 Qed.
 
-Corollary type_soundness_storeless e T `{!stampTable}:
+Corollary type_soundness_storeless e T g:
   [] ⊢ₜ[ g ] e : T → safe e.
 Proof.
   intros HsT.
-  apply: (adequacy_mapped_semtyping dlangΣ e getStampTable T); intros.
+  apply: (adequacy_mapped_semtyping dlangΣ e g T); intros.
   apply fundamental_typed, HsT.
 Qed.
 

--- a/theories/Dot/stamping/stampingDefsCore.v
+++ b/theories/Dot/stamping/stampingDefsCore.v
@@ -6,7 +6,6 @@ From D.Dot Require Import syn traversals.
 Set Implicit Arguments.
 
 Notation stys := (gmap stamp ty).
-Class stampTable := getStampTable : stys.
 
 Import Trav1.
 Set Implicit Arguments.

--- a/theories/Dot/typing/typing.v
+++ b/theories/Dot/typing/typing.v
@@ -3,25 +3,23 @@ From D.Dot.stamping Require Export stampingDefsCore.
 
 Reserved Notation "Γ ⊢ₜ[ g ] e : T"
   (at level 74, e, T at next level,
-  format "'[' '[' Γ ']'  '/' ⊢ₜ[ g ]  '[' e ']'  :  '[' T ']' ']'").
-Reserved Notation "Γ ⊢ₚ[ g ] p : T , i" (at level 74, p, T, i at next level).
+  format "'[' '[' Γ ']'  '/' ⊢ₜ[  g  ]  '[' e ']'  :  '[' T ']' ']'").
+Reserved Notation "Γ ⊢ₚ[ g  ] p : T , i" (at level 74, p, T, i at next level).
 Reserved Notation "Γ |d V ⊢[ g ]{ l := d } : T "
-(* Reserved Notation "Γ |d V ⊢[ g ]{ l := d  } : T " *)
+(* Reserved Notation "Γ |d V ⊢[ g  ]{ l := d  } : T " *)
   (at level 74, l, d, T, V at next level,
-   format "'[' '[' Γ  |d  V  ']' '/' '[' ⊢[ g ]{  l  :=  d  } ']' :  '[' T ']' ']'").
+   format "'[' '[' Γ  |d  V  ']' '/' '[' ⊢[  g  ]{  l  :=  d  } ']' :  '[' T ']' ']'").
 Reserved Notation "Γ |ds V ⊢[ g ] ds : T"
   (at level 74, ds, T, V at next level,
-  format "'[' '[' Γ  |ds  V  ']' '/' ⊢[ g ]  '[' ds ']'  :  T ']'" ).
-Reserved Notation "Γ ⊢ₜ[ g ] T1 , i1 <: T2 , i2" (at level 74, T1, T2, i1, i2 at next level).
+  format "'[' '[' Γ  |ds  V  ']' '/' ⊢[  g  ]  '[' ds ']'  :  T ']'" ).
+Reserved Notation "Γ ⊢ₜ[ g  ] T1 , i1 <: T2 , i2" (at level 74, T1, T2, i1, i2 at next level).
 
 Implicit Types (L T U V : ty) (v : vl) (e : tm) (d : dm) (p: path) (ds : dms) (Γ : list ty) (g : stys).
 
-Section syntyping.
-  Context `{hasStampTable: stampTable}.
 (**
 Judgments for typing, subtyping, path and definition typing.
 *)
-Inductive typed Γ : tm → ty → Prop :=
+Inductive typed Γ g : tm → ty → Prop :=
 (** First, elimination forms *)
 (** Dependent application; only allowed if the argument is a value . *)
 | Appv_typed e1 v2 T1 T2:
@@ -31,7 +29,7 @@ Inductive typed Γ : tm → ty → Prop :=
 
 | App_path_typed p2 e1 T1 T2 T2':
     T2 .Tp[ p2 /]~ T2' →
-    is_stamped_ty (length Γ) getStampTable T2' →
+    is_stamped_ty (length Γ) g T2' →
     Γ ⊢ₜ[ g ] e1: TAll T1 T2 →
     Γ ⊢ₚ[ g ] p2 : T1, 0 →
     (*────────────────────────────────────────────────────────────*)
@@ -52,13 +50,13 @@ Inductive typed Γ : tm → ty → Prop :=
 (** Introduction forms *)
 | Lam_typed e T1 T2:
     (* T1 :: Γ ⊢ₜ[ g ] e : T2 → (* Would work, but allows the argument to occur in its own type. *) *)
-    is_stamped_ty (length Γ) getStampTable T1 →
+    is_stamped_ty (length Γ) g T1 →
     T1.|[ren (+1)] :: Γ ⊢ₜ[ g ] e : T2 →
     (*─────────────────────────*)
     Γ ⊢ₜ[ g ] tv (vabs e) : TAll T1 T2
 | VObj_typed ds T:
     Γ |ds T ⊢[ g ] ds: T →
-    is_stamped_ty (S (length Γ)) getStampTable T →
+    is_stamped_ty (S (length Γ)) g T →
     (*──────────────────────*)
     Γ ⊢ₜ[ g ] tv (vobj ds): TMu T
 | TMuI_typed v T:
@@ -88,8 +86,8 @@ Inductive typed Γ : tm → ty → Prop :=
     Γ ⊢ₜ[ g ] tv v : T1 →
     Γ ⊢ₜ[ g ] tv v : T2 →
     Γ ⊢ₜ[ g ] tv v : TAnd T1 T2
-where "Γ ⊢ₜ[ g ] e : T " := (typed Γ e T)
-with dms_typed Γ : ty → dms → ty → Prop :=
+where "Γ ⊢ₜ[ g ] e : T " := (typed Γ g e T)
+with dms_typed Γ g : ty → dms → ty → Prop :=
 | dnil_typed V : Γ |ds V ⊢[ g ] [] : TTop
 (* This demands definitions and members to be defined in aligned lists. *)
 | dcons_typed V l d ds T1 T2:
@@ -98,16 +96,16 @@ with dms_typed Γ : ty → dms → ty → Prop :=
     dms_hasnt ds l →
     (*──────────────────────*)
     Γ |ds V ⊢[ g ] (l, d) :: ds : TAnd T1 T2
-where "Γ |ds V ⊢[ g ] ds : T" := (dms_typed Γ V ds T)
-with dm_typed Γ : ty → label → dm → ty → Prop :=
+where "Γ |ds V ⊢[ g ] ds : T" := (dms_typed Γ g V ds T)
+with dm_typed Γ g : ty → label → dm → ty → Prop :=
 | dty_typed T V l L U s σ:
-    T ~[ S (length Γ) ] (getStampTable, (s, σ)) →
-    Forall (is_stamped_vl (S (length Γ)) getStampTable) σ →
+    T ~[ S (length Γ) ] (g, (s, σ)) →
+    Forall (is_stamped_vl (S (length Γ)) g) σ →
     TLater V :: Γ ⊢ₜ[ g ] TLater L, 0 <: TLater T, 0 →
     TLater V :: Γ ⊢ₜ[ g ] TLater T, 0 <: TLater U, 0 →
     Γ |d V ⊢[ g ]{ l := dtysem σ s } : TTMem l L U
 | dvabs_typed V T1 T2 e l:
-    is_stamped_ty (S (length Γ)) getStampTable T1 →
+    is_stamped_ty (S (length Γ)) g T1 →
     T1.|[ren (+1)] :: V :: Γ ⊢ₜ[ g ] e : T2 →
     Γ |d V ⊢[ g ]{ l := dvl (vabs e) } : TVMem l (TAll T1 T2)
 | dvl_typed V l v T:
@@ -117,8 +115,8 @@ with dm_typed Γ : ty → label → dm → ty → Prop :=
     TLater V :: Γ ⊢ₜ[ g ] T1, 0 <: T2, 0 →
     Γ |d V ⊢[ g ]{ l := dvl v } : TVMem l T1 →
     Γ |d V ⊢[ g ]{ l := dvl v } : TVMem l T2
-where "Γ |d V ⊢[ g ]{ l := d  } : T" := (dm_typed Γ V l d T)
-with path_typed Γ : path → ty → nat → Prop :=
+where "Γ |d V ⊢[ g ]{ l := d  } : T" := (dm_typed Γ g V l d T)
+with path_typed Γ g : path → ty → nat → Prop :=
 | pv_typed v T:
     Γ ⊢ₜ[ g ] tv v : T →
     Γ ⊢ₚ[ g ] pv v : T, 0
@@ -136,12 +134,12 @@ with path_typed Γ : path → ty → nat → Prop :=
     Γ ⊢ₚ[ g ] p : T2, i + j
 | p_mu_i_typed p T {T' i} :
     T .Tp[ p /]~ T' →
-    is_stamped_ty (S (length Γ)) getStampTable T →
+    is_stamped_ty (S (length Γ)) g T →
     Γ ⊢ₚ[ g ] p : T', i →
     Γ ⊢ₚ[ g ] p : TMu T, i
 | p_mu_e_typed p T {T' i} :
     T .Tp[ p /]~ T' →
-    is_stamped_ty (length Γ) getStampTable T' →
+    is_stamped_ty (length Γ) g T' →
     Γ ⊢ₚ[ g ] p : TMu T, i →
     Γ ⊢ₚ[ g ] p : T', i
 | pself_inv_typed p T i l:
@@ -157,7 +155,7 @@ with path_typed Γ : path → ty → nat → Prop :=
     Γ ⊢ₚ[ g ] p : TSing p, i
 | psingleton_sym_typed p q i:
     Γ ⊢ₚ[ g ] p : TSing q, i →
-    is_stamped_path (length Γ) getStampTable q →
+    is_stamped_path (length Γ) g q →
     Γ ⊢ₚ[ g ] q : TSing p, i
 | psingleton_trans p q T i:
     Γ ⊢ₚ[ g ] p : TSing q, i →
@@ -167,26 +165,26 @@ with path_typed Γ : path → ty → nat → Prop :=
     Γ ⊢ₚ[ g ] p : TSing q, i →
     Γ ⊢ₚ[ g ] pself q l : T, i →
     Γ ⊢ₚ[ g ] pself p l : TSing (pself q l), i
-where "Γ ⊢ₚ[ g ] p : T , i" := (path_typed Γ p T i)
+where "Γ ⊢ₚ[ g ] p : T , i" := (path_typed Γ g p T i)
 (* Γ ⊢ₜ[ g ] T1, i1 <: T2, i2 means that TLater^i1 T1 <: TLater^i2 T2. *)
-with subtype Γ : ty → nat → ty → nat → Prop :=
+with subtype Γ g : ty → nat → ty → nat → Prop :=
 | Refl_stp i T :
-    is_stamped_ty (length Γ) getStampTable T →
+    is_stamped_ty (length Γ) g T →
     Γ ⊢ₜ[ g ] T, i <: T, i
 | Trans_stp i2 T2 {i1 i3 T1 T3}:
     Γ ⊢ₜ[ g ] T1, i1 <: T2, i2 →
     Γ ⊢ₜ[ g ] T2, i2 <: T3, i3 →
     Γ ⊢ₜ[ g ] T1, i1 <: T3, i3
 | TLaterL_stp i T:
-    is_stamped_ty (length Γ) getStampTable T →
+    is_stamped_ty (length Γ) g T →
     Γ ⊢ₜ[ g ] TLater T, i <: T, S i
 | TLaterR_stp i T:
-    is_stamped_ty (length Γ) getStampTable T →
+    is_stamped_ty (length Γ) g T →
     Γ ⊢ₜ[ g ] T, S i <: TLater T, i
 
 (* "Structural" rules about indexes *)
 | TAddLater_stp T i:
-    is_stamped_ty (length Γ) getStampTable T →
+    is_stamped_ty (length Γ) g T →
     Γ ⊢ₜ[ g ] T, i <: TLater T, i
 | TMono_stp T1 T2 i j:
     Γ ⊢ₜ[ g ] T1, i <: T2, j →
@@ -194,30 +192,30 @@ with subtype Γ : ty → nat → ty → nat → Prop :=
 
 (* "Logical" connectives *)
 | Top_stp i T :
-    is_stamped_ty (length Γ) getStampTable T →
+    is_stamped_ty (length Γ) g T →
     Γ ⊢ₜ[ g ] T, i <: TTop, i
 | Bot_stp i T :
-    is_stamped_ty (length Γ) getStampTable T →
+    is_stamped_ty (length Γ) g T →
     Γ ⊢ₜ[ g ] TBot, i <: T, i
 | TAnd1_stp T1 T2 i:
-    is_stamped_ty (length Γ) getStampTable T1 →
-    is_stamped_ty (length Γ) getStampTable T2 →
+    is_stamped_ty (length Γ) g T1 →
+    is_stamped_ty (length Γ) g T2 →
     Γ ⊢ₜ[ g ] TAnd T1 T2, i <: T1, i
 | TAnd2_stp T1 T2 i:
-    is_stamped_ty (length Γ) getStampTable T1 →
-    is_stamped_ty (length Γ) getStampTable T2 →
+    is_stamped_ty (length Γ) g T1 →
+    is_stamped_ty (length Γ) g T2 →
     Γ ⊢ₜ[ g ] TAnd T1 T2, i <: T2, i
 | TAnd_stp T U1 U2 i j:
     Γ ⊢ₜ[ g ] T, i <: U1, j →
     Γ ⊢ₜ[ g ] T, i <: U2, j →
     Γ ⊢ₜ[ g ] T, i <: TAnd U1 U2, j
 | TOr1_stp T1 T2 i:
-    is_stamped_ty (length Γ) getStampTable T1 →
-    is_stamped_ty (length Γ) getStampTable T2 →
+    is_stamped_ty (length Γ) g T1 →
+    is_stamped_ty (length Γ) g T2 →
     Γ ⊢ₜ[ g ] T1, i <: TOr T1 T2, i
 | TOr2_stp T1 T2 i:
-    is_stamped_ty (length Γ) getStampTable T1 →
-    is_stamped_ty (length Γ) getStampTable T2 →
+    is_stamped_ty (length Γ) g T1 →
+    is_stamped_ty (length Γ) g T2 →
     Γ ⊢ₜ[ g ] T2, i <: TOr T1 T2, i
 | TOr_stp T1 T2 U i j:
     Γ ⊢ₜ[ g ] T1, i <: U, j →
@@ -233,8 +231,8 @@ with subtype Γ : ty → nat → ty → nat → Prop :=
     Γ ⊢ₜ[ g ] TLater L, i <: TSel p l, i
 | PSub_singleton_stp p q {i T1 T2}:
     T1 ~Tp[ p := q ]* T2 →
-    is_stamped_ty (length Γ) getStampTable T1 →
-    is_stamped_ty (length Γ) getStampTable T2 →
+    is_stamped_ty (length Γ) g T1 →
+    is_stamped_ty (length Γ) g T2 →
     Γ ⊢ₚ[ g ] p : TSing q, i →
     Γ ⊢ₜ[ g ] T1, i <: T2, i
 
@@ -249,13 +247,13 @@ with subtype Γ : ty → nat → ty → nat → Prop :=
 (* Subtyping for recursive types. Congruence, and opening in both directions. *)
 | Mu_stp_mu T1 T2 i:
     (iterate TLater i T1 :: Γ) ⊢ₜ[ g ] T1, i <: T2, i →
-    is_stamped_ty (S (length Γ)) getStampTable T1 →
+    is_stamped_ty (S (length Γ)) g T1 →
     Γ ⊢ₜ[ g ] TMu T1, i <: TMu T2, i
 | Mu_stp T i:
-    is_stamped_ty (length Γ) getStampTable T →
+    is_stamped_ty (length Γ) g T →
     Γ ⊢ₜ[ g ] TMu T.|[ren (+1)], i <: T, i
 | Stp_mu T i:
-    is_stamped_ty (length Γ) getStampTable T →
+    is_stamped_ty (length Γ) g T →
     Γ ⊢ₜ[ g ] T, i <: TMu T.|[ren (+1)], i
 
 (* "Congruence" or "variance" rules for subtyping. Unneeded for "logical" types.
@@ -267,7 +265,7 @@ with subtype Γ : ty → nat → ty → nat → Prop :=
 | TAllConCov_stp T1 T2 U1 U2 i:
     Γ ⊢ₜ[ g ] TLater T2, i <: TLater T1, i →
     iterate TLater (S i) T2.|[ren (+1)] :: Γ ⊢ₜ[ g ] TLater U1, i <: TLater U2, i →
-    is_stamped_ty (length Γ) getStampTable T2 →
+    is_stamped_ty (length Γ) g T2 →
     Γ ⊢ₜ[ g ] TAll T1 U1, i <: TAll T2 U2, i
 | TVMemCov_stp T1 T2 i l:
     Γ ⊢ₜ[ g ] T1, i <: T2, i →
@@ -282,30 +280,23 @@ with subtype Γ : ty → nat → ty → nat → Prop :=
     Let's prove F[A] ∧ F[B] <: F[A ∧ B] in the model.
     *)
 | TAllDistr_stp T U1 U2 i:
-    is_stamped_ty (length Γ) getStampTable T →
-    is_stamped_ty (S (length Γ)) getStampTable U1 →
-    is_stamped_ty (S (length Γ)) getStampTable U2 →
+    is_stamped_ty (length Γ) g T →
+    is_stamped_ty (S (length Γ)) g U1 →
+    is_stamped_ty (S (length Γ)) g U2 →
     Γ ⊢ₜ[ g ] TAnd (TAll T U1) (TAll T U2), i <: TAll T (TAnd U1 U2), i
 | TVMemDistr_stp l T1 T2 i:
-    is_stamped_ty (length Γ) getStampTable T1 →
-    is_stamped_ty (length Γ) getStampTable T2 →
+    is_stamped_ty (length Γ) g T1 →
+    is_stamped_ty (length Γ) g T2 →
     Γ ⊢ₜ[ g ] TAnd (TVMem l T1) (TVMem l T2), i <: TVMem l (TAnd T1 T2), i
 | TTMemDistr_strp l L U1 U2 i:
-    is_stamped_ty (length Γ) getStampTable L →
-    is_stamped_ty (length Γ) getStampTable U1 →
-    is_stamped_ty (length Γ) getStampTable U2 →
+    is_stamped_ty (length Γ) g L →
+    is_stamped_ty (length Γ) g U1 →
+    is_stamped_ty (length Γ) g U2 →
     Γ ⊢ₜ[ g ] TAnd (TTMem l L U1) (TTMem l L U2), i <: TTMem l L (TAnd U1 U2), i
-where "Γ ⊢ₜ[ g ] T1 , i1 <: T2 , i2" := (subtype Γ T1 i1 T2 i2).
+where "Γ ⊢ₜ[ g ] T1 , i1 <: T2 , i2" := (subtype Γ g T1 i1 T2 i2).
 
-  (* Make [T] first argument: Hide Γ for e.g. typing examples. *)
-  Global Arguments dty_typed {Γ} T _ _ _ _ _ _ _ _ _ _ : assert.
-End syntyping.
-
-Notation "Γ ⊢ₜ[ g ] e : T " := (typed Γ e T).
-Notation "Γ |ds V ⊢[ g ] ds : T" := (dms_typed Γ V ds T).
-Notation "Γ |d V ⊢[ g ]{ l := d  } : T" := (dm_typed Γ V l d T).
-Notation "Γ ⊢ₚ[ g ] p : T , i" := (path_typed Γ p T i).
-Notation "Γ ⊢ₜ[ g ] T1 , i1 <: T2 , i2" := (subtype Γ T1 i1 T2 i2).
+(* Make [T] first argument: Hide [Γ] and [g] for e.g. typing examples. *)
+Global Arguments dty_typed {Γ g} T _ _ _ _ _ _ _ _ _ _ : assert.
 
 Scheme exp_stamped_typed_mut_ind := Induction for typed Sort Prop
 with   exp_stamped_dms_typed_mut_ind := Induction for dms_typed Sort Prop

--- a/theories/Dot/typing/typingProofs.v
+++ b/theories/Dot/typing/typingProofs.v
@@ -3,34 +3,33 @@ From D.Dot Require Import typing typeExtractionSyn traversals stampedness_bindin
 Set Implicit Arguments.
 
 Section syntyping_lemmas.
-  Context `{hasStampTable: stampTable}.
 
   Hint Constructors Forall : core.
-  Lemma stamped_mut_subject Γ:
-    (∀ e  T, Γ ⊢ₜ[ g ] e : T → is_stamped_tm (length Γ) getStampTable e) ∧
-    (∀ V ds T, Γ |ds V ⊢[ g ] ds : T → Forall (is_stamped_dm (S (length Γ)) getStampTable) (map snd ds)) ∧
-    (∀ V l d T, Γ |d V ⊢[ g ]{ l := d } : T → is_stamped_dm (S (length Γ)) getStampTable d) ∧
-    (∀ p T i, Γ ⊢ₚ[ g ] p : T, i → is_stamped_path (length Γ) getStampTable p).
+  Lemma stamped_mut_subject Γ g :
+    (∀ e T, Γ ⊢ₜ[ g ] e : T → is_stamped_tm (length Γ) g e) ∧
+    (∀ V ds T, Γ |ds V ⊢[ g ] ds : T → Forall (is_stamped_dm (S (length Γ)) g) (map snd ds)) ∧
+    (∀ V l d T, Γ |d V ⊢[ g ]{ l := d } : T → is_stamped_dm (S (length Γ)) g d) ∧
+    (∀ p T i, Γ ⊢ₚ[ g ] p : T, i → is_stamped_path (length Γ) g p).
   Proof.
     eapply exp_stamped_typing_mut_ind with
-        (P := λ Γ e T _, is_stamped_tm (length Γ) getStampTable e)
-        (P0 := λ Γ V ds T _, Forall (is_stamped_dm (S (length Γ)) getStampTable) (map snd ds))
-        (P1 := λ Γ V l d T _, is_stamped_dm (S (length Γ)) getStampTable d)
-        (P2 := λ Γ p T i _, is_stamped_path (length Γ) getStampTable p);
+        (P := λ Γ g e T _, is_stamped_tm (length Γ) g e)
+        (P0 := λ Γ g V ds T _, Forall (is_stamped_dm (S (length Γ)) g) (map snd ds))
+        (P1 := λ Γ g V l d T _, is_stamped_dm (S (length Γ)) g d)
+        (P2 := λ Γ g p T i _, is_stamped_path (length Γ) g p); clear Γ g;
         cbn; intros; try by (with_is_stamped inverse + idtac);
           eauto using is_stamped_path2tm.
     - repeat constructor => //=. by eapply lookup_lt_Some.
     - intros; elim: i {s} => [|i IHi]; rewrite /= ?iterate_0 ?iterate_S //; eauto.
     - move: e => [T' ?]; ev. by apply @Trav1.trav_dtysem with
-        (T' := T') (ts' := (length σ, getStampTable)).
+        (T' := T') (ts' := (length σ, g)).
   Qed.
 
-  Lemma stamped_exp_subject Γ e T: Γ ⊢ₜ[ g ] e : T →
-    is_stamped_tm (length Γ) getStampTable e.
-  Proof. apply (stamped_mut_subject Γ). Qed.
-  Lemma stamped_path_subject Γ p T i:
-    Γ ⊢ₚ[ g ] p : T, i → is_stamped_path (length Γ) getStampTable p.
-  Proof. apply (stamped_mut_subject Γ). Qed.
+  Lemma stamped_exp_subject Γ g e T: Γ ⊢ₜ[ g ] e : T →
+    is_stamped_tm (length Γ) g e.
+  Proof. apply stamped_mut_subject. Qed.
+  Lemma stamped_path_subject Γ g p T i:
+    Γ ⊢ₚ[ g ] p : T, i → is_stamped_path (length Γ) g p.
+  Proof. apply stamped_mut_subject. Qed.
   Local Hint Resolve stamped_exp_subject stamped_path_subject : core.
 
   (* The reverse direction slows proof search and isn't used anyway? *)
@@ -80,20 +79,20 @@ Section syntyping_lemmas.
       eapply (@is_stamped_ren_ty_1 (length Γ) (T.|[ren (+x)]) g), IHx; eauto.
   Qed.
 
-  Lemma is_stamped_TLater_n {i n T}:
-    is_stamped_ty n getStampTable T →
-    is_stamped_ty n getStampTable (iterate TLater i T).
+  Lemma is_stamped_TLater_n {i n T g}:
+    is_stamped_ty n g T →
+    is_stamped_ty n g (iterate TLater i T).
   Proof.
     elim: i => [|//i IHi]; rewrite ?iterate_0 ?iterate_S //; auto.
   Qed.
 
-  Lemma is_stamped_tv_inv {n v}:
-    is_stamped_tm n getStampTable (tv v) →
-    is_stamped_vl n getStampTable v.
+  Lemma is_stamped_tv_inv {n v g}:
+    is_stamped_tm n g (tv v) →
+    is_stamped_vl n g v.
   Proof. by inversion 1. Qed.
-  Lemma is_stamped_TLater_inv {n T}:
-    is_stamped_ty n getStampTable (TLater T) →
-    is_stamped_ty n getStampTable T.
+  Lemma is_stamped_TLater_inv {n T g}:
+    is_stamped_ty n g (TLater T) →
+    is_stamped_ty n g T.
   Proof. by inversion 1. Qed.
 
   Local Hint Resolve is_stamped_tv_inv is_stamped_TLater_n : core.
@@ -106,43 +105,43 @@ Section syntyping_lemmas.
         try (is_var T; fail 1); inverse H
     end.
 
-  Lemma stamped_mut_types Γ :
-    (∀ e T, Γ ⊢ₜ[ g ] e : T → ∀ (Hctx: stamped_ctx getStampTable Γ), is_stamped_ty (length Γ) getStampTable T) ∧
-    (∀ V ds T, Γ |ds V ⊢[ g ] ds : T → ∀ (Hctx: stamped_ctx getStampTable Γ), is_stamped_ty (S (length Γ)) getStampTable V →
-      is_stamped_ty (S (length Γ)) getStampTable T) ∧
-    (∀ V l d T, Γ |d V ⊢[ g ]{ l := d } : T → ∀ (Hctx: stamped_ctx getStampTable Γ), is_stamped_ty (S (length Γ)) getStampTable V →
-      is_stamped_ty (S (length Γ)) getStampTable T) ∧
-    (∀ p T i, Γ ⊢ₚ[ g ] p : T , i → ∀ (Hctx: stamped_ctx getStampTable Γ), is_stamped_ty (length Γ) getStampTable T) ∧
-    (∀ T1 i1 T2 i2, Γ ⊢ₜ[ g ] T1, i1 <: T2, i2 → ∀ (Hctx: stamped_ctx getStampTable Γ),
-      is_stamped_ty (length Γ) getStampTable T1 ∧ is_stamped_ty (length Γ) getStampTable T2).
+  Lemma stamped_mut_types Γ g :
+    (∀ e T, Γ ⊢ₜ[ g ] e : T → ∀ (Hctx: stamped_ctx g Γ), is_stamped_ty (length Γ) g T) ∧
+    (∀ V ds T, Γ |ds V ⊢[ g ] ds : T → ∀ (Hctx: stamped_ctx g Γ), is_stamped_ty (S (length Γ)) g V →
+      is_stamped_ty (S (length Γ)) g T) ∧
+    (∀ V l d T, Γ |d V ⊢[ g ]{ l := d } : T → ∀ (Hctx: stamped_ctx g Γ), is_stamped_ty (S (length Γ)) g V →
+      is_stamped_ty (S (length Γ)) g T) ∧
+    (∀ p T i, Γ ⊢ₚ[ g ] p : T , i → ∀ (Hctx: stamped_ctx g Γ), is_stamped_ty (length Γ) g T) ∧
+    (∀ T1 i1 T2 i2, Γ ⊢ₜ[ g ] T1, i1 <: T2, i2 → ∀ (Hctx: stamped_ctx g Γ),
+      is_stamped_ty (length Γ) g T1 ∧ is_stamped_ty (length Γ) g T2).
   Proof.
     eapply stamped_typing_mut_ind with
-        (P := λ Γ e T _, ∀ (Hctx: stamped_ctx getStampTable Γ),
-          is_stamped_ty (length Γ) getStampTable T)
-        (P0 := λ Γ V ds T _, ∀ (Hctx: stamped_ctx getStampTable Γ), is_stamped_ty (S (length Γ)) getStampTable V →
-          is_stamped_ty (S (length Γ)) getStampTable T)
-        (P1 := λ Γ V l d T _, ∀ (Hctx: stamped_ctx getStampTable Γ), is_stamped_ty (S (length Γ)) getStampTable V →
-          is_stamped_ty (S (length Γ)) getStampTable T)
-        (P2 := λ Γ p T i _, ∀ (Hctx: stamped_ctx getStampTable Γ),
-          is_stamped_ty (length Γ) getStampTable T)
-        (P3 := λ Γ T1 i1 T2 i2 _, ∀ (Hctx: stamped_ctx getStampTable Γ),
-               is_stamped_ty (length Γ) getStampTable T1 ∧ is_stamped_ty (length Γ) getStampTable T2); clear Γ.
+        (P := λ Γ g e T _, ∀ (Hctx: stamped_ctx g Γ),
+          is_stamped_ty (length Γ) g T)
+        (P0 := λ Γ g V ds T _, ∀ (Hctx: stamped_ctx g Γ), is_stamped_ty (S (length Γ)) g V →
+          is_stamped_ty (S (length Γ)) g T)
+        (P1 := λ Γ g V l d T _, ∀ (Hctx: stamped_ctx g Γ), is_stamped_ty (S (length Γ)) g V →
+          is_stamped_ty (S (length Γ)) g T)
+        (P2 := λ Γ g p T i _, ∀ (Hctx: stamped_ctx g Γ),
+          is_stamped_ty (length Γ) g T)
+        (P3 := λ Γ g T1 i1 T2 i2 _, ∀ (Hctx: stamped_ctx g Γ),
+               is_stamped_ty (length Γ) g T1 ∧ is_stamped_ty (length Γ) g T2); clear Γ g.
     all: intros; cbn in *; ev; try solve [ eauto using is_stamped_ren_ty_1 ].
     all: try specialize (H Hctx); try specialize (H0 Hctx); ev.
     all: try solve [try with_is_stamped_inverse; repeat constructor; cbn; eauto 4].
     - inverse H. eapply is_stamped_sub_rev_ty => //. eauto.
     - by apply stamped_lookup.
-    - have Hctx': stamped_ctx getStampTable (TLater V :: Γ). by eauto.
+    - have Hctx': stamped_ctx g (TLater V :: Γ). by eauto.
       move: (H Hctx') (H0 Hctx'). intuition.
-    - have Hctx': stamped_ctx getStampTable (T1.|[ren (+1)] :: V :: Γ).
+    - have Hctx': stamped_ctx g (T1.|[ren (+1)] :: V :: Γ).
       by eauto.
       move: (H Hctx'); intuition.
-    - have Hctx': stamped_ctx getStampTable (TLater V :: Γ). by eauto.
+    - have Hctx': stamped_ctx g (TLater V :: Γ). by eauto.
       move: (H Hctx'); intuition.
-    - have Hctx': stamped_ctx getStampTable (iterate TLater i T1 :: Γ).
+    - have Hctx': stamped_ctx g (iterate TLater i T1 :: Γ).
       by eauto.
       move: (H Hctx'); intuition.
-    - have Hctx': stamped_ctx getStampTable (iterate TLater (S i) T2.|[ren (+1)] :: Γ).
+    - have Hctx': stamped_ctx g (iterate TLater (S i) T2.|[ren (+1)] :: Γ).
       by eauto.
       move: (H0 Hctx'). intros; ev; repeat econstructor; cbn; eauto.
   Qed.

--- a/theories/Dot/typing/typingStamping.v
+++ b/theories/Dot/typing/typingStamping.v
@@ -1,70 +1,54 @@
-From D.Dot Require Import typing_objIdent stampingDefsCore astStamping skeleton.
+From D.Dot Require Import typing_objIdent stampingDefsCore astStamping skeleton syn.path_repl.
 From D.Dot Require typing_unstamped.
 
 Set Implicit Arguments.
 
 Section syntyping_stamping_lemmas.
 
-  Hint Constructors typed subtype dms_typed dm_typed path_typed : core.
-  Remove Hints Trans_stp : core.
-  Hint Extern 10 => try_once Trans_stp : core.
+  Import typing_unstamped typing.
 
-  Arguments typed: clear implicits.
-  Arguments dms_typed: clear implicits.
-  Arguments dm_typed: clear implicits.
-  Arguments path_typed: clear implicits.
-  Arguments subtype: clear implicits.
-
-  Reserved Notation "Γ |⊢ₜ[ g  ] e : T"
-    (at level 74, e, T at next level).
-  Reserved Notation "Γ |ds V |⊢[ g  ] ds : T"
-    (at level 74, ds, T, V at next level).
-  Reserved Notation "Γ |d V |⊢[ g  ]{ l := d  } : T "
-    (at level 74, l, d, T, V at next level).
-  Reserved Notation "Γ |⊢ₚ[ g  ] p : T , i" (at level 74, p, T, i at next level).
-  Reserved Notation "Γ |⊢ₜ[ g  ] T1 , i1 <: T2 , i2" (at level 74, T1, T2, i1, i2 at next level).
-
-  Notation "Γ |⊢ₜ[ g  ] e : T " := (typed g Γ e T).
-  Notation "Γ |ds V |⊢[ g  ] ds : T" := (dms_typed g Γ V ds T).
-  Notation "Γ |d V |⊢[ g  ]{ l := d  } : T" := (dm_typed g Γ V l d T).
-  Notation "Γ |⊢ₚ[ g  ] p : T , i" := (path_typed g Γ p T i).
-  Notation "Γ |⊢ₜ[ g  ] T1 , i1 <: T2 , i2" := (subtype g Γ T1 i1 T2 i2).
+  Hint Constructors typing_objIdent.typed typing_objIdent.subtype typing_objIdent.dms_typed typing_objIdent.dm_typed typing_objIdent.path_typed : core.
+  Remove Hints typing_objIdent.Trans_stp : core.
+  Hint Extern 10 => try_once typing_objIdent.Trans_stp : core.
 
   Implicit Types (L T U V : ty) (v : vl) (e : tm) (d : dm) (p: path) (ds : dms) (Γ : list ty) (g : stys).
 
-Hint Extern 5 (is_stamped_path _ _ _) => try_once is_stamped_mono_path : core.
+  Hint Extern 5 (is_stamped_path _ _ _) => try_once is_stamped_mono_path : core.
 
-  Lemma stamped_objIdent_typing_mono_mut Γ (g g' : stys) (Hle: g ⊆ g'):
-    (∀ e T, Γ |⊢ₜ[ g ] e : T → Γ |⊢ₜ[ g' ] e : T) ∧
-    (∀ V ds T, Γ |ds V |⊢[ g ] ds : T → Γ |ds V |⊢[ g' ] ds : T) ∧
-    (∀ V l d T, Γ |d V |⊢[ g ]{ l := d } : T → Γ |d V |⊢[ g' ]{ l := d } : T) ∧
-    (∀ p T i, Γ |⊢ₚ[ g ] p : T, i → Γ |⊢ₚ[ g' ] p : T, i) ∧
-    (∀ T1 i1 T2 i2, Γ |⊢ₜ[ g ] T1, i1 <: T2, i2 → Γ |⊢ₜ[ g' ] T1, i1 <: T2, i2).
+  Lemma stamped_objIdent_typing_mono_mut Γ g :
+    (∀ e T, Γ |⊢ₜ[ g ] e : T → ∀ g' (Hle : g ⊆ g'), Γ |⊢ₜ[ g' ] e : T) ∧
+    (∀ V ds T, Γ |ds V |⊢[ g ] ds : T → ∀ g' (Hle : g ⊆ g'), Γ |ds V |⊢[ g' ] ds : T) ∧
+    (∀ V l d T, Γ |d V |⊢[ g ]{ l := d } : T → ∀ g' (Hle : g ⊆ g'), Γ |d V |⊢[ g' ]{ l := d } : T) ∧
+    (∀ p T i, Γ |⊢ₚ[ g ] p : T, i → ∀ g' (Hle : g ⊆ g'), Γ |⊢ₚ[ g' ] p : T, i) ∧
+    (∀ T1 i1 T2 i2, Γ |⊢ₜ[ g ] T1, i1 <: T2, i2 → ∀ g' (Hle : g ⊆ g'), Γ |⊢ₜ[ g' ] T1, i1 <: T2, i2).
   Proof.
     eapply stamped_objIdent_typing_mut_ind with
-        (P := λ Γ e T _, Γ |⊢ₜ[ g' ] e : T)
-        (P0 := λ Γ V ds T _, Γ |ds V |⊢[ g' ] ds : T)
-        (P1 := λ Γ V l d T _, Γ |d V |⊢[ g' ]{ l := d } : T)
-        (P2 := λ Γ p T i _, Γ |⊢ₚ[ g' ] p : T, i)
-        (P3 := λ Γ T1 i1 T2 i2 _, Γ |⊢ₜ[ g' ] T1, i1 <: T2, i2);
-    clear Γ; intros; eauto.
+        (P := λ Γ g e T _, ∀ g' (Hle : g ⊆ g'), Γ |⊢ₜ[ g' ] e : T)
+        (P0 := λ Γ g V ds T _, ∀ g' (Hle : g ⊆ g'), Γ |ds V |⊢[ g' ] ds : T)
+        (P1 := λ Γ g V l d T _, ∀ g' (Hle : g ⊆ g'), Γ |d V |⊢[ g' ]{ l := d } : T)
+        (P2 := λ Γ g p T i _, ∀ g' (Hle : g ⊆ g'), Γ |⊢ₚ[ g' ] p : T, i)
+        (P3 := λ Γ g T1 i1 T2 i2 _, ∀ g' (Hle : g ⊆ g'), Γ |⊢ₜ[ g' ] T1, i1 <: T2, i2);
+    clear Γ g; intros;
+      repeat match goal with
+      | H : forall g : stys, _ |- _ => specialize (H g' Hle)
+      end; eauto.
   Qed.
   Lemma stamped_objIdent_typed_mono Γ (g g' : stys) (Hle: g ⊆ g') e T:
     Γ |⊢ₜ[ g ] e : T → Γ |⊢ₜ[ g' ] e : T.
-  Proof. by apply (@stamped_objIdent_typing_mono_mut Γ g g'). Qed.
+  Proof. unmut_lemma (stamped_objIdent_typing_mono_mut Γ g). Qed.
   Lemma stamped_objIdent_subtype_mono Γ (g g' : stys) (Hle: g ⊆ g') T1 i1 T2 i2:
     Γ |⊢ₜ[ g ] T1, i1 <: T2, i2 → Γ |⊢ₜ[ g' ] T1, i1 <: T2, i2.
-  Proof. by apply (@stamped_objIdent_typing_mono_mut Γ g g'). Qed.
+  Proof. unmut_lemma (stamped_objIdent_typing_mono_mut Γ g). Qed.
 
   Lemma stamped_objIdent_dms_typed_mono Γ (g g' : stys) (Hle: g ⊆ g'):
     ∀ V ds T, Γ |ds V |⊢[ g ] ds : T → Γ |ds V |⊢[ g' ] ds : T.
-  Proof. by apply (@stamped_objIdent_typing_mono_mut Γ g g'). Qed.
+  Proof. unmut_lemma (stamped_objIdent_typing_mono_mut Γ g). Qed.
   Lemma stamped_objIdent_dm_typed_mono Γ (g g' : stys) (Hle: g ⊆ g'):
     ∀ V l d T, Γ |d V |⊢[ g ]{ l := d } : T → Γ |d V |⊢[ g' ]{ l := d } : T.
-  Proof. by apply (@stamped_objIdent_typing_mono_mut Γ g g'). Qed.
+  Proof. unmut_lemma (stamped_objIdent_typing_mono_mut Γ g). Qed.
   Lemma stamped_objIdent_path_typed_mono Γ (g g' : stys) (Hle: g ⊆ g'):
     ∀ p T i, Γ |⊢ₚ[ g ] p : T, i → Γ |⊢ₚ[ g' ] p : T, i.
-  Proof. by apply (@stamped_objIdent_typing_mono_mut Γ g g'). Qed.
+  Proof. unmut_lemma (stamped_objIdent_typing_mono_mut Γ g). Qed.
 
   Hint Extern 5 => try_once stamped_objIdent_typed_mono : core.
   Hint Extern 5 => try_once stamped_objIdent_dms_typed_mono : core.
@@ -82,9 +66,6 @@ Hint Extern 5 (is_stamped_path _ _ _) => try_once is_stamped_mono_path : core.
   Hint Extern 998 (_ = _) => f_equal : core.
 
   Local Ltac lte g g1 g2 := have ?: g ⊆ g2 by trans g1.
-
-  (* Importing this earlier shadows too much. *)
-  Import typing_unstamped.
 
   Hint Resolve is_stamped_path2tm is_unstamped_path2tm unstamp_path2tm : core.
   Hint Resolve unstamped_stamped_path unstamped_stamps_self_path : core.
@@ -208,7 +189,7 @@ Hint Extern 5 (is_stamped_path _ _ _) => try_once is_stamped_mono_path : core.
     destruct (stamp_dtysyn_spec g2 Husv); destruct_and!.
     have ?: g2 ⊆ g3 by simplify_eq. lte g g1 g2; lte g g2 g3; lte g1 g2 g3.
     exists (dtysem σ s), g3; simplify_eq; split_and!;
-      first eapply (typing_objIdent.dty_typed _ T); auto 2; [
+      first eapply (typing_objIdent.dty_typed _ _ T); auto 2; [
         exact: (stamped_objIdent_subtype_mono _ Hts1)|
         exact: (stamped_objIdent_subtype_mono _ Hts2)].
   - intros * Hus1 Hu1 IHs1 g.
@@ -316,10 +297,6 @@ Hint Extern 5 (is_stamped_path _ _ _) => try_once is_stamped_mono_path : core.
     ∀ (g : stys), ∃ e' (g' : stys),
     Γ |⊢ₜ[ g' ] e' : T ∧ g ⊆ g' ∧ stamps_tm (length Γ) e g' e'.
   Proof. apply (stamp_objIdent_typing_mut Γ). Qed.
-
-  Arguments typing.typed: clear implicits.
-  Notation "Γ ⊢ₜ[ g  ] e : T" := (typing.typed g Γ e T)
-    (at level 74, e, T at next level).
 
   Lemma safe_stamp {n e g e_s}:
     stamps_tm n e g e_s → safe e_s → safe e.


### PR DESCRIPTION
Using stampTable is too complicated and fragile, which could be okay in Coq, but
not on paper. So, stop doing that.