### PR TITLE
Allow values in (some) unstamped paths

### DIFF
--- a/theories/Dot/examples/typingExamplesUnst.v
+++ b/theories/Dot/examples/typingExamplesUnst.v
@@ -12,7 +12,7 @@ Implicit Types (L T U: ty) (v: vl) (e: tm) (d: dm) (ds: dms) (Γ : list ty).
 
 Example ex0 e Γ T:
   Γ u⊢ₜ e : T →
-  is_unstamped_ty (length Γ) T →
+  is_unstamped_ty' (length Γ) T →
   Γ u⊢ₜ e : ⊤.
 Proof. intros. apply (Subs_typed_nocoerce T TTop); tcrush. Qed.
 
@@ -89,7 +89,7 @@ Qed.
 
 (* Utilities needed for not. *)
 Lemma subIFT i Γ T:
-  is_unstamped_ty (length Γ) T.|[ren (+i)] →
+  is_unstamped_ty' (length Γ) T.|[ren (+i)] →
   (typeEq "A" T.|[ren (+1+i)]) :: Γ u⊢ₜ IFTBody, 0 <:
     TAll T.|[ren (+1+i)] (TAll T.|[ren (+2+i)] (▶: T.|[ren (+3+i)])), 0.
 Proof.
@@ -102,7 +102,7 @@ Proof.
 Qed.
 
 Lemma tyAppIFT_typed Γ T t :
-  is_unstamped_ty (length Γ) T →
+  is_unstamped_ty' (length Γ) T →
   Γ u⊢ₜ t : IFT →
   Γ u⊢ₜ tyApp t "A" T : T →: T →: ▶: T.
 Proof.
@@ -119,7 +119,7 @@ Definition iftCoerce t :=
   lett t (vabs' (vabs' (tskip (tapp (tapp (tv x2) (tv x1)) (tv x0))))).
 
 Lemma iftCoerce_typed Γ t T :
-  is_unstamped_ty (length Γ) T →
+  is_unstamped_ty' (length Γ) T →
   Γ u⊢ₜ t: T →: T →: ▶: T →
   Γ u⊢ₜ iftCoerce t : T →: T →: T.
 Proof.
@@ -138,7 +138,7 @@ Proof.
 Qed.
 
 Lemma iftCoerce_tyAppIFT_typed Γ T t :
-  is_unstamped_ty (length Γ) T →
+  is_unstamped_ty' (length Γ) T →
   Γ u⊢ₜ t : IFT →
   Γ u⊢ₜ iftCoerce (tyApp t "A" T) : T →: T →: T.
 Proof. intros. by apply /iftCoerce_typed /tyAppIFT_typed. Qed.

--- a/theories/Dot/misc_unused/experiments.v
+++ b/theories/Dot/misc_unused/experiments.v
@@ -100,7 +100,7 @@ Section Example.
   Qed.
 
   (* XXX use more semantic typing. *)
