### PR TITLE
Definition typing: make stoup optional

### DIFF
--- a/theories/Dot/examples/typingExInfra.v
+++ b/theories/Dot/examples/typingExInfra.v
@@ -65,6 +65,7 @@ Hint Extern 5 => try_once extraction_weaken : core.
 Hint Extern 5 (is_stamped_ty _ _ _) => try_once is_stamped_weaken_ty : core.
 Hint Extern 5 (is_stamped_dm _ _ _) => try_once is_stamped_weaken_dm : core.
 Hint Extern 5 (is_stamped_ty _ _ _) => progress cbn : core.
+Hint Extern 5 (is_stamped_ren _ _ _ _) => progress cbn : core.
 
 (** [tcrush] is the safest automation around. *)
 Ltac tcrush := repeat first [ eassumption | reflexivity | typconstructor | stcrush ].

--- a/theories/Dot/examples/typingExamples.v
+++ b/theories/Dot/examples/typingExamples.v
@@ -40,7 +40,7 @@ Proof.
   have Hst: is_stamped_ty (1 + length Γ) g (p0 @; "B").
   by tcrush.
   apply VObj_typed; tcrush. (* Avoid trying TMuI_typed, that's slow. *)
-  apply (dty_typed (p0 @; "B")); by wtcrush.
+  apply (dty_typed (p0 @; "B")); cbn; by wtcrush.
 Qed.
 
 (* Try out fixpoints. *)
@@ -302,7 +302,7 @@ Lemma dvabs_sub_typed {Γ} V T1 T2 e l L:
   shift T1 :: V :: Γ v⊢ₜ[ g ] e : T2 →
   TLater V :: Γ v⊢ₜ[ g ] TAll T1 T2, 0 <: L, 0 →
   is_stamped_ty (S (length Γ)) g T1 →
-  Γ |d V v⊢[ g ]{ l := dpt (pv (vabs e)) } : TVMem l L.
+  Γ |L V v⊢[ g ]{ l := dpt (pv (vabs e)) } : TVMem l L.
 Proof.
   intros He Hsub Hs.
   eapply dpt_sub_typed; first apply Hsub.

--- a/theories/Dot/fundamental.v
+++ b/theories/Dot/fundamental.v
@@ -16,10 +16,10 @@ Section fundamental.
     | H : context [wellMappedφ] |- _ => by iApply H
     end.
 
-  Fixpoint fundamental_dm_typed Γ g V l d T (HT: Γ |d V v⊢[ g ]{ l := d } : T) { struct HT }:
-    Γ |L V ⊨[ ⟦ g ⟧g ] { l := d } : T with
-  fundamental_dms_typed Γ g V ds T (HT: Γ |ds V v⊢[ g ] ds : T) { struct HT }:
-    Γ |L V ⊨ds[ ⟦ g ⟧g ] ds : T with
+  Fixpoint fundamental_dm_typed Γ g l d T (HT: Γ v⊢[ g ]{ l := d } : T) { struct HT }:
+    Γ ⊨[ ⟦ g ⟧g ] { l := d } : T with
+  fundamental_dms_typed Γ g ds T (HT: Γ v⊢ds[ g ] ds : T) { struct HT }:
+    Γ ⊨ds[ ⟦ g ⟧g ] ds : T with
   fundamental_subtype Γ g T1 i1 T2 i2 (HT: Γ v⊢ₜ[ g ] T1, i1 <: T2, i2) { struct HT }:
     Γ ⊨[ ⟦ g ⟧g ] T1, i1 <: T2, i2 with
   fundamental_typed Γ g e T (HT: Γ v⊢ₜ[ g ] e : T) { struct HT }:
@@ -30,10 +30,10 @@ Section fundamental.
     - iIntros "#Hm"; induction HT.
       + iApply D_Typ_Abs; by [> iApply fundamental_subtype .. |
           iApply extraction_to_leadsto_envD_equiv].
-      + iApply D_TVMem_All_I. by iApply fundamental_typed.
+      + subst; iApply D_TVMem_All_I. by iApply fundamental_typed.
       + iApply D_TVMem_I. by iApply fundamental_typed.
       + iApply D_Path_TVMem_I. by iApply fundamental_path_typed.
-      + iApply D_New_Mem_I'. by iApply fundamental_dms_typed.
+      + iApply D_New_Mem_I. by iApply fundamental_dms_typed.
       + iApply D_TVMem_Sub; by [> iApply fundamental_subtype|].
     - iIntros "#Hm"; induction HT.
       + by iApply DNil_I.

--- a/theories/Dot/lr/lr_lemmasDefs.v
+++ b/theories/Dot/lr/lr_lemmasDefs.v
@@ -79,16 +79,6 @@ Section Sec.
     (* exact: (path_includes_field_aliases (pv (var_vl 0)) ρ _ (vobj ds)). *)
   Qed.
 
-  Lemma D_New_Mem_I' Γ V T l ds:
-    (TLater V :: Γ) |L TAnd T (TSing (pself (pv (ids 1)) l)) ⊨ds ds : T -∗
-    Γ |L V ⊨ { l := dpt (pv (vobj ds)) } : TVMem l (TMu T).
-  Proof.
-    iIntros "#H"; iApply D_New_Mem_I.
-    iDestruct "H" as (Hwf) "#Hds". iFrame (Hwf).
-    iIntros "!>" (ρ Hpid) "/= #[[Hg Hv] [Ht Hal]]".
-    iApply ("Hds" $! ρ Hpid with "[$Hg $Hv $Ht $Hal]").
-  Qed.
-
   Context Γ.
 
   Lemma D_TVMem_Sub T1 T2 p l:

--- a/theories/Dot/typing/typingProofs.v
+++ b/theories/Dot/typing/typingProofs.v
@@ -8,14 +8,14 @@ Section syntyping_lemmas.
   Hint Constructors Forall : core.
   Lemma stamped_mut_subject Γ g :
     (∀ e T, Γ v⊢ₜ[ g ] e : T → is_stamped_tm (length Γ) g e) ∧
-    (∀ V ds T, Γ |ds V v⊢[ g ] ds : T → Forall (is_stamped_dm (S (length Γ)) g) (map snd ds)) ∧
-    (∀ V l d T, Γ |d V v⊢[ g ]{ l := d } : T → is_stamped_dm (S (length Γ)) g d) ∧
+    (∀ ds T, Γ v⊢ds[ g ] ds : T → Forall (is_stamped_dm (length Γ) g) (map snd ds)) ∧
+    (∀ l d T, Γ v⊢[ g ]{ l := d } : T → is_stamped_dm (length Γ) g d) ∧
     (∀ p T i, Γ v⊢ₚ[ g ] p : T, i → is_stamped_path (length Γ) g p).
   Proof.
     eapply exp_stamped_typing_mut_ind with
         (P := λ Γ g e T _, is_stamped_tm (length Γ) g e)
-        (P0 := λ Γ g V ds T _, Forall (is_stamped_dm (S (length Γ)) g) (map snd ds))
-        (P1 := λ Γ g V l d T _, is_stamped_dm (S (length Γ)) g d)
+        (P0 := λ Γ g ds T _, Forall (is_stamped_dm (length Γ) g) (map snd ds))
+        (P1 := λ Γ g l d T _, is_stamped_dm (length Γ) g d)
         (P2 := λ Γ g p T i _, is_stamped_path (length Γ) g p); clear Γ g;
         cbn; intros; try by (with_is_stamped inverse + idtac);
           eauto using is_stamped_path2tm.
@@ -99,26 +99,20 @@ Section syntyping_lemmas.
 
   Lemma stamped_mut_types Γ g :
     (∀ e T, Γ v⊢ₜ[ g ] e : T → ∀ (Hctx: stamped_ctx g Γ), is_stamped_ty (length Γ) g T) ∧
-    (∀ V ds T, Γ |ds V v⊢[ g ] ds : T → ∀ (Hctx: stamped_ctx g Γ), is_stamped_ty (S (length Γ)) g V →
-      is_stamped_ty (S (length Γ)) g T) ∧
-    (∀ V l d T, Γ |d V v⊢[ g ]{ l := d } : T → ∀ (Hctx: stamped_ctx g Γ), is_stamped_ty (S (length Γ)) g V →
-      is_stamped_ty (S (length Γ)) g T) ∧
+    (∀ ds T, Γ v⊢ds[ g ] ds : T → ∀ (Hctx: stamped_ctx g Γ), is_stamped_ty (length Γ) g T) ∧
+    (∀ l d T, Γ v⊢[ g ]{ l := d } : T → ∀ (Hctx: stamped_ctx g Γ), is_stamped_ty (length Γ) g T) ∧
     (∀ p T i, Γ v⊢ₚ[ g ] p : T , i → ∀ (Hctx: stamped_ctx g Γ), is_stamped_ty (length Γ) g T) ∧
     (∀ T1 i1 T2 i2, Γ v⊢ₜ[ g ] T1, i1 <: T2, i2 → ∀ (Hctx: stamped_ctx g Γ),
       is_stamped_ty (length Γ) g T1 ∧ is_stamped_ty (length Γ) g T2).
   Proof.
     eapply stamped_typing_mut_ind with
-        (P := λ Γ g e T _, ∀ (Hctx: stamped_ctx g Γ),
-          is_stamped_ty (length Γ) g T)
-        (P0 := λ Γ g V ds T _, ∀ (Hctx: stamped_ctx g Γ), is_stamped_ty (S (length Γ)) g V →
-          is_stamped_ty (S (length Γ)) g T)
-        (P1 := λ Γ g V l d T _, ∀ (Hctx: stamped_ctx g Γ), is_stamped_ty (S (length Γ)) g V →
-          is_stamped_ty (S (length Γ)) g T)
-        (P2 := λ Γ g p T i _, ∀ (Hctx: stamped_ctx g Γ),
-          is_stamped_ty (length Γ) g T)
+        (P := λ Γ g e T _, ∀ (Hctx: stamped_ctx g Γ), is_stamped_ty (length Γ) g T)
+        (P0 := λ Γ g ds T _, ∀ (Hctx: stamped_ctx g Γ), is_stamped_ty (length Γ) g T)
+        (P1 := λ Γ g l d T _, ∀ (Hctx: stamped_ctx g Γ), is_stamped_ty (length Γ) g T)
+        (P2 := λ Γ g p T i _, ∀ (Hctx: stamped_ctx g Γ), is_stamped_ty (length Γ) g T)
         (P3 := λ Γ g T1 i1 T2 i2 _, ∀ (Hctx: stamped_ctx g Γ),
                is_stamped_ty (length Γ) g T1 ∧ is_stamped_ty (length Γ) g T2); clear Γ g.
-    all: intros; cbn in *;
+    all: intros; simplify_eq/=; try nosplit inverse Hctx;
       try (efeed pose proof H ; [by eauto | ev; clear H ]);
       try (efeed pose proof H0; [by eauto | ev; clear H0]);
       repeat constructor; cbn; eauto 2;

--- a/theories/Dot/typing/typing_unstamped_derived.v
+++ b/theories/Dot/typing/typing_unstamped_derived.v
@@ -106,8 +106,8 @@ Ltac hideCtx :=
   | |- ?Γ u⊢ₜ _ : _ => hideCtx' Γ
   | |- ?Γ u⊢ₜ _, _ <: _, _ => hideCtx' Γ
   | |- ?Γ u⊢ₚ _ : _, _  => hideCtx' Γ
-  | |- ?Γ |d _ u⊢{ _ := _  } : _ => hideCtx' Γ
-  | |- ?Γ |ds _ u⊢ _ : _ => hideCtx' Γ
+  | |- ?Γ u⊢{ _ := _  } : _ => hideCtx' Γ
+  | |- ?Γ u⊢ds _ : _ => hideCtx' Γ
   end.
 
 Lemma Var_typed' Γ x T1 T2 :
@@ -188,11 +188,11 @@ Lemma LSel_stp' Γ U {p l L i}:
 Proof. intros; ettrans; last exact: (@LSel_stp _ p); tcrush. Qed.
 
 (* Worse than dty_typed, but shown in the paper. *)
-Lemma dty_typed_intermediate Γ T V l L U:
-  is_unstamped_ty' (S (length Γ)) T →
-  TLater V :: Γ u⊢ₜ L, 0 <: T, 0 →
-  TLater V :: Γ u⊢ₜ T, 0 <: U, 0 →
-  Γ |d V u⊢{ l := dtysyn T } : TTMem l L U.
+Lemma dty_typed_intermediate Γ T l L U:
+  is_unstamped_ty' (length Γ) T →
+  Γ u⊢ₜ L, 0 <: T, 0 →
+  Γ u⊢ₜ T, 0 <: U, 0 →
+  Γ u⊢{ l := dtysyn T } : TTMem l L U.
 Proof. intros; apply dty_typed; tcrush. Qed.
 
 (** * Manipulating laters, basics. *)
@@ -249,9 +249,9 @@ Proof. intros; apply /val_LB /packTV_typed'. Qed. *)
   Γ u⊢ₜ (pv (packTV T) @; "A"), i <: ▶: T, i.
 Proof. intros; by apply /val_UB /packTV_typed'. Qed. *)
 
-Lemma Dty_typed Γ T V l:
-  is_unstamped_ty' (S (length Γ)) T →
-  Γ |d V u⊢{ l := dtysyn T } : TTMem l T T.
+Lemma Dty_typed Γ T l:
+  is_unstamped_ty' (length Γ) T →
+  Γ u⊢{ l := dtysyn T } : TTMem l T T.
 Proof. intros. tcrush. Qed.
 
 (* We can derive rules Bind1 and Bind2 (the latter only conjectured) from
@@ -350,7 +350,7 @@ Lemma dvabs_sub_typed {Γ} V T1 T2 e l L:
   shift T1 :: V :: Γ u⊢ₜ e : T2 →
   TLater V :: Γ u⊢ₜ TAll T1 T2, 0 <: L, 0 →
   is_unstamped_ty' (S (length Γ)) T1 →
-  Γ |d V u⊢{ l := dpt (pv (vabs e)) } : TVMem l L.
+  Γ |L V u⊢{ l := dpt (pv (vabs e)) } : TVMem l L.
 Proof.
   intros He Hsub Hs.
   eapply dpt_sub_typed; first apply Hsub.
@@ -616,8 +616,8 @@ Lemma AnfBind_typed Γ t (T U: ty) :
   Γ u⊢ₜ anfBind t : U.
 Proof. intros; eapply Let_typed; eauto. Qed.
 
-Lemma pDOT_Def_Path_derived Γ V l p T
-  (Hx : TLater V :: Γ u⊢ₚ p : T, 0)
-  (Hu : is_unstamped_path (S (length Γ)) AlsoNonVars p) :
-  Γ |d V u⊢{ l := dpt p } : TVMem l (TSing p).
+Lemma pDOT_Def_Path_derived Γ l p T
+  (Hx : Γ u⊢ₚ p : T, 0)
+  (Hu : is_unstamped_path (length Γ) AlsoNonVars p) :
+  Γ u⊢{ l := dpt p } : TVMem l (TSing p).
 Proof. eapply dpath_typed, Hu. apply (psingleton_refl_typed (T := T)), Hx. Qed.


### PR DESCRIPTION
One new typing rule cannot be written precisely using the stouped typing judgment, so turn the "stoup" into the same syntactic sugar we already use in semantic typing. This also simplifies a few proofs.
OTOH, `dvabs_typed` becomes more awkward to write: maybe we could strengthen it, while we're changing it.