### PR TITLE
New later stripping judgment for function introduction, suggested by Robbert

### DIFF
--- a/theories/Dot/fundamental.v
+++ b/theories/Dot/fundamental.v
@@ -42,7 +42,8 @@ Section fundamental.
       + by iApply T_All_E; [iApply H|iApply H0].
       + by iApply T_Obj_E; iApply H.
       + by iApply T_Mu_E; iApply H.
-      + iApply T_All_I_Strong; [|by iApply H]. exact: fundamental_ctx_sub.
+      + iApply T_All_I_Strong; [|by iApply H].
+        by apply fundamental_ctx_sub, ctx_strip_to_sub.
       + iApply T_Obj_I. by iApply H.
       + iApply T_Mu_I. by iApply H.
       + by iApply T_Var.

--- a/theories/Dot/lr/later_sub_sem.v
+++ b/theories/Dot/lr/later_sub_sem.v
@@ -168,6 +168,8 @@ Section CtxSub.
   Qed.
 
   Lemma ty_sub_id T : ⊨T T <: T. Proof. done. Qed.
+  Lemma ty_sub_trans T1 T2 T3 : ⊨T T1 <: T2 → ⊨T T2 <: T3 → ⊨T T1 <: T3.
+  Proof. by intros ->. Qed.
 
   Lemma ty_sub_TLater T : ⊨T T <: TLater T.
   Proof. intros ?. auto. Qed.
@@ -177,7 +179,16 @@ Section CtxSub.
     ⊨T T1 <: TLater T2.
   Proof. intros ->. apply ty_sub_TLater. Qed.
 
-  Hint Resolve ty_sub_id ty_sub_TLater ty_sub_TLater_add ty_sub_TLater_unTLater unTLater_ty_sub : ctx_sub.
+  Lemma ty_distr_TAnd_TLater T1 T2 :
+    ⊨T TAnd (TLater T1) (TLater T2) <: TLater (TAnd T1 T2).
+  Proof. iIntros (??) "[$ $]". Qed.
+
+  Lemma ty_distr_TOr_TLater T1 T2 :
+    ⊨T TOr (TLater T1) (TLater T2) <: TLater (TOr T1 T2).
+  Proof. iIntros (??) "[$|$]". Qed.
+
+  Hint Resolve ty_sub_id ty_sub_TLater ty_sub_TLater_add ty_sub_TLater_unTLater
+    ty_distr_TAnd_TLater ty_distr_TOr_TLater unTLater_ty_sub : ctx_sub.
 
   (* Unused *)
   Lemma TLater_unTLater_ty_sub_TLater T :
@@ -185,7 +196,7 @@ Section CtxSub.
   Proof. by rewrite unTLater_ty_sub. Qed.
 
   Lemma fundamental_ty_sub {T1 T2} : ⊢T T1 <: T2 → ⊨T T1 <: T2.
-  Proof. induction 1; auto with f_equiv ctx_sub. Qed.
+  Proof. induction 1; auto with f_equiv ctx_sub. exact: ty_sub_trans. Qed.
   Hint Resolve fundamental_ty_sub : ctx_sub.
 
   (** Lift the above ordering to environments. *)

--- a/theories/Dot/typing/typingProofs.v
+++ b/theories/Dot/typing/typingProofs.v
@@ -18,7 +18,7 @@ Section storeless_syntyping_lemmas.
         (P0 := λ Γ g ds T _, Forall (is_stamped_dm (length Γ) g) (map snd ds))
         (P1 := λ Γ g l d T _, is_stamped_dm (length Γ) g d)
         (P2 := λ Γ g p T i _, is_stamped_path (length Γ) g p); clear Γ g;