-  Example packTV_semTyped Γ s T (Hu: is_unstamped_ty (length Γ) T):
+  Example packTV_semTyped Γ s T (Hu: is_unstamped_ty' (length Γ) T):
     s ↝ ⟦ T ⟧ -∗
     Γ ⊨ tv (packTV (length Γ) s) : typeEq "A" T.
     (* Γ ⊨ tv (packTV (length Γ) s) : type "A" >: ⊥ <: T. *)
@@ -202,14 +202,14 @@ Section Example.
   Qed.
 (* lett (hclose (htv hloopDefV @: "loop")) *)
   Example barsyn e v1 Γ T :
-    is_unstamped_ty (S (length Γ)) T →
+    is_unstamped_ty' (S (length Γ)) T →
     T :: Γ v⊢ₜ[ g0 s0 ⊤ ] e : Example.iftFalse →
     T :: Γ v⊢ₜ[ g0 s0 ⊤ ] tv v1 : ⊤ →
     T :: Γ v⊢ₜ[ g0 s0 ⊤ ] applyE e v1 x0 : TSing (pv x0).
   Proof.
     intros; apply foosyn => //.
     eapply Var_typed_sub; [ done | tcrush]. cbn.
-    apply unstamped_stamped_type.
+    eapply unstamped_stamped_type.
     by rewrite hsubst_id.
   Qed.
 

--- a/theories/Dot/misc_unused/path_repl_misc.v
+++ b/theories/Dot/misc_unused/path_repl_misc.v
@@ -34,16 +34,16 @@ Proof. done. Qed.
 
 
 (* Lemma unstamped_val_unshifts_0 v n :
-  is_unstamped_path n (pv v) → v ≠ ids 0 → unshifts_vl v.
+  is_unstamped_path' n (pv v) → v ≠ ids 0 → unshifts_vl v.
 Proof. rewrite -unshifts_vl_equiv; apply unstamped_val_unshifts. Qed. *)
 
 Lemma is_unstamped_path_root n p :
-  is_unstamped_path n p →
-  is_unstamped_path n (pv (path_root p)).
+  is_unstamped_path' n p →
+  is_unstamped_path' n (pv (path_root p)).
 Proof. elim: p => //=; intros; with_is_unstamped inverse; eauto. Qed.
 
 Lemma unstamped_path_unshifts_n p i n :
-  path_root p ≠ ids i → is_unstamped_path n p → unshiftsN_vl i (path_root p).
+  path_root p ≠ ids i → is_unstamped_path' n p → unshiftsN_vl i (path_root p).
 Proof. intros Hne Hu%is_unstamped_path_root. exact: unstamped_val_unshifts. Qed.
 
 (*

--- a/theories/Dot/stamping/traversals.v
+++ b/theories/Dot/stamping/traversals.v
@@ -11,6 +11,7 @@ Module Trav1.
 Record Traversal {travStateT: Type} :=
   {
     upS: travStateT → travStateT;
+    intoTypeS: travStateT → travStateT;
     varP: travStateT → nat → Prop;
     dtysynP: travStateT → ty → Prop;
     dtysemP: travStateT → vls → stamp → ty → travStateT → Prop;
@@ -108,10 +109,10 @@ Section fold.
       forall_traversal_ty ts T2 →
       forall_traversal_ty ts (TTMem l T1 T2)
   | trav_TSel ts p l:
-      forall_traversal_path ts p →
+      forall_traversal_path (trav.(intoTypeS) ts) p →
       forall_traversal_ty ts (TSel p l)
   | trav_TSing ts p:
-      forall_traversal_path ts p →
+      forall_traversal_path (trav.(intoTypeS) ts) p →
       forall_traversal_ty ts (TSing p)
   | trav_TPrim ts b: forall_traversal_ty ts (TPrim b)
     .

--- a/theories/Dot/stamping/unstampedness_binding.v
+++ b/theories/Dot/stamping/unstampedness_binding.v
@@ -9,25 +9,25 @@ Implicit Types
          (T: ty) (v: vl) (e: tm) (p: path) (d: dm) (ds: dms) (vs: vls)
          (Γ : ctx) (g: stys) (n: nat).
 
-Definition is_unstamped_sub n m s :=
-  ∀ i, i < n → is_unstamped_vl m (s i).
-Notation is_unstamped_ren n m r := (is_unstamped_sub n m (ren r)).
+Definition is_unstamped_sub n m b s :=
+  ∀ i, i < n → is_unstamped_vl m b (s i).
+Notation is_unstamped_ren n m b r := (is_unstamped_sub n m b (ren r)).
 
 Lemma is_unstamped_nclosed_mut:
-  (∀ t i,
-    is_unstamped_tm i t →
+  (∀ t i b,
+    is_unstamped_tm i b t →
     nclosed t i) ∧
-  (∀ v i,
-    is_unstamped_vl i v →
+  (∀ v i b,
+    is_unstamped_vl i b v →
     nclosed_vl v i) ∧
-  (∀ d i,
-    is_unstamped_dm i d →
+  (∀ d i b,
+    is_unstamped_dm i b d →
     nclosed d i) ∧
-  (∀ p i,
-    is_unstamped_path i p →
+  (∀ p i b,
+    is_unstamped_path i b p →
     nclosed p i) ∧
-  (∀ T i,
-    is_unstamped_ty i T →
+  (∀ T i b,
+    is_unstamped_ty i b T →
     nclosed T i).
 Proof.
   apply syntax_mut_ind; intros; with_is_unstamped inverse => //; ev;
@@ -41,91 +41,91 @@ Proof.
     decompose_Forall; case_match; subst. eauto.
 Qed.
 
-Lemma is_unstamped_nclosed_tm e n: is_unstamped_tm n e → nclosed e n.
+Lemma is_unstamped_nclosed_tm e n b: is_unstamped_tm n b e → nclosed e n.
 Proof. apply is_unstamped_nclosed_mut. Qed.
-Lemma is_unstamped_nclosed_vl v n: is_unstamped_vl n v → nclosed_vl v n.
+Lemma is_unstamped_nclosed_vl v n b: is_unstamped_vl n b v → nclosed_vl v n.
 Proof. apply is_unstamped_nclosed_mut. Qed.
-Lemma is_unstamped_nclosed_dm d n: is_unstamped_dm n d → nclosed d n.
+Lemma is_unstamped_nclosed_dm d n b: is_unstamped_dm n b d → nclosed d n.
 Proof. apply is_unstamped_nclosed_mut. Qed.
-Lemma is_unstamped_nclosed_path p n: is_unstamped_path n p → nclosed p n.
+Lemma is_unstamped_nclosed_path p n b: is_unstamped_path n b p → nclosed p n.
 Proof. apply is_unstamped_nclosed_mut. Qed.
-Lemma is_unstamped_nclosed_ty T n: is_unstamped_ty n T → nclosed T n.
+Lemma is_unstamped_nclosed_ty T n b: is_unstamped_ty n b T → nclosed T n.
 Proof. apply is_unstamped_nclosed_mut. Qed.
 
 Hint Resolve is_unstamped_nclosed_tm is_unstamped_nclosed_vl
   is_unstamped_nclosed_dm is_unstamped_nclosed_path
   is_unstamped_nclosed_ty : core.
 
-Lemma is_unstamped_nclosed_σ σ i:
-  is_unstamped_σ i σ →
+Lemma is_unstamped_nclosed_σ σ i b:
+  is_unstamped_σ i b σ →
   nclosed_σ σ i.
 Proof. intros; decompose_Forall. exact: is_unstamped_nclosed_vl. Qed.
 Hint Resolve is_unstamped_nclosed_ty is_unstamped_nclosed_σ : core.
 
-Lemma is_unstamped_nclosed_sub n m ξ :
-  is_unstamped_sub n m ξ → nclosed_sub n m ξ.
+Lemma is_unstamped_nclosed_sub n m b ξ :
+  is_unstamped_sub n m b ξ → nclosed_sub n m ξ.
 Proof. move => Hst i Hle. apply /is_unstamped_nclosed_vl /Hst/Hle. Qed.
 
 Lemma is_unstamped_weaken_mut:
-  (∀ e__s m n,
-      is_unstamped_tm m e__s →
+  (∀ e__s m n b,
+      is_unstamped_tm m b e__s →
       m <= n →
-      is_unstamped_tm n e__s) ∧
-  (∀ v__s m n,
-      is_unstamped_vl m v__s →
+      is_unstamped_tm n b e__s) ∧
+  (∀ v__s m n b,
+      is_unstamped_vl m b v__s →
       m <= n →
-      is_unstamped_vl n v__s) ∧
-  (∀ d__s m n,
-      is_unstamped_dm m d__s →
+      is_unstamped_vl n b v__s) ∧
+  (∀ d__s m n b,
+      is_unstamped_dm m b d__s →
       m <= n →
-      is_unstamped_dm n d__s) ∧
-  (∀ p__s m n,
-      is_unstamped_path m p__s →
+      is_unstamped_dm n b d__s) ∧
+  (∀ p__s m n b,
+      is_unstamped_path m b p__s →
       m <= n →
-      is_unstamped_path n p__s) ∧
-  (∀ T__s m n,
-      is_unstamped_ty m T__s →
+      is_unstamped_path n b p__s) ∧
+  (∀ T__s m n b,
+      is_unstamped_ty m b T__s →
       m <= n →
-      is_unstamped_ty n T__s).
+      is_unstamped_ty n b T__s).
 Proof.
   apply syntax_mut_ind;
     by [intros; with_is_unstamped inverse; econstructor;
       decompose_Forall; eauto with lia].
 Qed.
 
-Lemma is_unstamped_weaken_tm e__s m n:
-  is_unstamped_tm m e__s →
+Lemma is_unstamped_weaken_tm e__s m n b:
+  is_unstamped_tm m b e__s →
   m <= n →
-  is_unstamped_tm n e__s.
+  is_unstamped_tm n b e__s.
 Proof. apply (is_unstamped_weaken_mut). Qed.
-Lemma is_unstamped_weaken_vl v__s m n:
-  is_unstamped_vl m v__s →
+Lemma is_unstamped_weaken_vl v__s m n b:
+  is_unstamped_vl m b v__s →
   m <= n →
-  is_unstamped_vl n v__s.
+  is_unstamped_vl n b v__s.
 Proof. apply (is_unstamped_weaken_mut). Qed.
-Lemma is_unstamped_weaken_dm d__s m n:
-  is_unstamped_dm m d__s →
+Lemma is_unstamped_weaken_dm d__s m n b:
+  is_unstamped_dm m b d__s →
   m <= n →
-  is_unstamped_dm n d__s.
+  is_unstamped_dm n b d__s.
 Proof. apply (is_unstamped_weaken_mut). Qed.
-Lemma is_unstamped_weaken_path p__s m n:
-  is_unstamped_path m p__s →
+Lemma is_unstamped_weaken_path p__s m n b:
+  is_unstamped_path m b p__s →
   m <= n →
-  is_unstamped_path n p__s.
+  is_unstamped_path n b p__s.
 Proof. apply (is_unstamped_weaken_mut). Qed.
-Lemma is_unstamped_weaken_ty T__s m n:
-  is_unstamped_ty m T__s →
+Lemma is_unstamped_weaken_ty T__s m n b:
+  is_unstamped_ty m b T__s →
   m <= n →
-  is_unstamped_ty n T__s.
+  is_unstamped_ty n b T__s.
 Proof. apply (is_unstamped_weaken_mut). Qed.
 
-Lemma is_unstamped_weaken_σ σ m n:
-  is_unstamped_σ m σ →
+Lemma is_unstamped_weaken_σ σ m n b:
+  is_unstamped_σ m b σ →
   m <= n →
-  is_unstamped_σ n σ.
+  is_unstamped_σ n b σ.
 Proof. intros; decompose_Forall. exact: is_unstamped_weaken_vl. Qed.
 
-Lemma is_unstamped_idsσ_ren m n j: j + n <= m → is_unstamped_σ m (idsσ n).|[ren (+j)].
+Lemma is_unstamped_idsσ_ren m n j b: j + n <= m → is_unstamped_σ m b (idsσ n).|[ren (+j)].
 Proof.
   elim: n m j => [//=|n IHn] m j Ijm.
   cbn; rewrite (hren_upn_gen 0 1 j) /= plusnO.
@@ -133,17 +133,17 @@ Proof.
   apply IHn; lia.
 Qed.
 
-Lemma is_unstamped_idsσ m n: n <= m → is_unstamped_σ m (idsσ n).
+Lemma is_unstamped_idsσ m n b: n <= m → is_unstamped_σ m b (idsσ n).
 Proof. pose proof (@is_unstamped_idsσ_ren m n 0) as H. asimpl in H. exact: H. Qed.
 Hint Resolve is_unstamped_idsσ : core.
 
-Lemma is_unstamped_ren_shift n m j:
-  m >= j + n → is_unstamped_ren n m (+j).
+Lemma is_unstamped_ren_shift n m j b:
+  m >= j + n → is_unstamped_ren n m b (+j).
 Proof. constructor => //=; lia. Qed.
 
-Lemma is_unstamped_ren_up n m r:
-  is_unstamped_ren n m r →
-  is_unstamped_ren (S n) (S m) (upren r).
+Lemma is_unstamped_ren_up n m r b:
+  is_unstamped_ren n m b r →
+  is_unstamped_ren (S n) (S m) b (upren r).
 Proof.
   (* rewrite /is_unstamped_ren /is_unstamped_sub /=. *)
   move => Hr [|i] //= Hi; first by constructor => /=; lia.
@@ -155,7 +155,7 @@ Hint Resolve is_unstamped_ren_up is_unstamped_ren_shift : core.
 
 From D.Dot Require Import closed_subst.
 
-Lemma is_unstamped_nclosed_ren i j r: is_unstamped_ren i j r → nclosed_ren i j r.
+Lemma is_unstamped_nclosed_ren i j r b: is_unstamped_ren i j b r → nclosed_ren i j r.
 Proof.
   move => /= Hr x Hx. specialize (Hr x Hx); inverse Hr. exact: nclosed_vl_ids.
 Qed.
@@ -165,43 +165,56 @@ Lemma is_unstamped_ren_var v r:
   ∃ x : var, rename r v = var_vl x.
 Proof. naive_solver. Qed.
 
+Lemma is_unstamped_var_intype i j b :
+  is_unstamped_vl i b (ids j) → is_unstamped_vl i InType (ids j).
+Proof. inversion 1; by constructor. Qed.
+Lemma is_unstamped_ren_intype i j b r :
+  is_unstamped_ren i j b r → is_unstamped_ren i j InType r.
+Proof. intros Hu ?**. by eapply is_unstamped_var_intype, Hu. Qed.
+
+Hint Extern 0 (forall_traversal_tm _ _ _) => cbn : core.
+Hint Extern 0 (forall_traversal_vl _ _ _) => cbn : core.
+Hint Extern 0 (forall_traversal_dm _ _ _) => cbn : core.
+Hint Extern 0 (forall_traversal_path _ _ _) => cbn : core.
+Hint Extern 0 (forall_traversal_ty _ _ _) => cbn : core.
+
 Lemma is_unstamped_ren_mut:
-  (∀ t r i j,
-    is_unstamped_ren i j r →
-    is_unstamped_tm i t →
-    is_unstamped_tm j (rename r t)) ∧
-  (∀ v r i j,
-    is_unstamped_ren i j r →
-    is_unstamped_vl i v →
-    is_unstamped_vl j (rename r v)) ∧
-  (∀ d r i j,
-    is_unstamped_ren i j r →
-    is_unstamped_dm i d →
-    is_unstamped_dm j (rename r d)) ∧
-  (∀ p r i j,
-    is_unstamped_ren i j r →
-    is_unstamped_path i p →
-    is_unstamped_path j (rename r p)) ∧
-  (∀ T r i j,
-    is_unstamped_ren i j r →
-    is_unstamped_ty i T →
-    is_unstamped_ty j (rename r T)).
+  (∀ t r i j b,
+    is_unstamped_ren i j b r →
+    is_unstamped_tm i b t →
+    is_unstamped_tm j b (rename r t)) ∧
+  (∀ v r i j b,
+    is_unstamped_ren i j b r →
+    is_unstamped_vl i b v →
+    is_unstamped_vl j b (rename r v)) ∧
+  (∀ d r i j b,
+    is_unstamped_ren i j b r →
+    is_unstamped_dm i b d →
+    is_unstamped_dm j b (rename r d)) ∧
+  (∀ p r i j b,
+    is_unstamped_ren i j b r →
+    is_unstamped_path i b p →
+    is_unstamped_path j b (rename r p)) ∧
+  (∀ T r i j b,
+    is_unstamped_ren i j b r →
+    is_unstamped_ty i b T →
+    is_unstamped_ty j b (rename r T)).
 Proof.
   apply syntax_mut_ind; intros; with_is_unstamped ltac:(fun H => inversion_clear H);
-    cbn in *; try by [|eauto using is_unstamped_ren_var].
+    cbn in *; try by [|naive_solver eauto using is_unstamped_ren_var, is_unstamped_ren_intype].
   - constructor; rewrite list_pair_swap_snd_rename Forall_fmap;
       by decompose_Forall; eauto.
 Qed.
 
-Lemma is_unstamped_ren_vl v r i j:
-  is_unstamped_ren i j r →
-  is_unstamped_vl i v →
-  is_unstamped_vl j (rename r v).
+Lemma is_unstamped_ren_vl v r i j b:
+  is_unstamped_ren i j b r →
+  is_unstamped_vl i b v →
+  is_unstamped_vl j b (rename r v).
 Proof. apply is_unstamped_ren_mut. Qed.
 
-Lemma is_unstamped_sub_up n m s:
-  is_unstamped_sub n m s →
-  is_unstamped_sub (S n) (S m) (up s).
+Lemma is_unstamped_sub_up n m s b:
+  is_unstamped_sub n m b s →
+  is_unstamped_sub (S n) (S m) b (up s).
 Proof.
   move => Hs [|i] Hi //=. by constructor => /=; lia.
   eapply is_unstamped_ren_vl; eauto with lia.
@@ -226,8 +239,8 @@ Abort. *)
 Lemma is_unstamped_sub_mut:
   (∀ t s i j,
     is_unstamped_sub i j s →
-    is_unstamped_tm i t →
-    is_unstamped_tm j t.|[s]) ∧
+    is_unstamped_tm i b t →
+    is_unstamped_tm j b t.|[s]) ∧
   (∀ v s i j,
     is_unstamped_sub i j s →
     is_unstamped_vl i v →
@@ -275,17 +288,17 @@ Proof.
   intros; rewrite Forall_fmap. decompose_Forall. exact: is_unstamped_sub_vl.
 Qed. *)
 
-Lemma is_unstamped_vl_ids i j: i < j → is_unstamped_vl j (ids i).
+Lemma is_unstamped_vl_ids i j b: i < j → is_unstamped_vl j b (ids i).
 Proof. rewrite /ids /ids_vl; by constructor. Qed.
 Hint Resolve is_unstamped_vl_ids : core.
 
-Lemma is_unstamped_sub_stail i j v sb:
-  is_unstamped_sub (S i) j (v .: sb) →
-  is_unstamped_sub i j sb.
+Lemma is_unstamped_sub_stail i j v sb b:
+  is_unstamped_sub (S i) j b (v .: sb) →
+  is_unstamped_sub i j b sb.
 Proof. move => Hs k Hle. apply (Hs (S k)), lt_n_S, Hle. Qed.
 
-Lemma is_unstamped_sub_equiv {σ i} :
-  is_unstamped_σ i σ ↔ is_unstamped_sub (length σ) i (to_subst σ).
+Lemma is_unstamped_sub_equiv {σ i b} :
+  is_unstamped_σ i b σ ↔ is_unstamped_sub (length σ) i b (to_subst σ).
 Proof.
   split; elim: σ => [//| /= v σ IHσ] Hcl/=.
   - by move => ??; lia.
@@ -296,34 +309,34 @@ Qed.
 Hint Resolve -> is_unstamped_sub_equiv : core.
 
 
-Lemma is_unstamped_sub_single n v:
-  is_unstamped_vl n v →
-  is_unstamped_sub (S n) n (v .: ids).
+Lemma is_unstamped_sub_single n v b:
+  is_unstamped_vl n b v →
+  is_unstamped_sub (S n) n b (v .: ids).
 Proof. move => Hv [|i] Hin /=; eauto with lia. Qed.
 
-Lemma is_unstamped_sub_ren_ty T r i j:
-  is_unstamped_ren i j r →
-  is_unstamped_ty i T → is_unstamped_ty j T.|[ren r].
+Lemma is_unstamped_sub_ren_ty T r i j b:
+  is_unstamped_ren i j b r →
+  is_unstamped_ty i b T → is_unstamped_ty j b T.|[ren r].
 Proof. rewrite -ty_rename_Lemma. apply is_unstamped_ren_mut. Qed.
 
-Lemma is_unstamped_sub_ren_path p r i j:
-  is_unstamped_ren i j r →
-  is_unstamped_path i p → is_unstamped_path j p.|[ren r].
+Lemma is_unstamped_sub_ren_path p r i j b:
+  is_unstamped_ren i j b r →
+  is_unstamped_path i b p → is_unstamped_path j b p.|[ren r].
 Proof. rewrite -path_rename_Lemma. apply is_unstamped_ren_mut. Qed.
 
 
-Lemma is_unstamped_ren1 i : is_unstamped_ren i (S i) (+1).
+Lemma is_unstamped_ren1 i b : is_unstamped_ren i (S i) b (+1).
 Proof. apply is_unstamped_ren_shift; lia. Qed.
 Hint Resolve is_unstamped_ren1 : core.
 
-Lemma is_unstamped_ren1_ty i T:
-  is_unstamped_ty i T ->
-  is_unstamped_ty (S i) (T.|[ren (+1)]).
+Lemma is_unstamped_ren1_ty i T b:
+  is_unstamped_ty i b T ->
+  is_unstamped_ty (S i) b (T.|[ren (+1)]).
 Proof. exact: is_unstamped_sub_ren_ty. Qed.
 
-Lemma is_unstamped_ren1_path i p:
-  is_unstamped_path i p ->
-  is_unstamped_path (S i) (shift p).
+Lemma is_unstamped_ren1_path i p b:
+  is_unstamped_path i b p ->
+  is_unstamped_path (S i) b (shift p).
 Proof. exact: is_unstamped_sub_ren_path. Qed.
 
 
@@ -335,29 +348,29 @@ Proof. intros [x ?]; destruct v; simplify_eq; eauto. Qed.
 Lemma is_unstamped_sub_rev_mut:
   (∀ e i,
     nclosed e i →
-    ∀ s j,
-    is_unstamped_tm j (e.|[s]) →
-    is_unstamped_tm i e) ∧
+    ∀ s j b,
+    is_unstamped_tm j b (e.|[s]) →
+    is_unstamped_tm i b e) ∧
   (∀ v i,
     nclosed_vl v i →
-    ∀ s j,
-    is_unstamped_vl j (v.[s]) →
-    is_unstamped_vl i v) ∧
+    ∀ s j b,
+    is_unstamped_vl j b (v.[s]) →
+    is_unstamped_vl i b v) ∧
   (∀ d i,
     nclosed d i →
-    ∀ s j,
-    is_unstamped_dm j (d.|[s]) →
-    is_unstamped_dm i d) ∧
+    ∀ s j b,
+    is_unstamped_dm j b (d.|[s]) →
+    is_unstamped_dm i b d) ∧
   (∀ p i,
     nclosed p i →
-    ∀ s j,
-    is_unstamped_path j (p.|[s]) →
-    is_unstamped_path i p) ∧
+    ∀ s j b,
+    is_unstamped_path j b (p.|[s]) →
+    is_unstamped_path i b p) ∧
   (∀ T i,
     nclosed T i →
-    ∀ s j,
-    is_unstamped_ty j (T.|[s]) →
-    is_unstamped_ty i T).
+    ∀ s j b,
+    is_unstamped_ty j b (T.|[s]) →
+    is_unstamped_ty i b T).
 Proof.
   apply nclosed_syntax_mut_ind => /=; intros;
     with_is_unstamped ltac:(fun H => try nosplit (inverse H)); ev;
@@ -368,28 +381,29 @@ Proof.
     constructor => /=.
     rewrite ->?@Forall_fmap in *.
     decompose_Forall. destruct x; cbn in *. eauto.
+  - constructor; naive_solver eauto using is_unstamped_sub_rev_var.
 Qed.
 
-Lemma is_unstamped_sub_rev_vl v s i j:
+Lemma is_unstamped_sub_rev_vl v s i j b:
   nclosed_vl v i →
-  is_unstamped_vl j (v.[s]) →
-  is_unstamped_vl i v.
+  is_unstamped_vl j b (v.[s]) →
+  is_unstamped_vl i b v.
 Proof. unmut_lemma is_unstamped_sub_rev_mut. Qed.
-Lemma is_unstamped_sub_rev_ty T s i j:
+Lemma is_unstamped_sub_rev_ty T s i j b:
   nclosed T i →
-  is_unstamped_ty j (T.|[s]) →
-  is_unstamped_ty i T.
+  is_unstamped_ty j b (T.|[s]) →
+  is_unstamped_ty i b T.
 Proof. unmut_lemma is_unstamped_sub_rev_mut. Qed.
 
-Lemma is_unstamped_sub_one_rev i T v:
+Lemma is_unstamped_sub_one_rev i b T v:
   nclosed T (S i) →
-  is_unstamped_ty i (T.|[v/]) →
-  is_unstamped_ty (S i) T.
+  is_unstamped_ty i b (T.|[v/]) →
+  is_unstamped_ty (S i) b T.
 Proof. intros; by eapply is_unstamped_sub_rev_ty. Qed.
 
-Lemma is_unstamped_ren_ty i T:
-  is_unstamped_ty i T <->
-  is_unstamped_ty (S i) (T.|[ren (+1)]).
+Lemma is_unstamped_ren_ty i b T:
+  is_unstamped_ty i b T <->
+  is_unstamped_ty (S i) b (T.|[ren (+1)]).
 Proof.
   split; first exact: is_unstamped_ren1_ty.
   intros Hu.

--- a/theories/Dot/typing/typing_unstamped.v
+++ b/theories/Dot/typing/typing_unstamped.v
@@ -26,8 +26,8 @@ Inductive typed Γ : tm → ty → Prop :=
 (** First, elimination forms *)
 (** Dependent application; only allowed if the argument is a path. *)
 | App_path_typed p2 e1 T1 T2:
-    is_unstamped_ty (S (length Γ)) T2 →
-    is_unstamped_path (length Γ) p2 →
+    is_unstamped_ty' (S (length Γ)) T2 →
+    is_unstamped_path' (length Γ) p2 →
     (* T2 .Tp[ p2 /]~ T2' → *)
     Γ u⊢ₜ e1: TAll T1 T2 →
     Γ u⊢ₚ p2 : T1, 0 →
@@ -45,13 +45,13 @@ Inductive typed Γ : tm → ty → Prop :=
 (** Introduction forms *)
 | Lam_typed e T1 T2:
     (* T1 :: Γ u⊢ₜ e : T2 → (* Would work, but allows the argument to occur in its own type. *) *)
-    is_unstamped_ty (length Γ) T1 →
+    is_unstamped_ty' (length Γ) T1 →
     T1.|[ren (+1)] :: Γ u⊢ₜ e : T2 →
     (*─────────────────────────*)
     Γ u⊢ₜ tv (vabs e) : TAll T1 T2
 | VObj_typed ds T:
     Γ |ds T u⊢ ds: T →
-    is_unstamped_ty (S (length Γ)) T →
+    is_unstamped_ty' (S (length Γ)) T →
     (*──────────────────────*)
     Γ u⊢ₜ tv (vobj ds): TMu T
 | Nat_typed n:
@@ -84,12 +84,12 @@ with dms_typed Γ : ty → dms → ty → Prop :=
 where "Γ |ds V u⊢ ds : T" := (dms_typed Γ V ds T)
 with dm_typed Γ : ty → label → dm → ty → Prop :=
 | dty_typed T V l L U:
-    is_unstamped_ty (S (length Γ)) T →
+    is_unstamped_ty' (S (length Γ)) T →
     TLater V :: Γ u⊢ₜ TLater L, 0 <: TLater T, 0 →
     TLater V :: Γ u⊢ₜ TLater T, 0 <: TLater U, 0 →
     Γ |d V u⊢{ l := dtysyn T } : TTMem l L U
 | dvabs_typed V T1 T2 e l:
-    is_unstamped_ty (S (length Γ)) T1 →
+    is_unstamped_ty' (S (length Γ)) T1 →
     T1.|[ren (+1)] :: V :: Γ u⊢ₜ e : T2 →
     Γ |d V u⊢{ l := dvl (vabs e) } : TVMem l (TAll T1 T2)
 | dvl_typed V l v T:
@@ -97,7 +97,7 @@ with dm_typed Γ : ty → label → dm → ty → Prop :=
     Γ |d V u⊢{ l := dvl v } : TVMem l T
 | dnew_typed V l T ds:
     TLater V :: Γ |ds TAnd T (TSing (pself (pv (ids 1)) l)) u⊢ ds : T →
-    is_unstamped_ty (S (S (length Γ))) T →
+    is_unstamped_ty' (S (S (length Γ))) T →
     Γ |d V u⊢{ l := dvl (vobj ds) } : TVMem l (TMu T)
 | dvl_sub_typed V T1 T2 v l:
     TLater V :: Γ u⊢ₜ T1, 0 <: T2, 0 →
@@ -121,11 +121,11 @@ with path_typed Γ : path → ty → nat → Prop :=
     (*───────────────────────────────*)
     Γ u⊢ₚ p : T2, i + j
 | p_mu_i_typed p T {i} :
-    is_unstamped_ty (S (length Γ)) T →
+    is_unstamped_ty' (S (length Γ)) T →
     Γ u⊢ₚ p : T .Tp[ p /], i →
     Γ u⊢ₚ p : TMu T, i
 | p_mu_e_typed p T {i} :
-    is_unstamped_ty (S (length Γ)) T →
+    is_unstamped_ty' (S (length Γ)) T →
     Γ u⊢ₚ p : TMu T, i →
     Γ u⊢ₚ p : T .Tp[ p /], i
 | pself_inv_typed p T i l:
@@ -137,7 +137,7 @@ with path_typed Γ : path → ty → nat → Prop :=
     Γ u⊢ₚ p : TSing p, i
 | psingleton_inv_typed p q i:
     Γ u⊢ₚ p : TSing q, i →
-    is_unstamped_path (length Γ) q →
+    is_unstamped_path' (length Γ) q →
     Γ u⊢ₚ q : TTop, i
 | psingleton_trans p q T i:
     Γ u⊢ₚ p : TSing q, i →
@@ -151,50 +151,50 @@ where "Γ u⊢ₚ p : T , i" := (path_typed Γ p T i)
 (* Γ u⊢ₜ T1, i1 <: T2, i2 means that TLater^i1 T1 <: TLater^i2 T2. *)
 with subtype Γ : ty → nat → ty → nat → Prop :=
 | Refl_stp i T :
-    is_unstamped_ty (length Γ) T →
+    is_unstamped_ty' (length Γ) T →
     Γ u⊢ₜ T, i <: T, i
 | Trans_stp i2 T2 {i1 i3 T1 T3}:
     Γ u⊢ₜ T1, i1 <: T2, i2 →
     Γ u⊢ₜ T2, i2 <: T3, i3 →
     Γ u⊢ₜ T1, i1 <: T3, i3
 | TLaterL_stp i T:
-    is_unstamped_ty (length Γ) T →
+    is_unstamped_ty' (length Γ) T →
     Γ u⊢ₜ TLater T, i <: T, S i
 | TLaterR_stp i T:
-    is_unstamped_ty (length Γ) T →
+    is_unstamped_ty' (length Γ) T →
     Γ u⊢ₜ T, S i <: TLater T, i
 
 (* "Structural" rule about indexes *)
 | TAddLater_stp T i:
-    is_unstamped_ty (length Γ) T →
+    is_unstamped_ty' (length Γ) T →
     Γ u⊢ₜ T, i <: TLater T, i
 
 (* "Logical" connectives *)
 | Top_stp i T :
-    is_unstamped_ty (length Γ) T →
+    is_unstamped_ty' (length Γ) T →
     Γ u⊢ₜ T, i <: TTop, i
 | Bot_stp i T :
-    is_unstamped_ty (length Γ) T →
+    is_unstamped_ty' (length Γ) T →
     Γ u⊢ₜ TBot, i <: T, i
 | TAnd1_stp T1 T2 i:
-    is_unstamped_ty (length Γ) T1 →
-    is_unstamped_ty (length Γ) T2 →
+    is_unstamped_ty' (length Γ) T1 →
+    is_unstamped_ty' (length Γ) T2 →
     Γ u⊢ₜ TAnd T1 T2, i <: T1, i
 | TAnd2_stp T1 T2 i:
-    is_unstamped_ty (length Γ) T1 →
-    is_unstamped_ty (length Γ) T2 →
+    is_unstamped_ty' (length Γ) T1 →
+    is_unstamped_ty' (length Γ) T2 →
     Γ u⊢ₜ TAnd T1 T2, i <: T2, i
 | TAnd_stp T U1 U2 i j:
     Γ u⊢ₜ T, i <: U1, j →
     Γ u⊢ₜ T, i <: U2, j →
     Γ u⊢ₜ T, i <: TAnd U1 U2, j
 | TOr1_stp T1 T2 i:
-    is_unstamped_ty (length Γ) T1 →
-    is_unstamped_ty (length Γ) T2 →
+    is_unstamped_ty' (length Γ) T1 →
+    is_unstamped_ty' (length Γ) T2 →
     Γ u⊢ₜ T1, i <: TOr T1 T2, i
 | TOr2_stp T1 T2 i:
-    is_unstamped_ty (length Γ) T1 →
-    is_unstamped_ty (length Γ) T2 →
+    is_unstamped_ty' (length Γ) T1 →
+    is_unstamped_ty' (length Γ) T2 →
     Γ u⊢ₜ T2, i <: TOr T1 T2, i
 | TOr_stp T1 T2 U i j:
     Γ u⊢ₜ T1, i <: U, j →
@@ -210,8 +210,8 @@ with subtype Γ : ty → nat → ty → nat → Prop :=
     Γ u⊢ₜ TLater L, i <: TSel p l, i
 | PSub_singleton_stp p q {i T1 T2}:
     T1 ~Tp[ p := q ]* T2 →
-    is_unstamped_ty (length Γ) T1 →
-    is_unstamped_ty (length Γ) T2 →
+    is_unstamped_ty' (length Γ) T1 →
+    is_unstamped_ty' (length Γ) T2 →
     Γ u⊢ₚ p : TSing q, i →
     Γ u⊢ₜ T1, i <: T2, i
 | PSym_singleton_stp T {p q i}:
@@ -233,13 +233,13 @@ with subtype Γ : ty → nat → ty → nat → Prop :=
 (* Subtyping for recursive types. Congruence, and opening in both directions. *)
 | Mu_stp_mu T1 T2 i j:
     (iterate TLater i T1 :: Γ) u⊢ₜ T1, i <: T2, j →
-    is_unstamped_ty (S (length Γ)) T1 →
+    is_unstamped_ty' (S (length Γ)) T1 →
     Γ u⊢ₜ TMu T1, i <: TMu T2, j
 | Mu_stp T i:
-    is_unstamped_ty (length Γ) T →
+    is_unstamped_ty' (length Γ) T →
     Γ u⊢ₜ TMu T.|[ren (+1)], i <: T, i
 | Stp_mu T i:
-    is_unstamped_ty (length Γ) T →
+    is_unstamped_ty' (length Γ) T →
     Γ u⊢ₜ T, i <: TMu T.|[ren (+1)], i
 
 (* "Congruence" or "variance" rules for subtyping. Unneeded for "logical" types.
@@ -251,7 +251,7 @@ with subtype Γ : ty → nat → ty → nat → Prop :=
 | TAllConCov_stp T1 T2 U1 U2 i:
     Γ u⊢ₜ TLater T2, i <: TLater T1, i →
     iterate TLater (S i) T2.|[ren (+1)] :: Γ u⊢ₜ TLater U1, i <: TLater U2, i →
-    is_unstamped_ty (length Γ) T2 →
+    is_unstamped_ty' (length Γ) T2 →
     Γ u⊢ₜ TAll T1 U1, i <: TAll T2 U2, i
 | TVMemCov_stp T1 T2 i l:
     Γ u⊢ₜ T1, i <: T2, i →
@@ -266,18 +266,18 @@ with subtype Γ : ty → nat → ty → nat → Prop :=
     Let's prove F[A] ∧ F[B] <: F[A ∧ B] in the model.
     *)
 | TAllDistr_stp T U1 U2 i:
-    is_unstamped_ty (length Γ) T →
-    is_unstamped_ty (S (length Γ)) U1 →
-    is_unstamped_ty (S (length Γ)) U2 →
+    is_unstamped_ty' (length Γ) T →
+    is_unstamped_ty' (S (length Γ)) U1 →
+    is_unstamped_ty' (S (length Γ)) U2 →
     Γ u⊢ₜ TAnd (TAll T U1) (TAll T U2), i <: TAll T (TAnd U1 U2), i
 | TVMemDistr_stp l T1 T2 i:
-    is_unstamped_ty (length Γ) T1 →
-    is_unstamped_ty (length Γ) T2 →
+    is_unstamped_ty' (length Γ) T1 →
+    is_unstamped_ty' (length Γ) T2 →
     Γ u⊢ₜ TAnd (TVMem l T1) (TVMem l T2), i <: TVMem l (TAnd T1 T2), i
 | TTMemDistr_stp l L U1 U2 i:
-    is_unstamped_ty (length Γ) L →
-    is_unstamped_ty (length Γ) U1 →
-    is_unstamped_ty (length Γ) U2 →
+    is_unstamped_ty' (length Γ) L →
+    is_unstamped_ty' (length Γ) U1 →
+    is_unstamped_ty' (length Γ) U2 →
     Γ u⊢ₜ TAnd (TTMem l L U1) (TTMem l L U2), i <: TTMem l L (TAnd U1 U2), i
 
 (* "Structural" rule about indexes. Only try last. *)


### PR DESCRIPTION
To capture the full pDOT (per #146), we're going to use non-variable values in some unstamped paths, the ones that we'll use to model type members. This (WIP) PR generalizes unstamped syntax to prepare for that, by adding an extra parameter to `is_unstamped`.