### PR TITLE
Avoid substitution in forall

### DIFF
--- a/theories/Dot/lr/lr_lemma_nobinding.v
+++ b/theories/Dot/lr/lr_lemma_nobinding.v
@@ -18,9 +18,6 @@ Section Sec.
     iDestruct "H1" as (t ?) "#H1"; iDestruct "H2" as (t' ->) "#H2"; simplify_eq.
     iExists _; iSplit => //.
     iIntros "!>" (w) "#HT".
-    iSpecialize ("H1" with "HT").
-    iSpecialize ("H2" with "HT").
-    iNext.
     (* Oh. Dreaded conjunction rule. Tho could we use a version
     for separating conjunction? *)
     iApply wp_and. by iApply "H1". by iApply "H2".

--- a/theories/Dot/lr/path_repl.v
+++ b/theories/Dot/lr/path_repl.v
@@ -256,10 +256,8 @@ Section path_repl.
     iDestruct (path_wp_to_wp _ (λ v, ⌜ pw = v ⌝)%I with "[%//]") as "Hpeq".
     iApply (wp_bind (fill [AppRCtx _])). rewrite path2tm_subst.
     iApply (wp_wand with "Hpeq"); iIntros (? <-) "/= {Hpeq}".
-    rewrite -wp_pure_step_later; last done.
     iSpecialize ("HvFun" with "Hpw").
-    iNext.
-    iApply (wp_wand with "HvFun"); iIntros (v) "{HvFun Hpw} Hres".
+    iApply (wp_wand with "HvFun"); iIntros "/=" (v) "{HvFun Hpw} Hres".
     by rewrite (psubst_one_repl Hrepl).
   Qed.
 

--- a/theories/Dot/lr/unary_lr.v
+++ b/theories/Dot/lr/unary_lr.v
@@ -119,7 +119,7 @@ Section logrel.
   Definition interp_forall interp1 interp2 : envD Σ :=
     λ ρ v,
     (∃ t, ⌜ v = vabs t ⌝ ∧
-     □ ∀ w, ▷ interp1 ρ w → ▷ interp_expr interp2 (w .: ρ) t.|[w/])%I.
+     □ ∀ w, ▷ interp1 ρ w → interp_expr interp2 (w .: ρ) (tapp (tv (vabs t)) (tv w)))%I.
   Global Arguments interp_forall /.
 
   Definition interp_mu interp : envD Σ :=

--- a/theories/Dot/misc/experiments.v
+++ b/theories/Dot/misc/experiments.v
@@ -107,13 +107,14 @@ Section Sec.
     (*─────────────────────────*)
     Γ ⊨ tv (vabs e) : TAll T1 T2.
   Proof.
-    iIntros "/= #HeT !>" (vs) "#HG".
+    iIntros "/= #HeT !>" (ρ) "#HG".
     rewrite -wp_value'. iExists _; iSplit; first done.
-    iIntros "!>" (v); rewrite -(decomp_s e (v .: vs)).
-    iIntros "#Hv".
+    iIntros "!>" (v) "#Hv".
+    (* Factor ⪭ out of [⟦ Γ ⟧* ρ] before [iNext]. *)
+    rewrite -wp_pure_step_later // -(decomp_s _ (v .: ρ)).
     (* iApply (wp_later_swap _ (⟦ T2 ⟧ (v .: vs))).
     iApply ("HeT" $! (v .: vs) with "[$HG]"). *)
-    iSpecialize ("HeT" $! (v .: vs) with "[$HG]").
+    iSpecialize ("HeT" $! (v .: ρ) with "[$HG]").
     by rewrite (interp_weaken_one T1 _ v).
     iApply (wp_later_swap with "HeT").
   Qed.
@@ -128,14 +129,14 @@ Section Sec.
     iExists t; iSplit => //.
     rewrite -mlater_pers. iModIntro (□ _)%I.
     iIntros (w). iSpecialize ("HvTU" $! w).
-    rewrite -(wp_later_swap _ (⟦ _ ⟧ _)).
     rewrite -impl_later.
+    rewrite -(wp_later_swap _ (⟦ _ ⟧ _)).
     (* Either: *)
     (* done. *)
     (* Or keep the old but more flexible code: *)
     iIntros "#HwT".
     iApply (wp_wand with "(HvTU [# $HwT //])").
-    by iIntros "!>" (v) "$".
+    by iIntros (v) "$".
   Qed.
 
   Lemma TVMem_Later_Swap Γ l T i:


### PR DESCRIPTION
Also suggested by @robbertkrebbers, tho I needed different lemmas to fix the proof.

However, not merging for now — the resulting semantics looks a bit weird to me and to explain, and it only seems to make a side point.