-        cbn; intros; try (rewrite <-(@ctx_sub_len_tlater Γ Γ') in *; last done);
+        cbn; intros; try (rewrite <-(@ctx_strip_len Γ Γ') in *; last done);
         try by (with_is_stamped inverse + idtac); eauto using is_stamped_path2tm.
     - repeat constructor => //=. by eapply lookup_lt_Some.
     - intros; elim: i {s} => [|i IHi]; rewrite /= ?iterate_0 ?iterate_S //; eauto.
@@ -111,11 +111,26 @@ Section storeless_syntyping_lemmas.
     exact: (is_stamped_TLater_n (i := 1)).
   Qed.
 
+  Lemma ty_strip_stamped n g T T' :
+    ⊢T T >>▷ T' ->
+    is_stamped_ty n g T →
+    is_stamped_ty n g T'.
+  Proof. induction 1; inversion 1; auto. Qed.
+
   Lemma ty_sub_stamped n g T T' :
     ⊢T T <: T' ->
     is_stamped_ty n g T →
     is_stamped_ty n g T'.
-  Proof. induction 1; inversion 1; eauto. Qed.
+  Proof. induction 1; inversion 1; auto. Qed.
+
+  Lemma ctx_strip_stamped Γ Γ' g :
+    ⊢G Γ >>▷* Γ' ->
+    stamped_ctx g Γ →
+    stamped_ctx g Γ'.
+  Proof.
+    induction 1; inversion 1; subst; constructor; first by auto.
+    by erewrite <- ctx_strip_len; [exact: ty_strip_stamped|].
+  Qed.
 
   Lemma ctx_sub_stamped Γ Γ' g :
     ⊢G Γ <:* Γ' ->
@@ -126,7 +141,7 @@ Section storeless_syntyping_lemmas.
     by erewrite <- ctx_sub_len; [exact: ty_sub_stamped|].
   Qed.
 
-  Local Hint Resolve ctx_sub_stamped fmap_TLater_stamped_inv : core.
+  Local Hint Resolve ctx_sub_stamped ctx_strip_stamped fmap_TLater_stamped_inv : core.
 
   Local Hint Resolve stamped_exp_subject stamped_path_subject : core.
   Lemma stamped_mut_types Γ g :
@@ -146,7 +161,7 @@ Section storeless_syntyping_lemmas.
                is_stamped_ty (length Γ) g T1 ∧ is_stamped_ty (length Γ) g T2); clear Γ g.
     all: intros; simplify_eq/=; try nosplit inverse Hctx;
       try (rewrite ->?(@ctx_sub_len Γ Γ'),
-        ?(@ctx_sub_len_tlater Γ Γ') in * by assumption);
+        ?(@ctx_strip_len Γ Γ') in * by assumption);
       try (efeed pose proof H ; [by eauto | ev; clear H ]);
       try (efeed pose proof H0; [by eauto | ev; clear H0]);
       repeat constructor; rewrite /= ?fmap_length; eauto 2;

--- a/theories/Dot/typing/typing_aux_defs.v
+++ b/theories/Dot/typing/typing_aux_defs.v
@@ -23,6 +23,9 @@ context. *)
 Reserved Notation "⊢G Γ1 <:* Γ2" (at level 74, Γ1, Γ2 at next level).
 Reserved Notation "⊢T T1 <: T2" (at level 74, T1, T2 at next level).
 
+Reserved Notation "⊢G G1 '>>▷*' G2" (at level 74, G1, G2 at next level).
+Reserved Notation "⊢T T1 '>>▷' T2" (at level 74, T1, T2 at next level).
+
 (** A left inverse of TLater. Sometimes written ⊲. *)
 (* Definition unTLater T : ty := match T with | TLater T' => T' | _ => T end. *)
 Fixpoint unTLater T : ty := match T with
@@ -35,12 +38,28 @@ end.
 Definition unTLater_TLater T: unTLater (TLater T) = T := reflexivity _.
 Global Instance: Cancel (=) unTLater TLater. Proof. exact: unTLater_TLater. Qed.
 
+Inductive ty_strip_syn : ty → ty → Prop :=
+| ty_strip_id_syn T : ⊢T T >>▷ T
+| ty_strip_TLater_add_syn T :
+  ⊢T TLater T >>▷ T
+| ty_strip_cong_TAnd_syn T1 T2 U1 U2 :
+  ⊢T T1 >>▷ U1 → ⊢T T2 >>▷ U2 → ⊢T TAnd T1 T2 >>▷ TAnd U1 U2
+| ty_strip_cong_TOr_syn T1 T2 U1 U2 :
+  ⊢T T1 >>▷ U1 → ⊢T T2 >>▷ U2 → ⊢T TOr T1 T2 >>▷ TOr U1 U2
+| ty_strip_cong_TLater_syn T1 T2 :
+  ⊢T T1 >>▷ T2 →
+  ⊢T TLater T1 >>▷ TLater T2
+where "⊢T T1 '>>▷' T2" := (ty_strip_syn T1 T2).
+Hint Constructors ty_strip_syn : ctx_sub.
+
 (** The actual constructor is [ty_sub_TLater_syn]; the other ones are
 just congruence under [TLater], [TAnd], [TOr].
 We also add transitivity: it is not admissible, and the counterexample is
 [⊢T T <: TLater (TLater T)]. *)
 Inductive ty_sub_syn : ty → ty → Prop :=
 | ty_sub_id_syn T : ⊢T T <: T
+| ty_trans_sub_syn T1 T2 T3 :
+  ⊢T T1 <: T2 → ⊢T T2 <: T3 → ⊢T T1 <: T3
 | ty_sub_TLater_add_syn T1 T2 :
   ⊢T T1 <: T2 → ⊢T T1 <: TLater T2
 | ty_sub_cong_TAnd_syn T1 T2 U1 U2 :
@@ -50,21 +69,29 @@ Inductive ty_sub_syn : ty → ty → Prop :=
 | ty_sub_cong_TLater_syn T1 T2 :
   ⊢T T1 <: T2 →
   ⊢T TLater T1 <: TLater T2
+(* | ty_swap_later_and T1 T2 :
+  ⊢T TLater (TAnd T1 T2) <: TAnd (TLater T1) (TLater T2) *)
+| ty_distr_TAnd_TLater_syn T1 T2 :
+  ⊢T TAnd (TLater T1) (TLater T2) <: TLater (TAnd T1 T2)
+| ty_distr_TOr_TLater_syn T1 T2 :
+  ⊢T TOr (TLater T1) (TLater T2) <: TLater (TOr T1 T2)
 (* Unused: *)
 (* | ty_sub_TLater_unTLater_syn T :
   ⊢T T <: TLater (unTLater T). *)
 where "⊢T T1 <: T2" := (ty_sub_syn T1 T2).
 Hint Constructors ty_sub_syn : ctx_sub.
 
+(** Control transitivity to ensure [eauto] does not diverge. *)
+Remove Hints ty_trans_sub_syn : ctx_sub.
+Hint Extern 5 (⊢T _ <: _) => try_once ty_trans_sub_syn : ctx_sub.
+
 Lemma ty_sub_TLater_syn T : ⊢T T <: TLater T. Proof. auto with ctx_sub. Qed.
+Hint Resolve ty_sub_TLater_syn : ctx_sub.
 
-Lemma ty_trans_sub_syn T1 T2 T3 : ⊢T T1 <: T2 → ⊢T T2 <: T3 → ⊢T T1 <: T3.
-Proof.
-  move: T1 => + + Hsub2.
-  induction Hsub2; inversion 1; subst; auto with ctx_sub.
-Qed.
-
-Hint Resolve ty_sub_TLater_syn ty_trans_sub_syn : ctx_sub.
+Lemma ty_strip_to_sub T1 T2 :
+  ⊢T T1 >>▷ T2 →
+  ⊢T T1 <: TLater T2.
+Proof. induction 1; eauto with ctx_sub. Qed.
 
 Lemma unTLater_ty_sub_syn T : ⊢T unTLater T <: T.
 Proof. induction T; cbn; auto with ctx_sub. Qed.
@@ -77,10 +104,22 @@ Abort. *)
 
 Hint Resolve unTLater_ty_sub_syn : ctx_sub.
 
+Inductive ctx_strip_syn : ctx → ctx → Prop :=
+| ctx_strip_nil_syn : ⊢G [] >>▷* []
+| ctx_strip_cons_syn T1 T2 Γ1 Γ2 :
+  ⊢T T1 >>▷ T2 →
+  ⊢G Γ1 >>▷* Γ2 →
+  ⊢G T1 :: Γ1 >>▷* T2 :: Γ2
+where "⊢G Γ1 >>▷* Γ2" := (ctx_strip_syn Γ1 Γ2).
+Hint Constructors ctx_strip_syn : ctx_sub.
+
+Lemma ctx_strip_id_syn Γ : ⊢G Γ >>▷* Γ.
+Proof. elim: Γ => //=; auto with ctx_sub. Qed.
+
+Hint Resolve ctx_strip_id_syn : ctx_sub.
+
 Inductive ctx_sub_syn : ctx → ctx → Prop :=
 | ctx_sub_nil_syn : ⊢G [] <:* []
-(* | ctx_sub_TLater_unTLater_syn Γ :
-  ⊢G Γ <:* TLater <$> (unTLater <$> Γ) *)
 | ctx_sub_cons_syn T1 T2 Γ1 Γ2 :
   ⊢T T1 <: T2 →
   ⊢G Γ1 <:* Γ2 →
@@ -88,15 +127,20 @@ Inductive ctx_sub_syn : ctx → ctx → Prop :=
 where "⊢G Γ1 <:* Γ2" := (ctx_sub_syn Γ1 Γ2).
 Hint Constructors ctx_sub_syn : ctx_sub.
 
-Lemma ctx_id_syn Γ : ⊢G Γ <:* Γ.
+Lemma ctx_sub_id_syn Γ : ⊢G Γ <:* Γ.
 Proof. induction Γ; auto with ctx_sub. Qed.
 
-Lemma ctx_trans_sub_syn Γ1 Γ2 Γ3 :
+Lemma ctx_sub_trans_sub_syn Γ1 Γ2 Γ3 :
   ⊢G Γ1 <:* Γ2 → ⊢G Γ2 <:* Γ3 → ⊢G Γ1 <:* Γ3.
 Proof.
   move: Γ1 => + + Hsub2.
   induction Hsub2; inversion 1; subst; eauto with ctx_sub.
 Qed.
+
+Lemma ctx_strip_to_sub G1 G2 :
+  ⊢G G1 >>▷* G2 →
+  ⊢G G1 <:* TLater <$> G2.
+Proof. elim=> /=; eauto using ty_strip_to_sub with ctx_sub. Qed.
 
 Lemma fmap_ctx_sub_syn {Γ} (f g : ty -> ty):
   (∀ T, ⊢T f T <: g T) →
@@ -124,7 +168,7 @@ Lemma TLater_cong_ctx_sub_syn Γ1 Γ2 :
   ⊢G TLater <$> Γ1 <:* TLater <$> Γ2.
 Proof. induction 1; cbn; auto with ctx_sub. Qed.
 
-Hint Resolve ctx_id_syn ctx_trans_sub_syn unTLater_ctx_sub_syn
+Hint Resolve ctx_sub_id_syn ctx_sub_trans_sub_syn unTLater_ctx_sub_syn
   ctx_sub_TLater_syn TLater_cong_ctx_sub_syn : ctx_sub.
 
 Ltac ietp_weaken_ctx := auto with ctx_sub.
@@ -134,3 +178,6 @@ Proof. by elim => [|> ?? /= ->]. Qed.
 
 Lemma ctx_sub_len_tlater {Γ Γ'} : ⊢G Γ <:* TLater <$> Γ' → length Γ = length Γ'.
 Proof. intros ->%ctx_sub_len. apply fmap_length. Qed.
+
+Lemma ctx_strip_len Γ Γ' : ⊢G Γ >>▷* Γ' → length Γ = length Γ'.
+Proof. by elim => [|> ?? /= ->]. Qed.

--- a/theories/Dot/typing/typing_stamped.v
+++ b/theories/Dot/typing/typing_stamped.v
@@ -40,7 +40,7 @@ Inductive typed Γ g : tm → ty → Prop :=
     Γ s⊢ₜ[ g ] tproj e l : T
 (** Introduction forms *)
 | iT_All_I_Strong e T1 T2 Γ':
-    ⊢G Γ <:* TLater <$> Γ' →
+    ⊢G Γ >>▷* Γ' →
     is_stamped_ty (length Γ) g T1 →
     (* T1 :: Γ' s⊢ₜ[ g ] e : T2 → (* Would work, but allows the argument to occur in its own type. *) *)
     shift T1 :: Γ' s⊢ₜ[ g ] e : T2 →

--- a/theories/Dot/typing/typing_storeless.v
+++ b/theories/Dot/typing/typing_storeless.v
@@ -55,7 +55,7 @@ Inductive typed Γ g : tm → ty → Prop :=
     Γ v⊢ₜ[ g ] tv v: T.|[v/]
 (** Introduction forms *)
 | iT_All_I_Strong e T1 T2 Γ':
-    ⊢G Γ <:* TLater <$> Γ' →
+    ⊢G Γ >>▷* Γ' →
     is_stamped_ty (length Γ) g T1 →
     (* T1 :: Γ' v⊢ₜ[ g ] e : T2 → (* Would work, but allows the argument to occur in its own type. *) *)
     shift T1 :: Γ' v⊢ₜ[ g ] e : T2 →

--- a/theories/Dot/typing/typing_unstamped.v
+++ b/theories/Dot/typing/typing_unstamped.v
@@ -44,7 +44,7 @@ Inductive typed Γ : tm → ty → Prop :=
     Γ u⊢ₜ tproj e l : T
 (** Introduction forms *)
 | iT_All_I_Strong e T1 T2 Γ':
-    ⊢G Γ <:* TLater <$> Γ' →
+    ⊢G Γ >>▷* Γ' →
     is_unstamped_ty' (length Γ) T1 →
     (* T1 :: Γ' u⊢ₜ e : T2 → (* Would work, but allows the argument to occur in its own type. *) *)
     shift T1 :: Γ' u⊢ₜ e : T2 →


### PR DESCRIPTION
We just changed this in the paper; this PR updates the Coq definition. For simplicity, I just use an adapter converting the new judgment to the old one, allowing me to reuse the theory.