### PR TITLE
Sketch support for higher kinds

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -27,6 +27,7 @@ theories/iris_extra/saved_interp_dep.v
 theories/misc_unused/saved_interp.v
 theories/misc_unused/saved_interp_n.v
 theories/misc_unused/hoInterps_experiments.v
+theories/misc_unused/hoInterps_bad.v
 theories/iris_extra/proofmode_extra.v
 theories/iris_extra/swap_later_impl.v
 theories/DSub/lr/adequacy.v

--- a/theories/misc_unused/hoInterps_bad.v
+++ b/theories/misc_unused/hoInterps_bad.v
@@ -221,7 +221,7 @@ Section semkinds.
 
   (* Fixpoint sem {n} (k : kind Σ n) : sp_kind Σ n :=
     match k with
-      | kintv φ1 φ2 => sp_kintv φ1 φ2
+      | kintv φ1 φ2 => sp_s_kintv φ1 φ2
       | kpi n φ1 k' => spk_kpi φ1 (sem k')
     end. *)
 
@@ -495,10 +495,10 @@ Section sec.
 
   (* Derive Signature for kind.
   Equations sem_eq {n} : kind Σ n → sp_kind Σ n :=
-    sem_eq (kintv φ1 φ2) := sp_kintv φ1 φ2;
+    sem_eq (kintv φ1 φ2) := sp_s_kintv φ1 φ2;
     sem_eq (kpi n φ1 k') := spk_kpi φ1 (sem_eq k').
 
-  Lemma unfold_sem_kintv φ1 φ2: sem_eq (kintv φ1 φ2) = sp_kintv φ1 φ2.
+  Lemma unfold_sem_kintv φ1 φ2: sem_eq (kintv φ1 φ2) = sp_s_kintv φ1 φ2.
   Proof. by simp sem_eq. Qed. *)
 End sec.
 End HoGenExperiments.

--- a/theories/misc_unused/hoInterps_bad.v
+++ b/theories/misc_unused/hoInterps_bad.v
@@ -172,7 +172,7 @@ Instance SubsetEq_type {Σ n} : SubsetEq (hoLtyO Σ n) := λI φ1 φ2,
 From D.Dot Require Import dot_lty unary_lr.
 Module HkDot2.
 (* Include HoSemTypes2 VlSorts dlang_inst dot_lty. *)
-Import HkDot.
+Export HkDot.
 
 Implicit Types (l : label) (p : path).
 
@@ -260,8 +260,8 @@ Arguments hoSTy: clear implicits.
 End HkDot2.
 
 (* These are "bad" experiments. *)
-Module HoGenExperimnents.
-Import swap_later_impl HkDot HkDot2.
+Module HoGenExperiments.
+Import swap_later_impl HkDot2.
 Section sec.
   Context `{!CTyInterp Σ}.
   Context `{dlangG Σ} `{HswapProp: SwapPropI Σ}.
@@ -390,31 +390,4 @@ Section sec.
   Lemma unfold_sem_kintv φ1 φ2: sem_eq (kintv φ1 φ2) = sp_kintv φ1 φ2.
   Proof. by simp sem_eq. Qed. *)
 End sec.
-End HoGenExperimnents.
-
-Module dot_experiments.
-Import HkDot HkDot2.
-(* Include TyInterpLemmas VlSorts dlang_inst.
-Export ty_interp_lemmas. *)
-
-Section sec.
-  Context `{!savedHoSemTypeG Σ} `{!dlangG Σ} `{CTyInterp Σ}.
-
-  Definition dm_to_type (d : dm) n (ψ : hoD Σ n) : iProp Σ :=
-    (∃ s σ, ⌜ d = dtysem σ s ⌝ ∧ s ↗n[ σ, n ] ψ)%I.
-  Notation "d ↗n[ n ] φ" := (dm_to_type d n φ) (at level 20).
-  Global Arguments dm_to_type: simpl never.
-
-  (* [K]'s argument must ignore [ρ]. Patch the definition of sp_kind instead. *)
-  Notation HoLty φ := (λ args, Lty (λI v, φ args v)).
-  Definition packHoLtyO {Σ n} φ : hoLtyO Σ n := HoLty (λI args v, □ φ args v).
-
-  Definition def_interp_tmem {n} (K : sf_kind Σ n): envPred dm Σ :=
-    (* λI ρ d, ∃ (φ : hoLtyO Σ n), d.|[ρ] ↗n[ n ] φ ∧ K 0 ρ φ. *)
-    λI ρ d, ∃ (φ : hoD Σ n), d.|[ρ] ↗n[ n ] φ ∧ K ρ (packHoLtyO φ).
-  Definition def_interp_tmem_spec (φ1 φ2 : olty Σ 0) : envPred dm Σ :=
-    def_interp_tmem (sf_kintv (oLater φ1) (oLater φ2)).
-End sec.
-
-Notation "d ↗n[ n ] φ" := (dm_to_type d n φ) (at level 20).
-End dot_experiments.
+End HoGenExperiments.

--- a/theories/misc_unused/hoInterps_bad.v
+++ b/theories/misc_unused/hoInterps_bad.v
@@ -320,7 +320,7 @@ Section sec.
     Γ s⊨ sf_kpi S1 K1 <∷[ i ] sf_kpi S2 K2.
   Proof using HswapProp. by rewrite -!sstpkD_star_eq_sstp -sSkd_Pi. Qed.
 
-  Lemma sSubK_Refl' Γ {n} T (K : s_kind Σ n) :
+  Lemma sKStp_Refl' Γ {n} T (K : s_kind Σ n) :
     let sfK := s_kind_to_sf_kind K in
     Γ s⊨ T ∷[ 0 ] sfK -∗
     Γ s⊨ T, 0 <: T, 0 ∷ sfK.
@@ -329,7 +329,7 @@ Section sec.
     by iApply (Proper_sfkind with "(HK Hg)").
   Qed.
 
-  Lemma sSubK_Refl Γ {n} T (K : s_kind Σ n) i :
+  Lemma sKStp_Refl Γ {n} T (K : s_kind Σ n) i :
     let sfK := s_kind_to_sf_kind K in
     Γ s⊨ T ∷[ i ] sfK -∗
     Γ s⊨ T, i <: T, i ∷ sfK.

--- a/theories/misc_unused/hoInterps_bad.v
+++ b/theories/misc_unused/hoInterps_bad.v
@@ -199,21 +199,6 @@ with kind : nat → Type :=
 Section semkinds.
   Context `{dlangG Σ}.
 
-  (* Definition skstar : sp_kind Σ 0 := λI ρ φ, True.
-  Definition srstar : sr_kind Σ 0 := λ ρ φ1 φ2,
-    (□ ∀ v, oClose φ1 v → oClose φ2 v)%I.
-  Definition sstar : sf_kind Σ 0 := SfKind skstar srstar. *)
-
-  (* Show that kinded subtyping correctly generalizes the existing kind-*
-  subtyping. *)
-
-  (* Definition fold_srelkind (base : sr_kind Σ 0) {n} : vec (olty Σ 0) n → sr_kind Σ n :=
-    vec_fold base (@srpi) n.
-  Definition subtype_w_expKind {n}: vec (olty Σ 0) n → sr_kind Σ n :=
-    fold_srelkind srstar. *)
-  (* Definition eqtype_w_expKind : ∀ n, vec (olty Σ 0) n → sr_kind Σ n :=
-    fold_srelkind kind_star_eqtype. *)
-
   (* Inductive kind {Σ} : nat → Type :=
     | kintv : olty Σ 0 → olty Σ 0 → kind 0
     | kpi n : olty Σ 0 → kind n → kind (S n).
@@ -259,28 +244,12 @@ End semkinds.
 Arguments hoSTy: clear implicits.
 End HkDot2.
 
-(* These are "bad" experiments. *)
+(* These are abandoned experiments. *)
 Module HoGenExperiments.
 Import swap_later_impl HkDot2.
 
-Program Definition sstpk `{!dlangG Σ} {n} i j Γ T1 T2 (K : sf_kind Σ n) : iProp Σ :=
-  □∀ ρ, s⟦Γ⟧*ρ → sf_kind_sub K ρ (envApply (oLaterN i T1) ρ) (envApply (oLaterN j T2) ρ).
-Notation "Γ s⊨ T1 , i <: T2 , j ∷ K" := (sstpk i j Γ T1 T2 K)
-  (at level 74, i, j, T1, T2, K at next level).
-
 Section sec.
-  Context `{!CTyInterp Σ}.
   Context `{dlangG Σ} `{HswapProp: SwapPropI Σ}.
-
-  Lemma sstpk_star_eq_sstp Γ i j T1 T2 :
-    Γ s⊨ T1 , i <: T2 , j ∷ sf_star ⊣⊢ Γ s⊨ T1 , i <: T2 , j.
-  Proof.
-    rewrite /sstpk /sf_kind_sub/= /sf_star; iSplit; iIntros "/= #Hsub !>" (ρ).
-    iIntros (v) "#Hg".
-    by iDestruct ("Hsub" $! ρ with "Hg") as "{Hsub} (_ & #Hsub &_)"; iApply ("Hsub" $! v).
-    iIntros "#Hg"; repeat iSplit; iIntros "!>" (v); [iIntros "[]" | | iIntros "_ //"].
-    by iApply ("Hsub" $! ρ v with "Hg").
-  Qed.
 
   Lemma subtyping_spec i j Γ T1 T2 ρ :
     Γ s⊨ T1, i <: T2, j -∗
@@ -320,82 +289,6 @@ Section sec.
     Γ s⊨ sf_kpi S1 K1 <∷[ i ] sf_kpi S2 K2.
   Proof using HswapProp. by rewrite -!sstpkD_star_eq_sstp -sSkd_Pi. Qed.
 
-  Lemma sKStp_Refl' Γ {n} T (K : sf_kind Σ n) :
-    Γ s⊨ T ∷[ 0 ] K -∗
-    Γ s⊨ T, 0 <: T, 0 ∷ K.
-  Proof.
-    iIntros "#HK !>". iIntros (ρ) "#Hg".
-    by iApply (Proper_sfkind with "(HK Hg)").
-  Qed.
-
-  Lemma sKStp_Refl Γ {n} T (K : sf_kind Σ n) i :
-    Γ s⊨ T ∷[ i ] K -∗
-    Γ s⊨ T, i <: T, i ∷ K.
-  Proof.
-    (* have ->: i = 0 by admit. *)
-    iIntros "#HK !>". iIntros (ρ) "#Hg".
-    Fail by iApply (Proper_sfkind with "(HK Hg)").
-  Abort.
-
-
-  (* Definition srstar1 : sr_kind Σ 0 := subtype.
-  Lemma srstar_eq ρ φ1 φ2 :
-    srstar1 ρ φ1 φ2 ≡ srstar ρ φ1 φ2.
-  Proof.
-    rewrite /srstar1 /srstar /subtype /vclose.
-    apply intuitionistically_proper, equiv_spec; split. by iIntros "H".
-    iIntros "H" (args). by rewrite (vec_vnil args).
-  Qed. *)
-
-  (* Definition skLaterN {Σ n} i (K : sp_kind Σ n) : sp_kind Σ n :=
-    λ ρ φ, K ρ (oLaterN i φ). *)
-  (* Definition srLaterN {Σ n} i j (K : sr_kind Σ n) : sr_kind Σ n :=
-    λ ρ T1 T2, K ρ (oLaterN i T1) (oLaterN j T2). *)
-  (* Definition sfLaterN {n} i (K : sf_kind Σ n) : sf_kind Σ n :=
-    SfKind (skLaterN i K) K. *)
-
-  (* Definition sstpk `{dlangG Σ} {n} i j Γ τ₁ τ₂ (K : sf_kind Σ n) : iProp Σ :=
-    □∀ ρ, s⟦Γ⟧*ρ → srLaterN i j (sf_kind_sub K) ρ τ₁ τ₂. *)
-  (* Definition semEquiv {n} : sr_kind Σ n := λI ρ (φ1 φ2 : olty Σ n),
-    □ ∀ args v, φ1 args ρ v ↔ φ2 args ρ v. *)
-  (* Definition kind_star_eqtype : sr_kind Σ 0 := λ ρ φ1 φ2,
-    (□ ∀ v, oClose φ1 ρ v ↔ oClose φ2 ρ v)%I. *)
-
-
-  (* Definition sstpk1 {n} i Γ (T1 T2 : oltyO Σ n) (K : sf_kind Σ n) : iProp Σ :=
-    □∀ ρ, s⟦Γ⟧*ρ → ▷^i sf_kind_sub K ρ (envApply T1 ρ) (envApply T2 ρ).
-  Lemma sstpk1_star_eq_sstp Γ i T1 T2 :
-    sstpk1 i Γ T1 T2 sf_star ⊣⊢ Γ s⊨ T1 , i <: T2 , i.
-  Proof using HswapProp.
-    rewrite /sstpk1 /sf_kind_sub/= /sf_star.
-    iSplit; iIntros "/= #Hsub !>" (ρ); [iIntros (v)|]; iIntros "#Hg".
-    iSpecialize ("Hsub" $! ρ with "Hg"); iSpecialize ("Hsub" $! v).
-    rewrite -mlaterN_pers laterN_impl.
-    by iApply "Hsub".
-    rewrite -mlaterN_pers; iIntros (v) "!>"; rewrite -mlaterN_impl.
-    iDestruct "Hsub" as "#Hsub".
-    iApply ("Hsub" $! ρ v with "Hg").
-  Qed. *)
-
-  (* Lemma sstpk1_star_eq_sstp Γ i j T1 T2 :
-    sstpk i j Γ T1 T2 sf_star ⊣⊢ Γ s⊨ T1 , i <: T2 , j.
-  Proof using HswapProp.
-    rewrite /sstpk /sf_kind_sub/= /sf_star.
-    iSplit; iIntros "/= #Hsub !>" (ρ); [iIntros (v)|]; iIntros "#Hg".
-    iDestruct ("Hsub" $! ρ with "Hg") as "{Hsub} (_ & #Hsub &_)"; iSpecialize ("Hsub" $! v).
-    rewrite /= -laterN_impl.
-    by iApply "Hsub".
-    rewrite -mlaterN_pers; iIntros (v) "!>"; rewrite -mlaterN_impl.
-    iDestruct "Hsub" as "#Hsub".
-    iApply ("Hsub" $! ρ v with "Hg").
-  Qed. *)
-
-
-  (* Inductive kind : nat → Type :=
-    | kintv : ty → ty → kind 0
-    | kpi n : ty → kind n → kind (S n). *)
-
-
   Inductive htype : nat → Type :=
     | TWrap : ty → htype 0
     | TLam {n} : olty Σ 0 → htype n → htype (S n)
@@ -409,30 +302,9 @@ Section sec.
     end.
   Definition typeSem {n} (T : htype n) : hoEnvD Σ n := hoSTySem (htype_to_hosty T).
 
-  Lemma K_App_Lam {n} (argT : olty Σ 0) (φ1 φ2: hoLtyO Σ (S n)) (K : sf_kind Σ n) ρ :
-    sf_kind_sub (sf_kpi argT K) ρ φ1 φ2 ⊣⊢ (□∀ v, oClose argT ρ v → sf_kind_sub K (v .: ρ) (vcurry φ1 v) (vcurry φ2 v))%I.
+  Lemma sf_kpi_eq {n} (S : olty Σ 0) (φ1 φ2: hoLtyO Σ n.+1) (K : sf_kind Σ n) ρ :
+    sf_kpi S K ρ φ1 φ2 ⊣⊢ □∀ v, oClose S ρ v → K (v .: ρ) (vcurry φ1 v) (vcurry φ2 v).
   Proof. done. Qed.
-  (** XXX Need a subtyping judgment to throw in environments... *)
-
-  (* Here, we inherit eta from the metalanguage, in both directions. *)
-  (* Er, let's please carry it closer to the syntax? *)
-  Lemma eta1 {n} argT (φ : hoLtyO Σ n.+1) (K : sf_kind Σ n) ρ :
-    (∀ arg, K (arg .: ρ) (vcurry φ arg) (vcurry φ arg)) →
-    sf_kpi argT K ρ φ (vuncurry (vcurry φ)).
-  Proof. iIntros (HK) "!> * _". iApply HK. Qed.
-
-  (* Lemma eta2 {n} argT (φ : hoLtyO Σ (S n)) ρ :
-    srpi argT subtype ρ (vuncurry (vcurry φ)) φ.
-  Proof.
-    rewrite /srpi /subtype.
-    iIntros "!> * #Harg !>" (args v) "$".
-  Qed. *)
-
-  (* Lemma eta {n} argT (φ : olty Σ (S n)) ρ : srpi argT semEquiv ρ φ (vuncurry (vcurry φ)).
-  Proof.
-    rewrite /srpi /semEquiv.
-    iIntros "!> * #Harg !> **". rewrite -(iff_refl emp%I). done.
-  Qed. *)
 
   Program Fixpoint sem_program {n} {struct n} : s_kind Σ n → sf_kind Σ n :=
     match n return _ with

--- a/theories/misc_unused/hoInterps_bad.v
+++ b/theories/misc_unused/hoInterps_bad.v
@@ -10,6 +10,8 @@ Import EqNotations.
 
 Set Suggest Proof Using.
 Set Default Proof Using "Type".
+Set Implicit Arguments.
+Unset Strict Implicit.
 
 Module try1 (Import VS : VlSortsSig).
 Section saved_pred3_use.
@@ -116,6 +118,7 @@ Section saved_ho_sem_type_extra.
 
   Definition unpack : ∀ Ψ, hoEnvD Σ (packedHoEnvD_arity Ψ) :=
     λ Ψ args ρ v, unNext (projT2 Ψ args ρ v).
+  Arguments unpack : clear implicits.
 
   Lemma packedHoEnvD_arity_ne {Φ Ψ : packedHoEnvD Σ} {n} :
     Φ ≡{n}≡ Ψ → packedHoEnvD_arity Φ = packedHoEnvD_arity Ψ.

--- a/theories/misc_unused/hoInterps_bad.v
+++ b/theories/misc_unused/hoInterps_bad.v
@@ -199,8 +199,45 @@ with kind : nat → Type :=
   | kintv (L U : hty 0) : kind 0
   | kpi {n} (S : hty 0) (K : kind n) : kind n.+1.
 
+(** An inductive representation of gHkDOT semantic kinds. *)
+Inductive s_kind {Σ} : nat → Type :=
+  | s_kintv : olty Σ 0 → olty Σ 0 → s_kind 0
+  | s_kpi n : olty Σ 0 → s_kind n → s_kind n.+1.
+Global Arguments s_kind: clear implicits.
+
+(** Alternative inductive representation of gHkDOT semantic kinds. *)
+Record spine_s_kind {Σ} {n : nat} : Type := SpineSK {
+  spine_kargs : vec (olty Σ 0) n;
+  spine_L : olty Σ 0;
+  spine_U : olty Σ 0;
+}.
+Arguments spine_s_kind : clear implicits.
+
+
 Section semkinds.
   Context `{dlangG Σ}.
+
+  Definition sp_s_kintv (L U : olty Σ 0) : spine_s_kind Σ 0 := SpineSK vnil L U.
+  Definition sp_s_kpi {n} (S : olty Σ 0) (K : spine_s_kind Σ n) : spine_s_kind Σ n.+1 :=
+    SpineSK (vcons S (spine_kargs K)) (spine_L K) (spine_U K).
+
+  Fixpoint s_kind_to_spine_s_kind {n} (K : s_kind Σ n) : spine_s_kind Σ n :=
+    match K with
+    | s_kintv L U => sp_s_kintv L U
+    | s_kpi s K => sp_s_kpi s (s_kind_to_spine_s_kind K)
+    end.
+
+  Definition spine_s_kind_to_sf_kind {n} (K : spine_s_kind Σ n) : sf_kind Σ n :=
+    vec_fold (sf_kintv (spine_L K) (spine_U K)) (@sf_kpi Σ) n (spine_kargs K).
+  Global Arguments spine_s_kind_to_sf_kind {_} !_.
+
+  Fixpoint s_kind_to_sf_kind {n} (K : s_kind Σ n) : sf_kind Σ n :=
+    match K with
+    | s_kintv L U => sf_kintv L U
+    | s_kpi s K => sf_kpi s (s_kind_to_sf_kind K)
+    end.
+
+
 
   (* Inductive kind {Σ} : nat → Type :=
     | kintv : olty Σ 0 → olty Σ 0 → kind 0

--- a/theories/misc_unused/hoInterps_bad.v
+++ b/theories/misc_unused/hoInterps_bad.v
@@ -202,7 +202,7 @@ Section semkinds.
   (* Definition skstar : sp_kind Σ 0 := λI ρ φ, True.
   Definition srstar : sr_kind Σ 0 := λ ρ φ1 φ2,
     (□ ∀ v, oClose φ1 v → oClose φ2 v)%I.
-  Definition sstar : sf_kind Σ 0 := Sfkind skstar srstar. *)
+  Definition sstar : sf_kind Σ 0 := SfKind skstar srstar. *)
 
   (* Show that kinded subtyping correctly generalizes the existing kind-*
   subtyping. *)
@@ -222,7 +222,7 @@ Section semkinds.
   (* Fixpoint sem {n} (k : kind Σ n) : sp_kind Σ n :=
     match k with
       | kintv φ1 φ2 => sp_kintv φ1 φ2
-      | kpi n φ1 k' => spk_pi φ1 (sem k')
+      | kpi n φ1 k' => spk_kpi φ1 (sem k')
     end. *)
 
   (* Notice the argument type is not used here. *)
@@ -280,7 +280,7 @@ Section sec.
   (* Definition srLaterN {Σ n} i j (K : sr_kind Σ n) : sr_kind Σ n :=
     λ ρ T1 T2, K ρ (oLaterN i T1) (oLaterN j T2). *)
   (* Definition sfLaterN {n} i (K : sf_kind Σ n) : sf_kind Σ n :=
-    Sfkind (skLaterN i K) K. *)
+    SfKind (skLaterN i K) K. *)
 
   (* Definition sstpk `{dlangG Σ} {n} i j Γ τ₁ τ₂ (K : sf_kind Σ n) : iProp Σ :=
     □∀ ρ, s⟦Γ⟧*ρ → srLaterN i j (sf_kind_sub K) ρ τ₁ τ₂. *)
@@ -338,7 +338,7 @@ Section sec.
   Definition typeSem {n} (T : htype n) : hoEnvD Σ n := hoSTySem (htype_to_hosty T).
 
   Lemma K_App_Lam {n} (argT : olty Σ 0) (φ1 φ2: hoLtyO Σ (S n)) (K : sf_kind Σ n) ρ :
-    sf_kind_sub (sf_pi argT K) ρ φ1 φ2 ⊣⊢ (□∀ v, oClose argT ρ v → sf_kind_sub K (v .: ρ) (vcurry φ1 v) (vcurry φ2 v))%I.
+    sf_kind_sub (sf_kpi argT K) ρ φ1 φ2 ⊣⊢ (□∀ v, oClose argT ρ v → sf_kind_sub K (v .: ρ) (vcurry φ1 v) (vcurry φ2 v))%I.
   Proof. done. Qed.
   (** XXX Need a subtyping judgment to throw in environments... *)
 
@@ -346,7 +346,7 @@ Section sec.
   (* Er, let's please carry it closer to the syntax? *)
   Lemma eta1 {n} argT (φ : hoLtyO Σ n.+1) K ρ :
     (∀ arg, s_kind_to_sf_kind K (arg .: ρ) (vcurry φ arg)) →
-    sf_kind_sub (sf_pi argT (s_kind_to_sf_kind K)) ρ φ (vuncurry (vcurry φ)).
+    sf_kind_sub (sf_kpi argT (s_kind_to_sf_kind K)) ρ φ (vuncurry (vcurry φ)).
   Proof.
     rewrite /sf_kind_sub /=.
     iIntros (HK) "!> * #Harg". iApply s_kind_refl. iApply HK.
@@ -368,13 +368,13 @@ Section sec.
   Program Fixpoint sem_program {n} {struct n} : s_kind Σ n → sf_kind Σ n :=
     match n return _ with
     | 0 => λ k, match k with
-      | s_kintv φ1 φ2 => sf_intv φ1 φ2
+      | s_kintv φ1 φ2 => sf_kintv φ1 φ2
       | s_kpi _ _ => _
       end
     | S n => λ k, match k with
       | s_kintv φ1 φ2 => _
       | s_kpi φ1 k' =>
-        sf_pi φ1 (sem_program (rew _ in k'))
+        sf_kpi φ1 (sem_program (rew _ in k'))
       end
     end.
   Next Obligation. done. Qed.
@@ -385,7 +385,7 @@ Section sec.
   (* Derive Signature for kind.
   Equations sem_eq {n} : kind Σ n → sp_kind Σ n :=
     sem_eq (kintv φ1 φ2) := sp_kintv φ1 φ2;
-    sem_eq (kpi n φ1 k') := spk_pi φ1 (sem_eq k').
+    sem_eq (kpi n φ1 k') := spk_kpi φ1 (sem_eq k').
 
   Lemma unfold_sem_kintv φ1 φ2: sem_eq (kintv φ1 φ2) = sp_kintv φ1 φ2.
   Proof. by simp sem_eq. Qed. *)
@@ -413,7 +413,7 @@ Section sec.
     (* λI ρ d, ∃ (φ : hoLtyO Σ n), d.|[ρ] ↗n[ n ] φ ∧ K 0 ρ φ. *)
     λI ρ d, ∃ (φ : hoD Σ n), d.|[ρ] ↗n[ n ] φ ∧ K ρ (packHoLtyO φ).
   Definition def_interp_tmem_spec (φ1 φ2 : olty Σ 0) : envPred dm Σ :=
-    def_interp_tmem (sf_intv (oLater φ1) (oLater φ2)).
+    def_interp_tmem (sf_kintv (oLater φ1) (oLater φ2)).
 End sec.
 
 Notation "d ↗n[ n ] φ" := (dm_to_type d n φ) (at level 20).

--- a/theories/misc_unused/hoInterps_bad.v
+++ b/theories/misc_unused/hoInterps_bad.v
@@ -321,10 +321,10 @@ Section sec.
     Γ s⊨ T ∷[ i ] sf_star.
   Proof using HswapProp.
     iApply sK_KSub. iApply sK_Sing.
-    iApply sKSub_Intv; [iApply sBot_Sub | iApply sSub_Top].
+    iApply sKSub_Intv'; [iApply sBot_Sub | iApply sSub_Top].
   Qed.
 
-  Lemma sKSub_Pi {n} (S1 S2 : olty Σ 0) (K1 K2 : sf_kind Σ n) Γ i :
+  Lemma sKSub_Pi' {n} (S1 S2 : olty Σ 0) (K1 K2 : sf_kind Σ n) Γ i :
     Γ s⊨ S2, i <: S1, i -∗
     oLaterN i (shift S2) :: Γ s⊨ K1 <∷[ i ] K2 -∗
     Γ s⊨ sf_kpi S1 K1 <∷[ i ] sf_kpi S2 K2.
@@ -332,8 +332,8 @@ Section sec.
     iIntros "#HsubS #HsubK !>" (ρ) "#Hg /=".
     iPoseProof (subtyping_spec_swap with "HsubS Hg") as "{HsubS} HsubS".
     iAssert (□∀ arg : vl, let ρ' := arg .: ρ in
-            ▷^i (oClose S2 ρ arg → ∀ T : olty Σ n,
-            K1 ρ' (envApply T ρ') → K2 ρ' (envApply T ρ')))%I as
+            ▷^i (oClose S2 ρ arg → ∀ T : hoLtyO Σ n,
+            K1 ρ' T → K2 ρ' T))%I as
             "{HsubK} #HsubK". {
       setoid_rewrite <-mlaterN_impl.
       iIntros "!>" (arg) "HS2"; iIntros (T).
@@ -349,7 +349,7 @@ Section sec.
       iApply (Proper_sfkind with "(HTK1 (HsubS HS))") => args v /=.
       by rewrite (hoEnvD_weaken_one (vcurry T arg) args (arg .: ρ) v).
     } *)
-    iSpecialize ("HsubK" $! (oShift (vcurry T arg)) with "[]"). {
+    iSpecialize ("HsubK" $! (vcurry T arg) with "[]"). {
       by iApply (Proper_sfkind with "(HTK1 (HsubS HS))").
     }
     by iApply (Proper_sfkind with "HsubK").
@@ -361,7 +361,7 @@ Section sec.
     Γ s⊨ T, 0 <: T, 0 ∷ sfK.
   Proof.
     iIntros (?) "#HK !>". iIntros (ρ) "#Hg".
-    iApply s_kind_refl.
+    iApply sf_kind_sub_refl.
     by iApply (Proper_sfkind with "(HK Hg)").
   Qed.
 
@@ -372,7 +372,7 @@ Section sec.
   Proof.
     (* have ->: i = 0 by admit. *)
     iIntros (?) "#HK !>". iIntros (ρ) "#Hg".
-    iApply s_kind_refl.
+    iApply sf_kind_sub_refl.
     Fail by iApply (Proper_sfkind with "(HK Hg)").
   Abort.
 
@@ -460,7 +460,7 @@ Section sec.
     sf_kind_sub (sf_kpi argT (s_kind_to_sf_kind K)) ρ φ (vuncurry (vcurry φ)).
   Proof.
     rewrite /sf_kind_sub /=.
-    iIntros (HK) "!> * #Harg". iApply s_kind_refl. iApply HK.
+    iIntros (HK) "!> * #Harg". iApply sf_kind_sub_refl. iApply HK.
   Qed.
 
   (* Lemma eta2 {n} argT (φ : hoLtyO Σ (S n)) ρ :

--- a/theories/misc_unused/hoInterps_bad.v
+++ b/theories/misc_unused/hoInterps_bad.v
@@ -320,22 +320,20 @@ Section sec.
     Γ s⊨ sf_kpi S1 K1 <∷[ i ] sf_kpi S2 K2.
   Proof using HswapProp. by rewrite -!sstpkD_star_eq_sstp -sSkd_Pi. Qed.
 
-  Lemma sKStp_Refl' Γ {n} T (K : s_kind Σ n) :
-    let sfK := s_kind_to_sf_kind K in
-    Γ s⊨ T ∷[ 0 ] sfK -∗
-    Γ s⊨ T, 0 <: T, 0 ∷ sfK.
+  Lemma sKStp_Refl' Γ {n} T (K : sf_kind Σ n) :
+    Γ s⊨ T ∷[ 0 ] K -∗
+    Γ s⊨ T, 0 <: T, 0 ∷ K.
   Proof.
-    iIntros (?) "#HK !>". iIntros (ρ) "#Hg".
+    iIntros "#HK !>". iIntros (ρ) "#Hg".
     by iApply (Proper_sfkind with "(HK Hg)").
   Qed.
 
-  Lemma sKStp_Refl Γ {n} T (K : s_kind Σ n) i :
-    let sfK := s_kind_to_sf_kind K in
-    Γ s⊨ T ∷[ i ] sfK -∗
-    Γ s⊨ T, i <: T, i ∷ sfK.
+  Lemma sKStp_Refl Γ {n} T (K : sf_kind Σ n) i :
+    Γ s⊨ T ∷[ i ] K -∗
+    Γ s⊨ T, i <: T, i ∷ K.
   Proof.
     (* have ->: i = 0 by admit. *)
-    iIntros (?) "#HK !>". iIntros (ρ) "#Hg".
+    iIntros "#HK !>". iIntros (ρ) "#Hg".
     Fail by iApply (Proper_sfkind with "(HK Hg)").
   Abort.
 
@@ -418,9 +416,9 @@ Section sec.
 
   (* Here, we inherit eta from the metalanguage, in both directions. *)
   (* Er, let's please carry it closer to the syntax? *)
-  Lemma eta1 {n} argT (φ : hoLtyO Σ n.+1) K ρ :
-    (∀ arg, s_kind_to_sf_kind K (arg .: ρ) (vcurry φ arg) (vcurry φ arg)) →
-    sf_kind_sub (sf_kpi argT (s_kind_to_sf_kind K)) ρ φ (vuncurry (vcurry φ)).
+  Lemma eta1 {n} argT (φ : hoLtyO Σ n.+1) (K : sf_kind Σ n) ρ :
+    (∀ arg, K (arg .: ρ) (vcurry φ arg) (vcurry φ arg)) →
+    sf_kpi argT K ρ φ (vuncurry (vcurry φ)).
   Proof. iIntros (HK) "!> * _". iApply HK. Qed.
 
   (* Lemma eta2 {n} argT (φ : hoLtyO Σ (S n)) ρ :

--- a/theories/misc_unused/hoInterps_bad.v
+++ b/theories/misc_unused/hoInterps_bad.v
@@ -305,17 +305,7 @@ Section sec.
     Γ s⊨ L2, i <: L1, i -∗
     Γ s⊨ U1, i <: U2, i -∗
     Γ s⊨ sf_kintv L1 U1 <∷[ i ] sf_kintv L2 U2.
-  Proof using HswapProp.
-    iIntros "#HsubL #HsubU !>" (ρ) "#Hg". iIntros (T).
-    iPoseProof (subtyping_spec_swap with "HsubL Hg") as "{HsubL} HsubL".
-    iPoseProof (subtyping_spec_swap with "HsubU Hg") as "{HsubU} HsubU".
-    iNext i.
-    rewrite /sf_kind_sub/= /subtype_lty.
-    iIntros "#[#HsubL1 #HsubU1] /=".
-    iSplit; iIntros (v) "!> #H".
-    by iApply ("HsubL1" with "(HsubL H)").
-    by iApply ("HsubU" with "(HsubU1 H)").
-  Qed.
+  Proof using HswapProp. by rewrite -!sstpkD_star_eq_sstp -sKSub_Intv. Qed.
 
   Lemma sK_Star' Γ (T : olty Σ 0) i :
     Γ s⊨ T ∷[ i ] sf_star.
@@ -328,32 +318,7 @@ Section sec.
     Γ s⊨ S2, i <: S1, i -∗
     oLaterN i (shift S2) :: Γ s⊨ K1 <∷[ i ] K2 -∗
     Γ s⊨ sf_kpi S1 K1 <∷[ i ] sf_kpi S2 K2.
-  Proof using HswapProp.
-    iIntros "#HsubS #HsubK !>" (ρ) "#Hg /=".
-    iPoseProof (subtyping_spec_swap with "HsubS Hg") as "{HsubS} HsubS".
-    iAssert (□∀ arg : vl, let ρ' := arg .: ρ in
-            ▷^i (oClose S2 ρ arg → ∀ T : hoLtyO Σ n,
-            K1 ρ' T → K2 ρ' T))%I as
-            "{HsubK} #HsubK". {
-      setoid_rewrite <-mlaterN_impl.
-      iIntros "!>" (arg) "HS2"; iIntros (T).
-      rewrite -mlaterN_impl.
-      iIntros "HK1".
-      iApply ("HsubK" $! (arg .: ρ) with "[$Hg HS2] HK1").
-      iApply (hoEnvD_weaken_one S2 _ (_ .: _) _ with "HS2").
-    }
-    iIntros (T); iNext i.
-    iIntros "#HTK1 !>" (arg) "#HS".
-    iSpecialize ("HsubK" $! arg with "HS").
-    (* iSpecialize ("HsubK" $! !!(shift (vcurry T arg)) with "[]"). {
-      iApply (Proper_sfkind with "(HTK1 (HsubS HS))") => args v /=.
-      by rewrite (hoEnvD_weaken_one (vcurry T arg) args (arg .: ρ) v).
-    } *)
-    iSpecialize ("HsubK" $! (vcurry T arg) with "[]"). {
-      by iApply (Proper_sfkind with "(HTK1 (HsubS HS))").
-    }
-    by iApply (Proper_sfkind with "HsubK").
-  Qed.
+  Proof using HswapProp. by rewrite -!sstpkD_star_eq_sstp -sKSub_Pi. Qed.
 
   Lemma sSubK_Refl' Γ {n} T (K : s_kind Σ n) :
     let sfK := s_kind_to_sf_kind K in
@@ -361,7 +326,6 @@ Section sec.
     Γ s⊨ T, 0 <: T, 0 ∷ sfK.
   Proof.
     iIntros (?) "#HK !>". iIntros (ρ) "#Hg".
-    iApply sf_kind_sub_refl.
     by iApply (Proper_sfkind with "(HK Hg)").
   Qed.
 
@@ -372,7 +336,6 @@ Section sec.
   Proof.
     (* have ->: i = 0 by admit. *)
     iIntros (?) "#HK !>". iIntros (ρ) "#Hg".
-    iApply sf_kind_sub_refl.
     Fail by iApply (Proper_sfkind with "(HK Hg)").
   Abort.
 
@@ -456,12 +419,9 @@ Section sec.
   (* Here, we inherit eta from the metalanguage, in both directions. *)
   (* Er, let's please carry it closer to the syntax? *)
   Lemma eta1 {n} argT (φ : hoLtyO Σ n.+1) K ρ :
-    (∀ arg, s_kind_to_sf_kind K (arg .: ρ) (vcurry φ arg)) →
+    (∀ arg, s_kind_to_sf_kind K (arg .: ρ) (vcurry φ arg) (vcurry φ arg)) →
     sf_kind_sub (sf_kpi argT (s_kind_to_sf_kind K)) ρ φ (vuncurry (vcurry φ)).
-  Proof.
-    rewrite /sf_kind_sub /=.
-    iIntros (HK) "!> * #Harg". iApply sf_kind_sub_refl. iApply HK.
-  Qed.
+  Proof. iIntros (HK) "!> * _". iApply HK. Qed.
 
   (* Lemma eta2 {n} argT (φ : hoLtyO Σ (S n)) ρ :
     srpi argT subtype ρ (vuncurry (vcurry φ)) φ.

--- a/theories/misc_unused/hoInterps_bad.v
+++ b/theories/misc_unused/hoInterps_bad.v
@@ -1,0 +1,444 @@
+(* (* Must be loaded first, so that other modules can reset some flags. *)
+Require Import Equations.Equations. *)
+From iris.proofmode Require Import tactics.
+From iris.base_logic Require Import lib.saved_prop.
+From D Require Import iris_prelude saved_interp_n.
+From D Require Import saved_interp_dep asubst_intf dlang ty_interp_subst_lemmas.
+From Coq Require FunctionalExtensionality.
+From D Require swap_later_impl.
+Import EqNotations.
+
+Set Suggest Proof Using.
+Set Default Proof Using "Type".
+
+Module try1 (Import VS : VlSortsSig).
+Section saved_pred3_use.
+  Context {Σ : gFunctors}.
+
+  Notation envD Σ := (env -d> vl -d> iPropO Σ).
+  Notation hoEnvD Σ := (list vl -d> envD Σ).
+  Implicit Types (Φ : hoEnvD Σ) (n : nat).
+  Definition eFalse : envD Σ := λ ρ v, False%I.
+
+  (* We can track function arity by just storing a number,
+     but that's a bit cumbersome. *)
+  Definition hoEnvND Σ : Type := nat * hoEnvD Σ.
+  Definition vcurry : hoEnvND Σ → vl → hoEnvND Σ := λ '(n, Φ) a,
+    match n with
+    | 0 => (0, λ _, eFalse)
+    | S n => (n, λ args, Φ (a :: args))
+    end%I.
+  Definition vclose : hoEnvND Σ → envD Σ := λ '(n, Φ), Φ [].
+  Definition vuncurry n (Φ : vl → hoEnvD Σ) : hoEnvND Σ :=
+    (S n, λ args,
+      match args with
+      | w :: args => Φ w args
+      | [] => eFalse
+      end%I).
+End saved_pred3_use.
+End try1.
+From D Require Import saved_interp_dep lty asubst_base.
+
+Module noDepTypes.
+Module Type HoSemTypes (Import VS : VlSortsFullSig) (Import LWP : LiftWp VS).
+Include Lty VS LWP.
+Section saved_dep_use.
+  Context {Σ : gFunctors}.
+  Notation hoEnvND Σ := (sigTO (hoEnvD Σ)).
+  Implicit Types (Φ : hoEnvND Σ) (n : nat).
+  Definition eFalse : envD Σ := λ ρ v, False%I.
+
+  Unset Program Cases.
+  Program Definition vcurry : hoEnvND Σ → vl → hoEnvND Σ := λ '(existT n φ),
+    match n with
+    | 0 => λ _ _, existT 0 (λ _, eFalse)
+    | S m => λ φ a, existT m (λ args : vec vl m, φ (vcons a args))
+    end φ.
+
+  Definition vclose : hoEnvND Σ → envD Σ := λ '(existT n φ),
+    match n with
+    | 0 => λ φ, φ vnil
+    | S n => λ _, eFalse
+    end φ.
+  Lemma vclose_id φ : vclose (existT 0 φ) = φ vnil. Proof. done. Qed.
+
+  Program Definition vuncurry' : {n & vl → hoEnvD Σ n} → hoEnvND Σ := λ '(existT n φ),
+    existT (S n) (λ args, φ (vhead args) (vtail args)).
+  Program Definition vuncurry n : (vl → hoEnvND Σ) → hoEnvND Σ := λ φ,
+    existT (S n) (λ args,
+      let '(existT m φ') := φ (vhead args) in
+      match decide (m = n) with
+      | left Heq => φ' (rew <- [vec vl] Heq in vtail args)
+      | right _ => eFalse
+      end).
+  Lemma vec_eta {A n} (args : vec A (S n)) : vcons (vhead args) (vtail args) = args.
+  Proof. by dependent destruction args. Qed.
+
+  Lemma vcurry_vuncurry n (φ : hoEnvD Σ (S n)) : vuncurry n (vcurry (existT (S n) φ)) = existT (S n) φ.
+  Proof.
+    rewrite /vuncurry; cbn; destruct n; f_equiv;
+      apply FunctionalExtensionality.functional_extensionality_dep => args;
+      by rewrite (decide_left (P := (_ = _)) eq_refl) vec_eta.
+  Qed.
+
+  Lemma vuncurry_vcurry n (φ : vl → hoEnvD Σ n) :
+    vcurry (vuncurry n (λ v, existT n (φ v))) = (λ v, existT n (φ v)).
+  Proof.
+    apply FunctionalExtensionality.functional_extensionality_dep => v.
+    cbn; f_equiv.
+    apply FunctionalExtensionality.functional_extensionality_dep => args /=.
+    by rewrite (decide_left (P := (_ = _)) eq_refl).
+  Qed.
+End saved_dep_use.
+End HoSemTypes.
+End noDepTypes.
+
+From D Require Import hoInterps_experiments.
+
+(** The semantics of a kind includes a predicate on types, and a subtype predicate.
+  *)
+(* XXX make these non-expansive? *)
+Module Type HoSemTypes2 (Import VS : VlSortsFullSig) (Import LWP : LiftWp VS) (Import L : Lty VS LWP).
+Include HoSemTypes VS LWP L.
+
+
+Section saved_ho_sem_type_extra.
+  Context {Σ : gFunctors}.
+
+  Implicit Types (Ψ : packedHoEnvD Σ).
+
+  (** ** Accessing saved HO predicates. *)
+  Definition packedHoEnvD_arity : packedHoEnvD Σ -n> natO := packedHoEnvPred_arity.
+
+  Program Definition unNext: laterO (iPropO Σ) -n> iPropO Σ :=
+    λne φ, (▷ later_car φ)%I.
+  Next Obligation. solve_contractive. Qed.
+
+  Definition unpack : ∀ Ψ, hoEnvD Σ (packedHoEnvD_arity Ψ) :=
+    λ Ψ args ρ v, unNext (projT2 Ψ args ρ v).
+
+  Lemma packedHoEnvD_arity_ne {Φ Ψ : packedHoEnvD Σ} {n} :
+    Φ ≡{n}≡ Ψ → packedHoEnvD_arity Φ = packedHoEnvD_arity Ψ.
+  Proof. apply packedHoEnvD_arity. Qed.
+
+  Lemma unpack_ne {n Ψ1 Ψ2} (Heq : Ψ1 ≡{n}≡ Ψ2):
+    rew [hoEnvD Σ] (packedHoEnvD_arity_ne Heq) in unpack Ψ1 ≡{n}≡ unpack Ψ2.
+  Proof.
+    move: Ψ1 Ψ2 Heq (packedHoEnvD_arity_ne Heq) => [/= n1 Φ1] [/= n2 Φ2] [/= Heq1 Heq] HeqN.
+    move: Heq; rewrite (proof_irrel HeqN Heq1) /unpack /=.
+    destruct Heq1 => /= H ???. f_contractive. exact: H.
+  Qed.
+
+  Lemma unpack_ne_eta n Ψ1 Ψ2 (Heq : Ψ1 ≡{n}≡ Ψ2) a b c:
+    (rew [hoEnvD Σ] (packedHoEnvD_arity_ne Heq) in unpack Ψ1) a b c ≡{n}≡
+    unpack Ψ2 a b c.
+  Proof. exact: unpack_ne. Qed.
+End saved_ho_sem_type_extra.
+
+Notation skind Σ n := (∀ (i : nat), env → hoLty Σ n → iProp Σ).
+Notation srelkind Σ n := (env → hoLtyO Σ n → hoLtyO Σ n → iProp Σ).
+
+(* Semantic Full Kind. *)
+Record sfkind Σ n := Sfkind {
+  sfkind_car :> skind Σ n;
+  sfkind_sub : srelkind Σ n;
+}.
+Global Arguments Sfkind {_ _} _ _.
+Global Arguments sfkind_car {_ _} _ _ _ : simpl never.
+Global Arguments sfkind_sub {_ _} _ _ _ _ : simpl never.
+
+(** Kinded, indexed subtyping *)
+Program Definition sstpk `{dlangG Σ} {n} i j Γ T1 T2 (K : sfkind Σ n) : iProp Σ :=
+  □∀ ρ, s⟦Γ⟧*ρ → sfkind_sub K ρ (envApply (oLaterN i T1) ρ) (envApply (oLaterN j T2) ρ).
+(* :: is at level 60. *)
+(* Notation "Γ s⊨k T1 , i <: T2 , j ∷ K" := (sstpk i j Γ T1 T2 K)
+  (at level 74, i, j at level 59, T1, T2, i at next level). *)
+Notation "Γ s⊨ T1 , i <: T2 , j ∷ K" := (sstpk i j Γ T1 T2 K)
+  (at level 74, i, j, T1, T2 at next level).
+
+(* XXX Should we delay [T] as well? Yes, based on [iSel_Sub]/[iSub_Sel].
+Should we delay K?*)
+(* V1: delay K and rely on swaps to make that affect all types. *)
+(* Definition sktp `{dlangG Σ} {n} i Γ T (K : sfkind Σ n) : iProp Σ :=
+  □∀ ρ, s⟦Γ⟧*ρ → ▷^i K ρ T. *)
+(* V2: push the delay down. *)
+Definition sktp `{dlangG Σ} {n} i Γ T (K : sfkind Σ n) : iProp Σ :=
+  □∀ ρ, s⟦Γ⟧*ρ → K i ρ (envApply (oLaterN i T) ρ).
+(* XXX What delays are wanted here? *)
+(* Definition ssktp `{dlangG Σ} {n} i Γ (K1 K2 : sfkind Σ n) : iProp Σ :=
+  □∀ ρ T, s⟦Γ⟧*ρ → ▷^i K1 ρ (envApply T ρ) → ▷^i K2 ρ (envApply T ρ). *)
+Definition ssktp `{dlangG Σ} {n} i Γ (K1 K2 : sfkind Σ n) : iProp Σ :=
+  □∀ ρ (T : olty Σ n), s⟦Γ⟧*ρ → K1 i ρ (envApply T ρ) → K2 i ρ (envApply T ρ).
+
+End HoSemTypes2.
+
+
+From D.Dot Require Import dot_lty unary_lr.
+Module HkDot2.
+Include HoSemTypes2 VlSorts dlang_inst dot_lty.
+
+Implicit Types (l : label) (p : path).
+
+Inductive hty : nat → Type :=
+  | hTTop : hty 0
+  | hTBot : hty 0
+  | hTAnd : hty 0 → hty 0 → hty 0
+  | hTOr : hty 0 → hty 0 → hty 0
+  | hTLater {n} : hty n → hty n
+  | hTAll (S : hty 0) (T : hty 0) : hty 0
+  | hTMu {n} (T : hty n) : hty n (* Changed *)
+  | hTVMem l (T : hty 0) : hty 0
+  | hTTMem {n} l (K : kind n) : hty n (* Changed *)
+  | hTSel n p l : hty n (* Changed *)
+  | hTPrim (B : base_ty): hty 0
+  | hTSing p : hty 0
+  (* New *)
+  | hTLam {n} (T : hty n) : hty n.+1
+  | hTApp {n} (T : hty n.+1) (p : path): hty n
+with kind : nat → Type :=
+  | kintv (L U : hty 0) : kind 0
+  | kpi {n} (S : hty 0) (K : kind n) : kind n.+1.
+
+Section semkinds.
+  Context `{dlangG Σ}.
+
+  Definition subtype {n} : srelkind Σ n := λI ρ φ1 φ2,
+    □ ∀ args v, φ1 args v → φ2 args v.
+
+  Definition skstar : skind Σ 0 := λI i ρ φ, True.
+  Definition srstar : srelkind Σ 0 := λ ρ φ1 φ2,
+    (□ ∀ v, oClose φ1 v → oClose φ2 v)%I.
+  Definition sstar : sfkind Σ 0 := Sfkind skstar srstar.
+
+  (* Show that kinded subtyping correctly generalizes the existing kind-*
+  subtyping. *)
+  Lemma sstpk_star_eq_sstp Γ i j T1 T2 :
+    Γ s⊨ T1 , i <: T2 , j ∷ sstar ⊣⊢ Γ s⊨ T1 , i <: T2 , j.
+  Proof.
+    rewrite /sstpk /sfkind_sub/= /srstar; iSplit; iIntros "/= #Hsub !>" (ρ).
+    by iIntros (v) "#Hg"; iApply ("Hsub" $! ρ with "Hg").
+    by iIntros "#Hg" (v) "!>"; iApply ("Hsub" $! ρ v with "Hg").
+  Qed.
+
+  Definition skpi {n} (φArg : olty Σ 0) (K : skind Σ n) : skind Σ (S n) :=
+    λI i ρ φ, □∀ arg, oClose φArg ρ arg → K i (arg .: ρ) (vcurry φ arg).
+  Definition srpi {n} (φArg : olty Σ 0) (Kr : srelkind Σ n) : srelkind Σ (S n) :=
+    λI ρ φ1 φ2, □∀ arg, oClose φArg ρ arg → Kr (arg .: ρ) (vcurry φ1 arg) (vcurry φ2 arg).
+  Definition spi {n} (φArg : olty Σ 0) (K : sfkind Σ n) : sfkind Σ (S n) :=
+    Sfkind (skpi φArg (sfkind_car K)) (srpi φArg (sfkind_sub K)).
+
+  Definition fold_srelkind (base : srelkind Σ 0) {n} : vec (olty Σ 0) n → srelkind Σ n :=
+    vec_fold base (@srpi) n.
+  Definition subtype_w_expKind {n}: vec (olty Σ 0) n → srelkind Σ n :=
+    fold_srelkind srstar.
+  (* Definition eqtype_w_expKind : ∀ n, vec (olty Σ 0) n → srelkind Σ n :=
+    fold_srelkind kind_star_eqtype. *)
+
+  (* The point of Sandro's kind syntax is to use this only at kind 0. *)
+  Program Definition skintv (φ1 φ2 : olty Σ 0) : skind Σ 0 := λI i ρ φ,
+    subtype ρ (envApply (oLaterN i φ1) ρ) φ
+    (* subtype ρ (envApply (oLaterN (S i) φ1) ρ) (oLater i φ). *)
+    ∧
+    (* subtype ρ (oLaterN i φ) (envApply (oLaterN (S i) φ2) ρ). *)
+    subtype ρ φ (envApply (oLaterN i φ2) ρ).
+  Definition sintv (φ1 φ2 : olty Σ 0) : sfkind Σ 0 :=
+    Sfkind (skintv φ1 φ2) srstar.
+
+  Inductive kind {Σ} : nat → Type :=
+    | kintv : olty Σ 0 → olty Σ 0 → kind 0
+    | kpi n : olty Σ 0 → kind n → kind (S n).
+  Global Arguments kind: clear implicits.
+
+  Fixpoint sem {n} (k : kind Σ n) : skind Σ n :=
+    match k with
+      | kintv φ1 φ2 => skintv φ1 φ2
+      | kpi n φ1 k' => skpi φ1 (sem k')
+    end.
+
+  (* Notice the argument type is not used here. *)
+  Inductive hoSTy {Σ} : nat → Type :=
+    | TSWrap : olty Σ 0 → hoSTy 0
+    | TSLam {n} : olty Σ 0 → hoSTy n → hoSTy (S n)
+    | TSApp {n} : hoSTy (S n) → path → hoSTy n.
+
+  Definition oLam {n} (τ : oltyO Σ n) : oltyO Σ (S n) :=
+    (* vuncurry (λ v, τ.|[v/]). *)
+    vuncurry (λ v, Olty (λ args ρ, τ args (v .: ρ))).
+    (* Olty (λ args ρ, τ (vtail args) (vhead args .: ρ)). *)
+  Lemma oLam_equiv1 {n τ} : oLam (n := n) τ ≡
+    Olty (λ args ρ, τ (vtail args) (vhead args .: ρ)).
+  Proof. done. Qed.
+
+  (* *not* equivalent! *)
+  Lemma oLam_equiv2 {n τ} : oLam (n := n) τ ≡
+    vuncurry (λ v, τ.|[v/]).
+  Proof.
+    move=> args ρ v; rewrite /= /hsubst /hsubst_hoEnvD.
+    asimpl.
+    do 3 f_equiv.
+  Abort.
+
+  Definition oTApp {n} (τ : oltyO Σ (S n)) v : olty Σ n := vcurry τ v.
+  Definition oTAppP {n} (τ : oltyO Σ (S n)) (p : path) : olty Σ n :=
+    Olty (λ args ρ v, path_wp p.|[ρ] (λ w, vcurry τ w args ρ v)).
+
+  Lemma swap_oLam_oLater {n} (τ : olty Σ n) :
+    oLater (oLam τ) ≡ oLam (oLater τ).
+  Proof. done. Qed.
+
+  Lemma swap_oTApp_oLater {n} (τ : olty Σ (S n)) v:
+    oLater (oTApp τ v) ≡ oTApp (oLater τ) v.
+  Proof. done. Qed.
+
+  Fixpoint hoSTySem {n} (T : hoSTy n): olty Σ n :=
+    match T with
+    | TSWrap φ => φ
+    | TSLam _ T => oLam (hoSTySem T)
+    | TSApp T p => oTAppP (hoSTySem T) p
+    end.
+End semkinds.
+Arguments hoSTy: clear implicits.
+End HkDot2.
+
+(* These are "bad" experiments. *)
+Module HoGenExperimnents.
+Import swap_later_impl HkDot2.
+Section sec.
+  Context `{!CTyInterp Σ}.
+  Context `{dlangG Σ} `{HswapProp: SwapPropI Σ}.
+
+  Definition srstar1 : srelkind Σ 0 := subtype.
+  Lemma srstar_eq ρ φ1 φ2 :
+    srstar1 ρ φ1 φ2 ≡ srstar ρ φ1 φ2.
+  Proof.
+    rewrite /srstar1 /srstar /subtype /vclose.
+    apply intuitionistically_proper, equiv_spec; split. by iIntros "H".
+    iIntros "H" (args). by rewrite (vec_vnil args).
+  Qed.
+
+  (* Definition skLaterN {Σ n} i (K : skind Σ n) : skind Σ n :=
+    λ ρ φ, K ρ (oLaterN i φ). *)
+  (* Definition srLaterN {Σ n} i j (K : srelkind Σ n) : srelkind Σ n :=
+    λ ρ T1 T2, K ρ (oLaterN i T1) (oLaterN j T2). *)
+  (* Definition sfLaterN {n} i (K : sfkind Σ n) : sfkind Σ n :=
+    Sfkind (skLaterN i K) K. *)
+
+  (* Definition sstpk `{dlangG Σ} {n} i j Γ τ₁ τ₂ (K : sfkind Σ n) : iProp Σ :=
+    □∀ ρ, s⟦Γ⟧*ρ → srLaterN i j (sfkind_sub K) ρ τ₁ τ₂. *)
+  (* Definition semEquiv {n} : srelkind Σ n := λI ρ (φ1 φ2 : olty Σ n),
+    □ ∀ args v, φ1 args ρ v ↔ φ2 args ρ v. *)
+  (* Definition kind_star_eqtype : srelkind Σ 0 := λ ρ φ1 φ2,
+    (□ ∀ v, oClose φ1 ρ v ↔ oClose φ2 ρ v)%I. *)
+
+
+  Definition sstpk1 {n} i Γ (T1 T2 : oltyO Σ n) (K : sfkind Σ n) : iProp Σ :=
+    □∀ ρ, s⟦Γ⟧*ρ → ▷^i sfkind_sub K ρ (envApply T1 ρ) (envApply T2 ρ).
+  Lemma sstpk1_star_eq_sstp Γ i T1 T2 :
+    sstpk1 i Γ T1 T2 sstar ⊣⊢ Γ s⊨ T1 , i <: T2 , i.
+  Proof using HswapProp.
+    rewrite /sstpk1 /sfkind_sub/= /srstar.
+    iSplit; iIntros "/= #Hsub !>" (ρ); [iIntros (v)|]; iIntros "#Hg".
+    iSpecialize ("Hsub" $! ρ with "Hg"); iSpecialize ("Hsub" $! v).
+    rewrite -mlaterN_pers laterN_impl.
+    by iApply "Hsub".
+    rewrite -mlaterN_pers; iIntros (v) "!>"; rewrite -mlaterN_impl.
+    iDestruct "Hsub" as "#Hsub".
+    iApply ("Hsub" $! ρ v with "Hg").
+  Qed.
+
+  (* Inductive kind : nat → Type :=
+    | kintv : ty → ty → kind 0
+    | kpi n : ty → kind n → kind (S n). *)
+
+
+  Inductive htype : nat → Type :=
+    | TWrap : ty → htype 0
+    | TLam {n} : olty Σ 0 → htype n → htype (S n)
+    | TApp {n} : htype (S n) → path → htype n.
+
+  Fixpoint htype_to_hosty {n} (T : htype n) : hoSTy Σ n :=
+    match T with
+    | TWrap T => TSWrap V⟦T⟧
+    | TLam φ T => TSLam φ (htype_to_hosty T)
+    | TApp T v => TSApp (htype_to_hosty T) v
+    end.
+  Definition typeSem {n} (T : htype n) : hoEnvD Σ n := hoSTySem (htype_to_hosty T).
+
+  Lemma K_App_Lam {n} (argT : olty Σ 0) (φ1 φ2: hoLtyO Σ (S n)) (K : srelkind Σ n) ρ :
+    srpi argT K ρ φ1 φ2 ⊣⊢ (□∀ v, oClose argT ρ v → K (v .: ρ) (vcurry φ1 v) (vcurry φ2 v))%I.
+  Proof. done. Qed.
+  (** XXX Need a subtyping judgment to throw in environments... *)
+
+  (* Here, we inherit eta from the metalanguage, in both directions. *)
+  (* Er, let's please carry it closer to the syntax? *)
+  Lemma eta1 {n} argT (φ : hoLtyO Σ (S n)) ρ : srpi argT subtype ρ φ (vuncurry (vcurry φ)).
+  Proof.
+    rewrite /srpi /subtype.
+    iIntros "!> * #Harg !>" (args v) "$".
+  Qed.
+
+  Lemma eta2 {n} argT (φ : hoLtyO Σ (S n)) ρ : srpi argT subtype ρ (vuncurry (vcurry φ)) φ.
+  Proof.
+    rewrite /srpi /subtype.
+    iIntros "!> * #Harg !>" (args v) "$".
+  Qed.
+
+  (* Lemma eta {n} argT (φ : olty Σ (S n)) ρ : srpi argT semEquiv ρ φ (vuncurry (vcurry φ)).
+  Proof.
+    rewrite /srpi /semEquiv.
+    iIntros "!> * #Harg !> **". rewrite -(iff_refl emp%I). done.
+  Qed. *)
+
+  Program Fixpoint sem_program {n} {struct n} : kind Σ n → skind Σ n :=
+    match n return _ with
+    | 0 => λ k, match k with
+      | kintv φ1 φ2 => skintv φ1 φ2
+      | kpi n _ _ => _
+      end
+    | S n => λ k, match k with
+      | kintv φ1 φ2 => _
+      | kpi n φ1 k' =>
+        skpi φ1 (sem_program (rew _ in k'))
+      end
+    end.
+  Next Obligation. done. Qed.
+  Next Obligation. done. Qed.
+  Next Obligation. intros. congruence. Defined.
+  (* Derive Signature NoConfusion Subterm EqDec for kind. *)
+
+  (* Derive Signature for kind.
+  Equations sem_eq {n} : kind Σ n → skind Σ n :=
+    sem_eq (kintv φ1 φ2) := skintv φ1 φ2;
+    sem_eq (kpi n φ1 k') := skpi φ1 (sem_eq k').
+
+  Lemma unfold_sem_kintv φ1 φ2: sem_eq (kintv φ1 φ2) = skintv φ1 φ2.
+  Proof. by simp sem_eq. Qed. *)
+End sec.
+End HoGenExperimnents.
+
+Module dot_experiments.
+Import HkDot2.
+(* Include TyInterpLemmas VlSorts dlang_inst.
+Export ty_interp_lemmas. *)
+
+Section sec.
+  Context `{!savedHoSemTypeG Σ} `{!dlangG Σ} `{CTyInterp Σ}.
+
+  Definition dm_to_type (d : dm) n (ψ : hoD Σ n) : iProp Σ :=
+    (∃ s σ, ⌜ d = dtysem σ s ⌝ ∧ s ↗n[ σ, n ] ψ)%I.
+  Notation "d ↗n[ n ] φ" := (dm_to_type d n φ) (at level 20).
+  Global Arguments dm_to_type: simpl never.
+
+  (* [K]'s argument must ignore [ρ]. Patch the definition of skind instead. *)
+  Notation HoLty φ := (λ args, Lty (λI v, φ args v)).
+  Definition packHoLtyO {Σ n} φ : hoLtyO Σ n := HoLty (λI args v, □ φ args v).
+
+  Definition def_interp_tmem {n} (K : skind Σ n): envPred dm Σ :=
+    (* λI ρ d, ∃ (φ : hoLtyO Σ n), d.|[ρ] ↗n[ n ] φ ∧ K 0 ρ φ. *)
+    λI ρ d, ∃ (φ : hoD Σ n), d.|[ρ] ↗n[ n ] φ ∧ K 0 ρ (packHoLtyO φ).
+  Definition def_interp_tmem_spec (φ1 φ2 : olty Σ 0) : envPred dm Σ :=
+    def_interp_tmem (skintv (oLater φ1) (oLater φ2)).
+End sec.
+
+Notation "d ↗n[ n ] φ" := (dm_to_type d n φ) (at level 20).
+End dot_experiments.

--- a/theories/misc_unused/hoInterps_bad.v
+++ b/theories/misc_unused/hoInterps_bad.v
@@ -301,24 +301,24 @@ Section sec.
     iApply (subtyping_spec with "Hsub Hg").
   Qed.
 
-  Lemma sKSub_Intv' (L1 L2 U1 U2 : olty Σ 0) Γ i :
+  Lemma sSkd_Intv' (L1 L2 U1 U2 : olty Σ 0) Γ i :
     Γ s⊨ L2, i <: L1, i -∗
     Γ s⊨ U1, i <: U2, i -∗
     Γ s⊨ sf_kintv L1 U1 <∷[ i ] sf_kintv L2 U2.
-  Proof using HswapProp. by rewrite -!sstpkD_star_eq_sstp -sKSub_Intv. Qed.
+  Proof using HswapProp. by rewrite -!sstpkD_star_eq_sstp -sSkd_Intv. Qed.
 
   Lemma sK_Star' Γ (T : olty Σ 0) i :
     Γ s⊨ T ∷[ i ] sf_star.
   Proof using HswapProp.
-    iApply sK_KSub. iApply sK_Sing.
-    iApply sKSub_Intv'; [iApply sBot_Sub | iApply sSub_Top].
+    iApply sK_Sub. iApply sK_Sing.
+    iApply sSkd_Intv'; [iApply sBot_Sub | iApply sSub_Top].
   Qed.
 
-  Lemma sKSub_Pi' {n} (S1 S2 : olty Σ 0) (K1 K2 : sf_kind Σ n) Γ i :
+  Lemma sSkd_Pi' {n} (S1 S2 : olty Σ 0) (K1 K2 : sf_kind Σ n) Γ i :
     Γ s⊨ S2, i <: S1, i -∗
     oLaterN i (shift S2) :: Γ s⊨ K1 <∷[ i ] K2 -∗
     Γ s⊨ sf_kpi S1 K1 <∷[ i ] sf_kpi S2 K2.
-  Proof using HswapProp. by rewrite -!sstpkD_star_eq_sstp -sKSub_Pi. Qed.
+  Proof using HswapProp. by rewrite -!sstpkD_star_eq_sstp -sSkd_Pi. Qed.
 
   Lemma sSubK_Refl' Γ {n} T (K : s_kind Σ n) :
     let sfK := s_kind_to_sf_kind K in

--- a/theories/misc_unused/hoInterps_experiments.v
+++ b/theories/misc_unused/hoInterps_experiments.v
@@ -188,23 +188,13 @@ Section kinds_types.
 
   Program Definition sf_kpi {n} (S : olty Σ 0) (K : sf_kind Σ n) : sf_kind Σ n.+1 :=
     SfKind
-      (* (SpKind (λI ρ φ,
-        □∀ arg, S vnil ρ arg →
-        sf_kind_car K (arg .: ρ) (vcurry φ arg))) *)
       (SrKind (λI ρ φ1 φ2,
         □∀ arg, S vnil ρ arg →
         K (arg .: ρ) (vcurry φ1 arg) (vcurry φ2 arg))) _ _ _ _ _.
-  (* Next Obligation.
-    move=> n S K ρ m T1 T2 HT /=.
-    have ?: ∀ ρ, NonExpansive (sf_kind_car K ρ) by apply sf_kind_car_ne.
-    (* f_equiv; f_equiv => ?; *) solve_proper_ho.
-  Qed. *)
   Next Obligation.
     move=> n S K ρ m T1 T2 HT U1 U2 HU /=.
-    (* have Hne: ∀ ρ, NonExpansive2 (sf_kind_sub K ρ) by apply sf_kind_sub_ne. *)
     f_equiv; f_equiv => ?; f_equiv.
     by apply sf_kind_sub_ne; f_equiv.
-    (* apply Hne; by f_equiv. *)
   Qed.
   Next Obligation.
     iIntros "* #Heq /="; iSplit; iIntros "#HT !> * #HS";
@@ -212,10 +202,6 @@ Section kinds_types.
       iApply (sf_kind_sub_internal_proper with "[] HT");
       iIntros "!> *"; first iApply and_comm; iApply "Heq".
   Qed.
-  (* Next Obligation.
-    iIntros "* #H !>" (arg) "#Harg".
-    iApply (sf_kind_sub_refl with "(H Harg)").
-  Qed. *)
   Next Obligation.
     iIntros "* #H1 #H2 !>" (arg) "#Harg".
     iApply (sf_kind_sub_trans with "(H1 Harg) (H2 Harg)").
@@ -288,7 +274,6 @@ Section gen_lemmas.
   Local Notation IntoPersistent' P := (IntoPersistent false P P).
 
   Global Instance sstpkD_persistent : IntoPersistent' (sstpkD (n := n) i Γ T1 T2 K) | 0 := _.
-  (* Global Instance sktp_persistent `{!dlangG Σ} : IntoPersistent' (sktp (n := n) i Γ T K) | 0 := _. *)
   Global Instance ssktp_persistent : IntoPersistent' (ssktp (n := n) i Γ K1 K2) | 0 := _.
   Global Instance subtype_lty_persistent : IntoPersistent' (T1 ⊆@{Σ} T2) | 0 := _.
 
@@ -383,11 +368,6 @@ Section gen_lemmas.
     Γ s⊨ oLam T ∷[i] sf_kpi S K.
   Proof using HswapProp. apply sKStp_Lam. Qed.
 
-    (* rewrite /vcurry /envApply/flip/oLam/Olty/vhead/vcons/=.
-    by iApply "HTK".
-    case: (oLam T).
-    /iPPred_car/=.
-    by iApply "HTK". *)
   (** * Subkinding *)
   Lemma sSkd_Intv (L1 L2 U1 U2 : olty Σ 0) Γ i :
     Γ s⊨ L2 <:[ i ] L1 ∷ sf_star -∗
@@ -472,29 +452,16 @@ Section gen_lemmas.
   Qed.
   Global Instance: Params (@sstpkD) 4 := {}.
 
-  (* Replace by a Proper instance. *)
-  (* Lemma sKStp_Refl_Aux {n} Γ T1 T2 (K : sf_kind Σ n) i :
-    T1 ≡ T2 →
-    Γ s⊨ T1 ∷[i] K -∗
-    Γ s⊨ T1 <:[i] T2 ∷ K.
-  Proof. intros ->. apply sKStp_Refl. Qed. *)
-
   Lemma sKEq_Refl {n} Γ T1 T2 (K : sf_kind Σ n) i :
     T1 ≡ T2 →
     Γ s⊨ T1 ∷[i] K -∗
     Γ s⊨ T1 =[i] T2 ∷ K.
-  Proof.
-    (* intros <-; iIntros "$".  *)
-    iIntros (Heq) "#H"; by iSplit; iApply (Proper_sstpkD with "H").
-  Qed.
+  Proof. iIntros (Heq) "#H"; by iSplit; iApply (Proper_sstpkD with "H"). Qed.
 
   Lemma sKEq_Eta {n} Γ S T (K : sf_kind Σ n) i :
     Γ s⊨ T ∷[i] sf_kpi S K -∗
     Γ s⊨ T =[i] oLam (oTAppV (oShift T) (ids 0)) ∷ sf_kpi S K.
-  Proof.
-    iApply sKEq_Refl => + ρ v /=; apply: vec_S_inv => w args.
-    autosubst.
-  Qed.
+  Proof. iApply sKEq_Refl => + ρ v; apply: vec_S_inv => w args. autosubst. Qed.
 
   Lemma sKStp_Trans Γ {n} T1 T2 T3 (K : s_kind Σ n) i :
     Γ s⊨ T1 <:[ i ] T2 ∷ K -∗
@@ -664,37 +631,10 @@ Section dot_types.
     by rewrite (alias_paths_elim_eq _ Hal) path_wp_pv_eq.
   Qed.
 
-    (* rewrite /oTAppV/envApply/flip.
-    iApply (Proper_sfkind).
-    cbn.
-
-    iApply (Proper_sfkind with "HTK").
-    iS
-    rewrite -mlaterN_pers -impl_laterN.
-    iIntros "!> Hs".
-    iSpecialize ("HTK" $! (arg .: ρ) with "[$Hg $Hs]").
-    by iApply (Proper_sfkind with "HTK").
-  Qed. *)
-
   (* XXX argh. *)
   (* Definition kind_path_subst {n} p q (K1 K2 : sf_kind Σ n) : iProp Σ :=
     ∀ (H : alias_paths p q) ρ T1 T2,
-    K1 ρ T1 T2 ≡ K2 ρ T1 T2 .
-
-  Lemma sKStp_App Γ {n} (K1 K2 : sf_kind Σ n) S T i p :
-    Γ s⊨ T ∷[i] sf_kpi S K1 -∗
-    Γ s⊨p p : S, i -∗
-    Γ s⊨ oTAppV T v ∷[i] K2.
-  Proof.
-    iIntros "#HTK #Hv !> * #Hg".
-    rewrite kSubstOne_eq /=.
-    iSpecialize ("HTK" with "Hg"); iSpecialize ("Hv" with "Hg").
-    rewrite path_wp_pv_eq /=; iNext i.
-    iSpecialize ("HTK" with "Hv").
-    (* iEval rewrite /sf_kind_sub/=.
-    iApply ("HTK"). *)
-    by iApply (Proper_sfkind with "HTK").
-  Qed. *)
+    K1 ρ T1 T2 ≡ K2 ρ T1 T2 . *)
 
 
 

--- a/theories/misc_unused/hoInterps_experiments.v
+++ b/theories/misc_unused/hoInterps_experiments.v
@@ -6,6 +6,7 @@ From iris.base_logic Require Import lib.saved_prop.
 From D Require Import iris_prelude.
 From D Require Import saved_interp_dep asubst_intf asubst_base dlang lty.
 From D Require Import swap_later_impl.
+From D.Dot Require dot_lty unary_lr.
 
 Import EqNotations.
 
@@ -44,49 +45,161 @@ Definition hoLtyO Σ n := vec vl n -d> ltyO Σ.
 Definition envApply {Σ n} : oltyO Σ n → env → hoLtyO Σ n :=
   λ T, flip T.
 
-Definition oCurry {n} {A : ofeT} (Φ : vec vl (S n) → A) :
+Definition oCurry {n} {A : ofeT} (Φ : vec vl n.+1 → A) :
   vl -d> vec vl n -d> A := vcurry Φ.
 
 Definition oUncurry {n} {A : ofeT} (Φ : vl → vec vl n → A) :
-  vec vl (S n) -d> A := vuncurry Φ.
+  vec vl n.+1 -d> A := vuncurry Φ.
 Definition oLaterN {Σ n} i (τ : olty Σ n) := Olty (eLater i τ).
 
-Inductive skind {Σ} : nat → Type :=
-  | skintv : olty Σ 0 → olty Σ 0 → skind 0
-  | skpi n : olty Σ 0 → skind n → skind (S n).
-Global Arguments skind: clear implicits.
+(** An inductive representation of gHkDOT semantic kinds. *)
+Inductive s_kind {Σ} : nat → Type :=
+  | s_kintv : olty Σ 0 → olty Σ 0 → s_kind 0
+  | s_kpi n : olty Σ 0 → s_kind n → s_kind n.+1.
+Global Arguments s_kind: clear implicits.
 
-Record spine_skind {Σ} {n : nat} : Type := SpineSK {
+(** Alternative inductive representation of gHkDOT semantic kinds. *)
+Record spine_s_kind {Σ} {n : nat} : Type := SpineSK {
   spine_kargs : vec (olty Σ 0) n;
   spine_L : olty Σ 0;
   spine_U : olty Σ 0;
 }.
-Arguments spine_skind : clear implicits.
+Arguments spine_s_kind : clear implicits.
 
-Section saved_ho_sem_type_extra.
+(** Semantic kinds can be interpreted into predicates. *)
+(** Semantic Kinds as unary Predicates. *)
+Notation sp_kind Σ n := (env → hoLty Σ n → iProp Σ).
+(** Semantic Kinds as relations. *)
+Notation sr_kind Σ n := (env → hoLtyO Σ n → hoLtyO Σ n → iProp Σ).
+
+Notation iRel P Σ := (P Σ → P Σ → iProp Σ).
+Definition subtype_lty {Σ} : iRel ltyO Σ := λI φ1 φ2,
+  □ ∀ v, φ1 v → φ2 v.
+
+Infix "⊆" := subtype_lty : bi_scope.
+Notation "X ⊆ Y ⊆ Z" := (X ⊆ Y ∧ Y ⊆ Z)%I : bi_scope.
+Notation "X ⊆ Y ⊆ Z ⊆ W" := (X ⊆ Y ∧ Y ⊆ Z ∧ Z ⊆ W)%I (at level 70, Y, Z at next level) : bi_scope.
+
+(** Semantic Full Kind. *)
+Record sf_kind {Σ n} := Sfkind {
+  sf_kind_car :> sp_kind Σ n;
+  sf_kind_sub : sr_kind Σ n;
+}.
+Global Arguments sf_kind : clear implicits.
+Global Arguments sf_kind_car : simpl never.
+Global Arguments sf_kind_sub : simpl never.
+
+Section kinds_types.
   Context {Σ}.
 
-  Definition sp_skintv (L U : olty Σ 0) : spine_skind Σ 0 := SpineSK vnil L U.
-  Definition sp_skpi {n} (S : olty Σ 0) (K : spine_skind Σ n) : spine_skind Σ n.+1 :=
+  Definition sp_intv (L U : olty Σ 0) : spine_s_kind Σ 0 := SpineSK vnil L U.
+  Definition sp_pi {n} (S : olty Σ 0) (K : spine_s_kind Σ n) : spine_s_kind Σ n.+1 :=
     SpineSK (vcons S (spine_kargs K)) (spine_L K) (spine_U K).
 
-  Fixpoint skind_to_spine_skind {n} (K : skind Σ n) : spine_skind Σ n :=
+  Definition sf_intv (L U : olty Σ 0) : sf_kind Σ 0 :=
+    Sfkind
+      (λI ρ φ,
+        oClose L ρ ⊆ oClose φ ⊆ oClose U ρ)
+      (λI ρ φ1 φ2,
+        oClose L ρ ⊆ oClose φ1 ⊆ oClose φ2 ⊆ oClose U ρ).
+
+  Definition sf_pi {n} (S : olty Σ 0) (K : sf_kind Σ n) : sf_kind Σ n.+1 :=
+    Sfkind
+      (λI ρ φ,
+        □∀ arg, oClose S ρ arg →
+        sf_kind_car K (arg .: ρ) (vcurry φ arg))
+      (λI ρ φ1 φ2,
+        □∀ arg, oClose S ρ arg →
+        sf_kind_sub K (arg .: ρ) (vcurry φ1 arg) (vcurry φ2 arg)).
+
+
+  Definition sf_star : sf_kind Σ 0 := sf_intv oBot oTop.
+
+  Fixpoint s_kind_to_spine_s_kind {n} (K : s_kind Σ n) : spine_s_kind Σ n :=
     match K with
-    | skintv L U => sp_skintv L U
-    | skpi s K => sp_skpi s (skind_to_spine_skind K)
+    | s_kintv L U => sp_intv L U
+    | s_kpi s K => sp_pi s (s_kind_to_spine_s_kind K)
     end.
 
-End saved_ho_sem_type_extra.
+  Definition spine_s_kind_to_sf_kind {n} (K : spine_s_kind Σ n) : sf_kind Σ n :=
+    vec_fold (sf_intv (spine_L K) (spine_U K)) (@sf_pi) n (spine_kargs K).
+  Global Arguments spine_s_kind_to_sf_kind {_} !_.
+
+  Fixpoint s_kind_to_sf_kind {n} (K : s_kind Σ n) : sf_kind Σ n :=
+    match K with
+    | s_kintv L U => sf_intv L U
+    | s_kpi s K => sf_pi s (s_kind_to_sf_kind K)
+    end.
+
+  Lemma s_kind_refl {n} (K : s_kind Σ n) T (ρ : env) :
+    let sfK := s_kind_to_sf_kind K in
+    sfK ρ T -∗ sf_kind_sub sfK ρ T T.
+  Proof.
+    elim: n ρ K T => [|n IHn] ρ; cbn.
+    - move E: 0 => n K T. destruct K eqn:?; simplify_eq.
+      by iIntros "($&$) !>" (v) "$".
+    - move E: n.+1 => m K T.
+      (* case E': K T E => [|m S K'].
+      case: K T E. admit. *)
+      destruct K as [|m S K'] eqn:?; simplify_eq/=.
+      iIntros "#H !>" (arg) "#Harg".
+      iApply IHn.
+      iApply ("H" with "Harg").
+  Qed.
+
+  Definition oLam {n} (τ : oltyO Σ n) : oltyO Σ n.+1 :=
+    Olty (λ args ρ, τ (vtail args) (vhead args .: ρ)).
+    (* vuncurry (λ v, Olty (λ args ρ, τ args (v .: ρ))). *)
+  Definition oTAppV {n} (τ : oltyO Σ n.+1) v : olty Σ n := vcurry τ v.
+
+  Lemma swap_oLam_oLater {n} (τ : olty Σ n) :
+    oLater (oLam τ) ≡ oLam (oLater τ).
+  Proof. done. Qed.
+
+  Lemma swap_oTApp_oLater {n} (τ : olty Σ (S n)) v:
+    oLater (oTAppV τ v) ≡ oTAppV (oLater τ) v.
+  Proof. done. Qed.
+
+End kinds_types.
+
+(** Kinded, indexed subtyping *)
+Program Definition sstpk `{!dlangG Σ} {n} i j Γ T1 T2 (K : sf_kind Σ n) : iProp Σ :=
+  □∀ ρ, s⟦Γ⟧*ρ → sf_kind_sub K ρ (envApply (oLaterN i T1) ρ) (envApply (oLaterN j T2) ρ).
+Notation "Γ s⊨ T1 , i <: T2 , j ∷ K" := (sstpk i j Γ T1 T2 K)
+  (at level 74, i, j, T1, T2, K at next level).
+Definition sktp `{!dlangG Σ} {n} i Γ T (K : sf_kind Σ n) : iProp Σ :=
+  □∀ ρ, s⟦Γ⟧*ρ → ▷^i K ρ T.
+Notation "Γ s⊨ T ∷[ i ] K" := (sktp i Γ T K)
+  (at level 74, T, K at next level).
+Definition ssktp `{!dlangG Σ} {n} i Γ (K1 K2 : sf_kind Σ n) : iProp Σ :=
+  □∀ ρ (T : olty Σ n), s⟦Γ⟧*ρ → ▷^i (K1 ρ (envApply T ρ) → K2 ρ (envApply T ρ)).
+Notation "Γ s⊨ K1 <∷[ i ] K2" := (ssktp i Γ K1 K2)
+  (at level 74, K1, K2 at next level).
+
 End HoSemTypes.
 
-From D.Dot Require Import dot_lty unary_lr.
-
+Module HkDot.
+Import dot_lty unary_lr.
+Include HoSemTypes VlSorts dlang_inst dot_lty.
 Implicit Types
          (v w : vl) (e : tm) (d : dm) (ds : dms) (p : path)
-         (vs : vls) (ρ : var → vl) (l : label).
+         (ρ : var → vl) (l : label).
 
-Module HkDot.
-Include HoSemTypes VlSorts dlang_inst dot_lty.
+Section dot_types.
+  Context `{dlangG Σ} `{HswapProp: SwapPropI Σ}.
 
+  Lemma sstpk_star_eq_sstp Γ i j T1 T2 :
+    Γ s⊨ T1 , i <: T2 , j ∷ sf_star ⊣⊢ Γ s⊨ T1 , i <: T2 , j.
+  Proof.
+    rewrite /sstpk /sf_kind_sub/= /sf_star; iSplit; iIntros "/= #Hsub !>" (ρ).
+    iIntros (v) "#Hg".
+    by iDestruct ("Hsub" $! ρ with "Hg") as "{Hsub} (_ & #Hsub &_)"; iApply ("Hsub" $! v).
+    iIntros "#Hg"; repeat iSplit; iIntros "!>" (v); [iIntros "[]" | | iIntros "_ //"].
+    by iApply ("Hsub" $! ρ v with "Hg").
+  Qed.
+
+  Definition oTApp {n} (τ : oltyO Σ n.+1) (p : path) : olty Σ n :=
+    Olty (λ args ρ v, path_wp p.|[ρ] (λ w, vcurry τ w args ρ v)).
+End dot_types.
 End HkDot.
 

--- a/theories/misc_unused/hoInterps_experiments.v
+++ b/theories/misc_unused/hoInterps_experiments.v
@@ -713,19 +713,18 @@ Section dot_types.
   apply. Qed. *)
 
   Lemma sfkind_respects {n} (K : sf_kind Σ n) ρ (T1 T2 : hoLtyO Σ n) :
-    (∀ args v, T1 args v ↔ T2 args v) ⊢@{iPropI Σ} K ρ T1 T1 -∗ K ρ T2 T2.
+    (□ ∀ args v, T1 args v ↔ T2 args v) ⊢@{iPropI Σ} K ρ T1 T1 -∗ K ρ T2 T2.
   Proof.
     (* repeat setoid_rewrite <-bi.discrete_fun_equivI.  *)
   Admitted.
 
-  (* Lemma sK_Sel {Γ n} l (K : s_kind Σ n) v i : *)
-  Lemma sK_Sel {Γ n} l (K : sf_kind Σ n) v i :
+  Lemma sK_SelV {Γ n} l (K : sf_kind Σ n) v i :
     Γ s⊨p pv v : cTMemK l K, i -∗
     Γ s⊨ oSel n (pv v) l ∷[i] K.
   Proof.
     iIntros "#Hp !> * #Hg"; iSpecialize ("Hp" with "Hg"); iNext i.
-    rewrite /= path_wp_pv_eq /=; iDestruct "Hp" as (d Hl ψ) "[Hl HK]".
-    iApply (sfkind_respects with "[] HK"); iIntros (args w).
+    rewrite path_wp_pv_eq /=; iDestruct "Hp" as (d Hl ψ) "[Hl HK]".
+    iApply (sfkind_respects with "[] HK"); iIntros (args w) "!>".
     rewrite /= path_wp_pv_eq.
     iSplit; first by iIntros "H"; iExists ψ, d; iFrame (Hl) "Hl".
     iDestruct 1 as (ψ' ?d Hl') "[Hl' Hw]"; objLookupDet.

--- a/theories/misc_unused/hoInterps_experiments.v
+++ b/theories/misc_unused/hoInterps_experiments.v
@@ -247,8 +247,6 @@ Section kinds_types.
 
 End kinds_types.
 
-Coercion s_kind_to_sf_kind : s_kind >-> sf_kind.
-
 (** Kinded, indexed subtyping *)
 Program Definition sstpkD `{!dlangG Σ} {n} i Γ T1 T2 (K : sf_kind Σ n) : iProp Σ :=
   □∀ ρ, s⟦Γ⟧*ρ → ▷^i K ρ (envApply T1 ρ) (envApply T2 ρ).
@@ -463,7 +461,7 @@ Section gen_lemmas.
     Γ s⊨ T =[i] oLam (oTAppV (oShift T) (ids 0)) ∷ sf_kpi S K.
   Proof. iApply sKEq_Refl => + ρ v; apply: vec_S_inv => w args. autosubst. Qed.
 
-  Lemma sKStp_Trans Γ {n} T1 T2 T3 (K : s_kind Σ n) i :
+  Lemma sKStp_Trans Γ {n} T1 T2 T3 (K : sf_kind Σ n) i :
     Γ s⊨ T1 <:[ i ] T2 ∷ K -∗
     Γ s⊨ T2 <:[ i ] T3 ∷ K -∗
     Γ s⊨ T1 <:[ i ] T3 ∷ K.
@@ -669,7 +667,7 @@ Section dot_types.
   (** Here [n]'s argument to oSel should be explicit. *)
   Global Arguments oSel {_ _} n p l args ρ : rename.
 
-  Lemma sKStp_TMem {n} Γ l (K1 K2 : s_kind Σ n) i :
+  Lemma sKStp_TMem {n} Γ l (K1 K2 : sf_kind Σ n) i :
     Γ s⊨ K1 <∷[ i ] K2 -∗
     Γ s⊨ cTMemK l K1 <:[ i ] cTMemK l K2 ∷ sf_star.
   Proof using HswapProp.

--- a/theories/misc_unused/hoInterps_experiments.v
+++ b/theories/misc_unused/hoInterps_experiments.v
@@ -297,13 +297,14 @@ Section gen_lemmas.
     iIntros "#Hsub !>" (ρ). rewrite -sr_kintv_refl /sp_kintv /=. iApply "Hsub".
   Qed.
 
+  (** * Prefixes: K for Kinding, KStp for kinded subtyping, Skd for subkinding. *)
   Lemma sK_Sing Γ (T : olty Σ 0) i :
     Γ s⊨ T ∷[ i ] sf_kintv T T.
   Proof.
     rewrite -kinding_intro; iIntros "!>" (ρ) "_". by rewrite -subtype_refl.
   Qed.
 
-  Lemma sSK_KSub Γ {n} (T1 T2 : olty Σ n) (K1 K2 : sf_kind Σ n) i :
+  Lemma sKStp_Sub Γ {n} (T1 T2 : olty Σ n) (K1 K2 : sf_kind Σ n) i :
     Γ s⊨ T1 <:[ i ] T2 ∷ K1 -∗
     Γ s⊨ K1 <∷[ i ] K2 -∗
     Γ s⊨ T1 <:[ i ] T2 ∷ K2.
@@ -311,19 +312,19 @@ Section gen_lemmas.
     iIntros "#H1 #Hsub !>" (ρ) "#Hg". iApply ("Hsub" with "Hg (H1 Hg)").
   Qed.
 
-  Lemma sK_KSub Γ {n} (T : olty Σ n) (K1 K2 : sf_kind Σ n) i :
+  Lemma sK_Sub Γ {n} (T : olty Σ n) (K1 K2 : sf_kind Σ n) i :
     Γ s⊨ T ∷[ i ] K1 -∗
     Γ s⊨ K1 <∷[ i ] K2 -∗
     Γ s⊨ T ∷[ i ] K2.
-  Proof. apply sSK_KSub. Qed.
+  Proof. apply sKStp_Sub. Qed.
 
   Definition oShift {n} (T : oltyO Σ n) :=
     Olty (λ args ρ v, T args (stail ρ) v).
   Lemma oShift_eq {n} (T : oltyO Σ n) : oShift T ≡ shift T.
   Proof. move=>args ρ v /=. by rewrite (hoEnvD_weaken_one _ _ _ v). Qed.
 
-  (* XXX: Prefixes: Rename Sub to STyp, and use SKd for subkinding rather than SK? *)
-  Lemma sSK_Lam Γ {n} (K : sf_kind Σ n) S T1 T2 i :
+  (* XXX: Prefixes: Rename Sub to STyp *)
+  Lemma sKStp_Lam Γ {n} (K : sf_kind Σ n) S T1 T2 i :
     oLaterN i (oShift S) :: Γ s⊨ T1 <:[i] T2 ∷ K -∗
     Γ s⊨ oLam T1 <:[i] oLam T2 ∷ sf_kpi S K.
   Proof using HswapProp.
@@ -337,7 +338,7 @@ Section gen_lemmas.
   Lemma sK_Lam Γ {n} (K : sf_kind Σ n) S T i :
     oLaterN i (oShift S) :: Γ s⊨ T ∷[i] K -∗
     Γ s⊨ oLam T ∷[i] sf_kpi S K.
-  Proof using HswapProp. apply sSK_Lam. Qed.
+  Proof using HswapProp. apply sKStp_Lam. Qed.
 
     (* rewrite /vcurry /envApply/flip/oLam/Olty/vhead/vcons/=.
     by iApply "HTK".
@@ -345,7 +346,7 @@ Section gen_lemmas.
     /iPPred_car/=.
     by iApply "HTK". *)
   (** * Subkinding *)
-  Lemma sKSub_Intv (L1 L2 U1 U2 : olty Σ 0) Γ i :
+  Lemma sSkd_Intv (L1 L2 U1 U2 : olty Σ 0) Γ i :
     Γ s⊨ L2 <:[ i ] L1 ∷ sf_star -∗
     Γ s⊨ U1 <:[ i ] U2 ∷ sf_star -∗
     Γ s⊨ sf_kintv L1 U1 <∷[ i ] sf_kintv L2 U2.
@@ -358,7 +359,7 @@ Section gen_lemmas.
     iApply (subtype_trans with "HsubU1 HsubU").
   Qed.
 
-  Lemma sKSub_Pi {n} (S1 S2 : olty Σ 0) (K1 K2 : sf_kind Σ n) Γ i :
+  Lemma sSkd_Pi {n} (S1 S2 : olty Σ 0) (K1 K2 : sf_kind Σ n) Γ i :
     Γ s⊨ S2 <:[ i ] S1 ∷ sf_star -∗
     oLaterN i (oShift S2) :: Γ s⊨ K1 <∷[ i ] K2 -∗
     Γ s⊨ sf_kpi S1 K1 <∷[ i ] sf_kpi S2 K2.
@@ -380,14 +381,14 @@ Section gen_lemmas.
 
   (** Reflexivity and transitivity of subkinding seem admissible, but let's
   prove them anyway, to show they hold regardless of extensions. *)
-  Lemma sKSub_Refl {n} Γ i (K : sf_kind Σ n) :
+  Lemma sSkd_Refl {n} Γ i (K : sf_kind Σ n) :
     Γ s⊨ K <∷[ i ] K.
   Proof using HswapProp.
     rewrite /ssktp; setoid_rewrite <-(impl_laterN _).
     iIntros "!> * Hg * $".
   Qed.
 
-  Lemma sKSub_Trans {n} Γ i (K1 K2 K3 : sf_kind Σ n) :
+  Lemma sSkd_Trans {n} Γ i (K1 K2 K3 : sf_kind Σ n) :
     Γ s⊨ K1 <∷[ i ] K2 -∗
     Γ s⊨ K2 <∷[ i ] K3 -∗
     Γ s⊨ K1 <∷[ i ] K3.
@@ -475,7 +476,7 @@ Section dot_types.
   Lemma kSubstOne_eq {n} (K : sf_kind Σ n) v ρ : sf_kind_sub K.|[v/] ρ = kSubstOne v K ρ.
   Proof. by rewrite /sf_kind_sub/= subst_swap_base. Qed.
 
-  Lemma sSK_AppV Γ {n} (K : sf_kind Σ n) S T1 T2 i v :
+  Lemma sKStp_AppV Γ {n} (K : sf_kind Σ n) S T1 T2 i v :
     Γ s⊨ T1 <:[i] T2 ∷ sf_kpi S K -∗
     Γ s⊨p pv v : S, i -∗
     Γ s⊨ oTAppV T1 v <:[i] oTAppV T2 v ∷ K.|[v/].
@@ -490,7 +491,7 @@ Section dot_types.
     Γ s⊨ T ∷[i] sf_kpi S K -∗
     Γ s⊨p pv v : S, i -∗
     Γ s⊨ oTAppV T v ∷[i] K.|[v/].
-  Proof. apply sSK_AppV. Qed.
+  Proof. apply sKStp_AppV. Qed.
 
   Definition oTApp {n} (T : oltyO Σ n.+1) (p : path) : oltyO Σ n :=
     Olty (λ args ρ v, path_wp p.|[ρ] (λ w, T (vcons w args) ρ v)).
@@ -604,7 +605,7 @@ Section dot_types.
   Lemma sK_Star Γ (T : olty Σ 0) i :
     Γ s⊨ T ∷[ i ] sf_star.
   Proof using HswapProp.
-    iApply sK_KSub. iApply sK_Sing. iApply sKSub_Intv; rewrite sstpkD_star_eq_sstp.
+    iApply sK_Sub. iApply sK_Sing. iApply sSkd_Intv; rewrite sstpkD_star_eq_sstp.
     by iApply sBot_Sub.
     by iApply sSub_Top.
   Qed.

--- a/theories/misc_unused/hoInterps_experiments.v
+++ b/theories/misc_unused/hoInterps_experiments.v
@@ -126,6 +126,7 @@ Proof. apply Proper_sfkind. Qed.
 
 Global Instance vcurry_ne vl n A m : Proper (dist m ==> (=) ==> dist m) (@vcurry vl n A).
 Proof. solve_proper_ho. Qed.
+Add Printing Constructor iPPred.
 
 Section kinds_types.
   Context {Σ}.
@@ -258,7 +259,6 @@ Notation "Γ s⊨ K1 <∷[ i  ] K2" := (ssktp i Γ K1 K2)
   (at level 74, K1, K2 at next level).
 
 (* XXX *)
-Add Printing Constructor iPPred.
 Section gen_lemmas.
   Context `{dlangG Σ} `{HswapProp: SwapPropI Σ}.
 

--- a/theories/misc_unused/hoInterps_experiments.v
+++ b/theories/misc_unused/hoInterps_experiments.v
@@ -718,16 +718,17 @@ Section dot_types.
     (* repeat setoid_rewrite <-bi.discrete_fun_equivI.  *)
   Admitted.
 
-  Lemma sK_SelV {Γ n} l (K : sf_kind Σ n) v i :
-    Γ s⊨p pv v : cTMemK l K, i -∗
-    Γ s⊨ oSel n (pv v) l ∷[i] K.
+  Lemma sK_Sel {Γ n} l (K : sf_kind Σ n) p i :
+    Γ s⊨p p : cTMemK l K, i -∗
+    Γ s⊨ oSel n p l ∷[i] K.
   Proof.
     iIntros "#Hp !> * #Hg"; iSpecialize ("Hp" with "Hg"); iNext i.
-    rewrite path_wp_pv_eq /=; iDestruct "Hp" as (d Hl ψ) "[Hl HK]".
-    iApply (sfkind_respects with "[] HK"); iIntros (args w) "!>".
-    rewrite /= path_wp_pv_eq.
-    iSplit; first by iIntros "H"; iExists ψ, d; iFrame (Hl) "Hl".
-    iDestruct 1 as (ψ' ?d Hl') "[Hl' Hw]"; objLookupDet.
+    rewrite path_wp_eq /=; iDestruct "Hp" as (v Hal d Hl ψ) "[Hl HK] {Hg}".
+    iApply (sfkind_respects with "[] HK"); iIntros (args w) "!> {HK}".
+    rewrite /= path_wp_eq; iSplit. { iIntros "H"; iExists v; iFrame (Hal).
+      by iExists ψ, d; iFrame (Hl) "Hl". }
+    iDestruct 1 as (v' Hal' ψ' ?d Hl') "[Hl' Hw]".
+    have ? := path_wp_pure_det Hal Hal'; subst v'; objLookupDet.
     iDestruct (dm_to_type_agree args w with "Hl Hl'") as "Hag".
     iNext. by iRewrite "Hag".
   Qed.

--- a/theories/misc_unused/hoInterps_experiments.v
+++ b/theories/misc_unused/hoInterps_experiments.v
@@ -109,6 +109,7 @@ Global Arguments sf_kind : clear implicits.
 Global Arguments sf_kind_sub {_ _} !_ /.
 Add Printing Constructor sf_kind.
 Global Arguments SfKind {_ _} _.
+Global Instance: Params (@sf_kind_sub) 4 := {}.
 
 (* This is really properness of sf_kind_sub; but it's also proper over the
 first argument K. Maybe that's worth a wrapper with swapped arguments. *)
@@ -600,10 +601,9 @@ Section dot_types.
   Definition oTApp {n} (T : oltyO Σ n.+1) (p : path) : oltyO Σ n :=
     Olty (λ args ρ v, path_wp p.|[ρ] (λ w, T (vcons w args) ρ v)).
   Lemma oTApp_pv {n} (T : oltyO Σ n.+1) w :
-    oTApp T (pv w) ≡ oTAppV T w .
+    oTApp T (pv w) ≡ oTAppV T w.
   Proof. intros ???. by rewrite /= path_wp_pv_eq. Qed.
 
-  Global Instance: Params (@sf_kind_sub) 4 := {}.
   (** XXX Copy-paste of sKStp_AppV, plus hacks for missing Proper instances I guess? *)
   Lemma sKStp_App Γ {n} (K : sf_kind Σ n) S T1 T2 i v :
     Γ s⊨ T1 <:[i] T2 ∷ sf_kpi S K -∗
@@ -726,6 +726,7 @@ Section dot_types.
     by rewrite -(Hγφ args ρ v) make_intuitionistically.
   Qed.
   Lemma lift_olty_eq subj {τ1 τ2 : iPPred subj Σ} :
+    (* (iPPred_car τ1 ≡@{subj -d> _} iPPred_car τ2) ⊢@{iPropI Σ} τ1 ≡ τ2. *)
     (sbi_internal_eq (A := subj -d> _) (iPPred_car τ1) (iPPred_car τ2)) ⊢@{iPropI Σ} τ1 ≡ τ2.
   Proof. by uPred.unseal. Qed.
     (* iIntros "H".

--- a/theories/misc_unused/hoInterps_experiments.v
+++ b/theories/misc_unused/hoInterps_experiments.v
@@ -712,7 +712,7 @@ Section dot_types.
     iApply internal_eq_rewrite. ∗.
   apply. Qed. *)
 
-  Global Lemma sfkind_respects {n} (K : sf_kind Σ n) ρ (T1 T2 : hoLtyO Σ n) :
+  Lemma sfkind_respects {n} (K : sf_kind Σ n) ρ (T1 T2 : hoLtyO Σ n) :
     (∀ args v, T1 args v ↔ T2 args v) ⊢@{iPropI Σ} K ρ T1 T1 -∗ K ρ T2 T2.
   Proof.
     (* repeat setoid_rewrite <-bi.discrete_fun_equivI.  *)

--- a/theories/misc_unused/hoInterps_experiments.v
+++ b/theories/misc_unused/hoInterps_experiments.v
@@ -118,13 +118,13 @@ Section kinds_types.
   Definition sp_kpi {n} (S : olty Σ 0) (K : spine_s_kind Σ n) : spine_s_kind Σ n.+1 :=
     SpineSK (vcons S (spine_kargs K)) (spine_L K) (spine_U K).
 
-  Program Definition sf_kintv (L U : olty Σ 0) : sf_kind Σ 0 :=
+  Definition sf_kintv (L U : olty Σ 0) : sf_kind Σ 0 :=
     SfKind
       (SpKind (λI ρ φ,
         oClose L ρ ⊆ oClose φ ⊆ oClose U ρ))
       (SrKind (λI ρ φ1 φ2,
-        oClose L ρ ⊆ oClose φ1 ⊆ oClose φ2 ⊆ oClose U ρ)) _ _.
-  Solve All Obligations with solve_proper_ho.
+        oClose L ρ ⊆ oClose φ1 ⊆ oClose φ2 ⊆ oClose U ρ))
+        ltac:(solve_proper_ho) ltac:(solve_proper_ho).
 
   Program Definition sf_kpi {n} (S : olty Σ 0) (K : sf_kind Σ n) : sf_kind Σ n.+1 :=
     SfKind

--- a/theories/misc_unused/hoInterps_experiments.v
+++ b/theories/misc_unused/hoInterps_experiments.v
@@ -307,6 +307,14 @@ Section gen_lemmas.
     rewrite -kinding_intro; iIntros "!>" (ρ) "_". by rewrite -subtype_refl.
   Qed.
 
+  Lemma sKStp_Intv Γ (T1 T2 L U : olty Σ 0) i :
+    Γ s⊨ T1 <:[i] T2 ∷ sf_kintv L U -∗
+    Γ s⊨ T1 <:[i] T2 ∷ sf_kintv T1 T2.
+  Proof.
+    iIntros "#Hs !> * Hg"; iDestruct ("Hs" with "Hg") as "{Hs} (_ & $ & _)".
+    by rewrite -!subtype_refl.
+  Qed.
+
   (** Kind subsumption (for kinded subtyping). *)
   Lemma sKStp_Sub Γ {n} (T1 T2 : olty Σ n) (K1 K2 : sf_kind Σ n) i :
     Γ s⊨ T1 <:[ i ] T2 ∷ K1 -∗

--- a/theories/misc_unused/hoInterps_experiments.v
+++ b/theories/misc_unused/hoInterps_experiments.v
@@ -54,20 +54,6 @@ Definition oUncurry {n} {A : ofeT} (Φ : vl → vec vl n → A) :
   vec vl n.+1 -d> A := vuncurry Φ.
 Definition oLaterN {Σ n} i (τ : olty Σ n) := Olty (eLater i τ).
 
-(** An inductive representation of gHkDOT semantic kinds. *)
-Inductive s_kind {Σ} : nat → Type :=
-  | s_kintv : olty Σ 0 → olty Σ 0 → s_kind 0
-  | s_kpi n : olty Σ 0 → s_kind n → s_kind n.+1.
-Global Arguments s_kind: clear implicits.
-
-(** Alternative inductive representation of gHkDOT semantic kinds. *)
-Record spine_s_kind {Σ} {n : nat} : Type := SpineSK {
-  spine_kargs : vec (olty Σ 0) n;
-  spine_L : olty Σ 0;
-  spine_U : olty Σ 0;
-}.
-Arguments spine_s_kind : clear implicits.
-
 (** Semantic kinds can be interpreted into predicates. *)
 (** Semantic Kinds as unary Predicates. *)
 Notation sp_kind Σ n := (env → iPPred (hoLtyO Σ n) Σ).
@@ -144,10 +130,6 @@ Section kinds_types.
     iApply ("Hs2" with "(Hs1 HT1)").
   Qed.
 
-  Definition sp_s_kintv (L U : olty Σ 0) : spine_s_kind Σ 0 := SpineSK vnil L U.
-  Definition sp_s_kpi {n} (S : olty Σ 0) (K : spine_s_kind Σ n) : spine_s_kind Σ n.+1 :=
-    SpineSK (vcons S (spine_kargs K)) (spine_L K) (spine_U K).
-
   Definition sp_kintv (L U : olty Σ 0) : sp_kind Σ 0 := SpKind (λI ρ φ,
     oClose L ρ ⊆ oClose φ ⊆ oClose U ρ).
 
@@ -214,22 +196,6 @@ Section kinds_types.
   Qed.
 
   Definition sf_star : sf_kind Σ 0 := sf_kintv oBot oTop.
-
-  Fixpoint s_kind_to_spine_s_kind {n} (K : s_kind Σ n) : spine_s_kind Σ n :=
-    match K with
-    | s_kintv L U => sp_s_kintv L U
-    | s_kpi s K => sp_s_kpi s (s_kind_to_spine_s_kind K)
-    end.
-
-  Definition spine_s_kind_to_sf_kind {n} (K : spine_s_kind Σ n) : sf_kind Σ n :=
-    vec_fold (sf_kintv (spine_L K) (spine_U K)) (@sf_kpi) n (spine_kargs K).
-  Global Arguments spine_s_kind_to_sf_kind {_} !_.
-
-  Fixpoint s_kind_to_sf_kind {n} (K : s_kind Σ n) : sf_kind Σ n :=
-    match K with
-    | s_kintv L U => sf_kintv L U
-    | s_kpi s K => sf_kpi s (s_kind_to_sf_kind K)
-    end.
 
   Definition oLam {n} (τ : oltyO Σ n) : oltyO Σ n.+1 :=
     Olty (λI args ρ, τ (vtail args) (vhead args .: ρ)).

--- a/theories/misc_unused/hoInterps_experiments.v
+++ b/theories/misc_unused/hoInterps_experiments.v
@@ -125,10 +125,7 @@ Section kinds_types.
 
   Lemma subtype_trans {T1} T2 {T3} :
     T1 ⊆ T2 -∗ T2 ⊆ T3 -∗ T1 ⊆@{Σ} T3.
-  Proof.
-    iIntros "#Hs1 #Hs2 !>" (v) "#HT1".
-    iApply ("Hs2" with "(Hs1 HT1)").
-  Qed.
+  Proof. iIntros "#H1 #H2 !>" (v) "#HT1". iApply ("H2" with "(H1 HT1)"). Qed.
 
   Definition sp_kintv (L U : olty Σ 0) : sp_kind Σ 0 := SpKind (λI ρ φ,
     oClose L ρ ⊆ oClose φ ⊆ oClose U ρ).

--- a/theories/misc_unused/hoInterps_experiments.v
+++ b/theories/misc_unused/hoInterps_experiments.v
@@ -655,8 +655,9 @@ Section dot_types.
   Qed.
 
 
+  Notation hoLty_car τ := (λ args v, lty_car (τ args) v).
   Notation HoLty φ := (λ args, Lty (λI v, φ args v)).
-  Definition packHoLtyO {Σ n} (φ : hoD Σ n) : hoLtyO Σ n := HoLty (λI args v, □ ▷ φ args v).
+  Definition packHoLtyO {Σ n} (φ : hoD Σ n) : hoLtyO Σ n := HoLty (λI args v, ▷ □ φ args v).
 
   Definition oLDTMemK {n} l (K : sf_kind Σ n) : ldltyO Σ := mkLDlty (Some l) (λI ρ d,
     ∃ (ψ : hoD Σ n), d ↗n[ n ] ψ ∧ K ρ (packHoLtyO ψ) (packHoLtyO ψ)).
@@ -701,5 +702,36 @@ Section dot_types.
     iApply (Proper_sfkind' with "(HTK Hg)") => args v /=.
     by rewrite -(Hγφ args ρ v) make_intuitionistically.
   Qed.
+  (* Lemma lift_olty_eq subj {τ1 τ2 : iPPred subj Σ} :
+    (sbi_internal_eq (A := subj -d> _) (iPPred_car τ1) (iPPred_car τ2)) ⊢@{iPropI Σ} τ1 ≡ τ2.
+  Proof.
+  Admitted. *)
+    (* iIntros "H".
+    iApply prop_ext_2.
+    rewrite equiv_internal_eq.
+    iApply internal_eq_rewrite. ∗.
+  apply. Qed. *)
+
+  Global Lemma sfkind_respects {n} (K : sf_kind Σ n) ρ (T1 T2 : hoLtyO Σ n) :
+    (∀ args v, T1 args v ↔ T2 args v) ⊢@{iPropI Σ} K ρ T1 T1 -∗ K ρ T2 T2.
+  Proof.
+    (* repeat setoid_rewrite <-bi.discrete_fun_equivI.  *)
+  Admitted.
+
+  (* Lemma sK_Sel {Γ n} l (K : s_kind Σ n) v i : *)
+  Lemma sK_Sel {Γ n} l (K : sf_kind Σ n) v i :
+    Γ s⊨p pv v : cTMemK l K, i -∗
+    Γ s⊨ oSel n (pv v) l ∷[i] K.
+  Proof.
+    iIntros "#Hp !> * #Hg"; iSpecialize ("Hp" with "Hg"); iNext i.
+    rewrite /= path_wp_pv_eq /=; iDestruct "Hp" as (d Hl ψ) "[Hl HK]".
+    iApply (sfkind_respects with "[] HK"); iIntros (args w).
+    rewrite /= path_wp_pv_eq.
+    iSplit; first by iIntros "H"; iExists ψ, d; iFrame (Hl) "Hl".
+    iDestruct 1 as (ψ' ?d Hl') "[Hl' Hw]"; objLookupDet.
+    iDestruct (dm_to_type_agree args w with "Hl Hl'") as "Hag".
+    iNext. by iRewrite "Hag".
+  Qed.
+
 End dot_types.
 End HkDot.

--- a/theories/misc_unused/hoInterps_experiments.v
+++ b/theories/misc_unused/hoInterps_experiments.v
@@ -345,5 +345,29 @@ Section dot_types.
     }
     by iApply (Proper_sfkind with "HsubK").
   Qed.
+  (** Reflexivity and transitivity of subkinding are admissible. *)
+
+  (** * Kinded subtyping. *)
+  Lemma sSubK_Refl' Γ {n} T (K : s_kind Σ n) :
+    let sfK := s_kind_to_sf_kind K in
+    Γ s⊨ T ∷[ 0 ] sfK -∗
+    Γ s⊨ T, 0 <: T, 0 ∷ sfK.
+  Proof.
+    iIntros (?) "#HK !>". iIntros (ρ) "#Hg".
+    iApply s_kind_refl.
+    by iApply (Proper_sfkind with "(HK Hg)").
+  Qed.
+
+  Lemma sSubK_Refl Γ {n} T (K : s_kind Σ n) i :
+    let sfK := s_kind_to_sf_kind K in
+    Γ s⊨ T ∷[ i ] sfK -∗
+    Γ s⊨ T, i <: T, i ∷ sfK.
+  Proof.
+    (* have ->: i = 0 by admit. *)
+    iIntros (?) "#HK !>". iIntros (ρ) "#Hg".
+    iApply s_kind_refl.
+    Fail by iApply (Proper_sfkind with "(HK Hg)").
+  Abort.
+
 End dot_types.
 End HkDot.

--- a/theories/misc_unused/hoInterps_experiments.v
+++ b/theories/misc_unused/hoInterps_experiments.v
@@ -97,9 +97,12 @@ Record sf_kind {Σ n} := SfKind {
     sf_kind_sub ρ T1 T2 -∗
     sf_kind_sub ρ T2 T3 -∗
     sf_kind_sub ρ T1 T3;
-  sf_kind_sub_reg ρ T1 T2 :
+  sf_kind_sub_reg_1 ρ T1 T2 :
     sf_kind_sub ρ T1 T2 -∗
-    sf_kind_car ρ T1 ∧ sf_kind_car ρ T2;
+    sf_kind_car ρ T1;
+  sf_kind_sub_reg_2 ρ T1 T2 :
+    sf_kind_sub ρ T1 T2 -∗
+    sf_kind_car ρ T2;
 }.
 Global Arguments sf_kind : clear implicits.
 Global Arguments sf_kind_car : simpl never.
@@ -130,7 +133,6 @@ Section kinds_types.
     iApply ("Hs2" with "(Hs1 HT1)").
   Qed.
 
-
   Definition sp_kintv (L U : olty Σ 0) : spine_s_kind Σ 0 := SpineSK vnil L U.
   Definition sp_kpi {n} (S : olty Σ 0) (K : spine_s_kind Σ n) : spine_s_kind Σ n.+1 :=
     SpineSK (vcons S (spine_kargs K)) (spine_L K) (spine_U K).
@@ -141,15 +143,18 @@ Section kinds_types.
         oClose L ρ ⊆ oClose φ ⊆ oClose U ρ))
       (SrKind (λI ρ φ1 φ2,
         oClose L ρ ⊆ oClose φ1 ⊆ oClose φ2 ⊆ oClose U ρ))
-        ltac:(solve_proper_ho) ltac:(solve_proper_ho) _ _ _.
+        ltac:(solve_proper_ho) ltac:(solve_proper_ho) _ _ _ _.
   Next Obligation. by iIntros "* ($&$) !> * $". Qed.
   Next Obligation.
     iIntros "* ($&HLT1&_) (_ & HT2T3 & $)".
     iApply (subtype_trans (oClose T2) with "HLT1 HT2T3").
   Qed.
   Next Obligation.
-    iIntros "* /= #(A & B & C)"; iFrame "A C"; iSplit.
+    iIntros "* /= #(A & B & C)". iFrame "A".
     iApply (subtype_trans with "B C").
+  Qed.
+  Next Obligation.
+    iIntros "* /= #(A & B & C)". iFrame "C".
     iApply (subtype_trans with "A B").
   Qed.
 
@@ -160,7 +165,7 @@ Section kinds_types.
         sf_kind_car K (arg .: ρ) (vcurry φ arg)))
       (SrKind (λI ρ φ1 φ2,
         □∀ arg, S vnil ρ arg →
-        sf_kind_sub K (arg .: ρ) (vcurry φ1 arg) (vcurry φ2 arg))) _ _ _ _ _.
+        sf_kind_sub K (arg .: ρ) (vcurry φ1 arg) (vcurry φ2 arg))) _ _ _ _ _ _.
   Next Obligation.
     move=> n S K ρ m T1 T2 HT /=.
     have ?: ∀ ρ, NonExpansive (sf_kind_car K ρ) by apply sf_kind_car_ne.
@@ -182,9 +187,10 @@ Section kinds_types.
     iApply (sf_kind_sub_trans with "(H1 Harg) (H2 Harg)").
   Qed.
   Next Obligation.
-    iIntros "* /= #H"; iSplit; iIntros "!>" (arg) "#Harg".
-    iDestruct (sf_kind_sub_reg with "(H Harg)") as "[$_]".
-    iDestruct (sf_kind_sub_reg with "(H Harg)") as "[_$]".
+    iIntros "* /= #H !> * #Harg"; iApply (sf_kind_sub_reg_1 with "(H Harg)").
+  Qed.
+  Next Obligation.
+    iIntros "* /= #H !> * #Harg"; iApply (sf_kind_sub_reg_2 with "(H Harg)").
   Qed.
 
   Definition sf_star : sf_kind Σ 0 := sf_kintv oBot oTop.

--- a/theories/misc_unused/hoInterps_experiments.v
+++ b/theories/misc_unused/hoInterps_experiments.v
@@ -491,6 +491,68 @@ Section dot_types.
   Lemma oTApp_pv {n} (T : oltyO Σ n.+1) w :
     oTApp T (pv w) ≡ oTAppV T w .
   Proof. intros ???. by rewrite /= path_wp_pv_eq. Qed.
+
+  Global Instance Proper_envApply n: Proper ((≡) ==> (=) ==> (≡)) (envApply (Σ := Σ) (n := n)).
+  Proof. solve_proper_ho. Qed.
+
+  Global Instance: Params (@sf_kind_sub) 4 := {}.
+  (** XXX Copy-paste of sSubK_AppV, plus hacks for missing Proper instances I guess? *)
+  Lemma sSubK_App Γ {n} (K : sf_kind Σ n) S T i v :
+    Γ s⊨ T ∷[i] sf_kpi S K -∗
+    Γ s⊨p pv v : S, i -∗
+    Γ s⊨ oTApp T (pv v) ∷[i] K.|[v/].
+  Proof.
+    iIntros "#HTK #Hv !> * #Hg". rewrite kSubstOne_eq /=.
+    iSpecialize ("HTK" with "Hg"); iSpecialize ("Hv" with "Hg"); iNext i.
+    rewrite path_wp_pv_eq /=.
+    iSpecialize ("HTK" with "Hv").
+    (* Argh. *)
+    (* About sf_kind_sub. *)
+    (* Set Typeclasses Debug. *)
+    (* iEval rewrite {1}(oTApp_pv T). *)
+    (* Timeout 1 iEval rewrite oTApp_pv. *)
+    iApply (Proper_sfkind with "HTK"); by rewrite oTApp_pv.
+    (* Time by rewrite oTApp_pv. *)
+    (* Argh. *)
+    (* iApply ("HTK"). *)
+    (* by rewrite (oTApp_pv _ _ _ _ _). *)
+    (* by rewrite /= path_wp_pv_eq. *)
+  Qed.
+
+    (* rewrite /oTAppV/envApply/flip.
+    iApply (Proper_sfkind).
+    cbn.
+
+    iApply (Proper_sfkind with "HTK").
+    iS
+    rewrite -mlaterN_pers -impl_laterN.
+    iIntros "!> Hs".
+    iSpecialize ("HTK" $! (arg .: ρ) with "[$Hg $Hs]").
+    by iApply (Proper_sfkind with "HTK").
+  Qed. *)
+
+  (* XXX argh. *)
+  (* Definition kind_path_subst {n} p q (K1 K2 : sf_kind Σ n) : iProp Σ :=
+    ∀ (H : alias_paths p q) ρ T1 T2,
+    K1 ρ T1 T2 ≡ K2 ρ T1 T2 .
+
+  Lemma sSubK_App Γ {n} (K1 K2 : sf_kind Σ n) S T i p :
+    Γ s⊨ T ∷[i] sf_kpi S K1 -∗
+    Γ s⊨p p : S, i -∗
+    Γ s⊨ oTAppV T v ∷[i] K2.
+  Proof.
+    iIntros "#HTK #Hv !> * #Hg".
+    rewrite kSubstOne_eq /=.
+    iSpecialize ("HTK" with "Hg"); iSpecialize ("Hv" with "Hg").
+    rewrite path_wp_pv_eq /=; iNext i.
+    iSpecialize ("HTK" with "Hv").
+    (* iEval rewrite /sf_kind_sub/=.
+    iApply ("HTK"). *)
+    by iApply (Proper_sfkind with "HTK").
+  Qed. *)
+
+
+
   Lemma sstpkD_star_to_sstp Γ i T1 T2 :
     Γ s⊨ T1 <:[ i ] T2 ∷ sf_star ⊢ Γ s⊨ T1 , i <: T2 , i.
   Proof.

--- a/theories/misc_unused/hoInterps_experiments.v
+++ b/theories/misc_unused/hoInterps_experiments.v
@@ -6,7 +6,7 @@ From iris.base_logic Require Import lib.saved_prop.
 From D Require Import iris_prelude.
 From D Require Import saved_interp_dep asubst_intf asubst_base dlang lty.
 From D Require Import swap_later_impl.
-From D.Dot.lr Require dot_lty unary_lr lr_lemmasNoBinding.
+From D.Dot.lr Require dot_lty unary_lr lr_lemmasNoBinding typeExtractionSem.
 
 Import EqNotations.
 
@@ -516,7 +516,7 @@ End gen_lemmas.
 End HoSemTypes.
 
 Module HkDot.
-Import dot_lty unary_lr lr_lemmasNoBinding.
+Import dot_lty unary_lr lr_lemmasNoBinding typeExtractionSem.
 Include HoSemTypes VlSorts dlang_inst dot_lty.
 Implicit Types
          (v w : vl) (e : tm) (d : dm) (ds : dms) (p : path)
@@ -686,6 +686,20 @@ Section dot_types.
     iApply sK_Sub. iApply sK_Sing. iApply sSkd_Intv; rewrite sstpkD_star_eq_sstp.
     by iApply sBot_Sub.
     by iApply sSub_Top.
+  Qed.
+
+  (** Generalization of [sD_Typ_Abs]. *)
+  Lemma sD_TypK_Abs {Γ n} T (K : sf_kind Σ n) s σ l:
+    Γ s⊨ oLater T ∷[ 0 ] K -∗
+    s ↝[ σ ] T -∗
+    Γ s⊨ { l := dtysem σ s } : cTMemK l K.
+  Proof.
+    iIntros "#HTK"; iDestruct 1 as (φ Hγφ) "#Hγ".
+    iIntros "/= !>" (ρ Hpid) "Hg"; iSplit; first done.
+    iExists (hoEnvD_inst (σ.|[ρ]) φ); iSplit.
+    by iApply (dm_to_type_intro with "Hγ").
+    iApply (Proper_sfkind' with "(HTK Hg)") => args v /=.
+    by rewrite -(Hγφ args ρ v) make_intuitionistically.
   Qed.
 End dot_types.
 End HkDot.

--- a/theories/misc_unused/hoInterps_experiments.v
+++ b/theories/misc_unused/hoInterps_experiments.v
@@ -475,16 +475,22 @@ Section dot_types.
   Lemma kSubstOne_eq {n} (K : sf_kind Σ n) v ρ : sf_kind_sub K.|[v/] ρ = kSubstOne v K ρ.
   Proof. by rewrite /sf_kind_sub/= subst_swap_base. Qed.
 
-  Lemma sSubK_AppV Γ {n} (K : sf_kind Σ n) S T i v :
-    Γ s⊨ T ∷[i] sf_kpi S K -∗
+  Lemma sSK_AppV Γ {n} (K : sf_kind Σ n) S T1 T2 i v :
+    Γ s⊨ T1 <:[i] T2 ∷ sf_kpi S K -∗
     Γ s⊨p pv v : S, i -∗
-    Γ s⊨ oTAppV T v ∷[i] K.|[v/].
+    Γ s⊨ oTAppV T1 v <:[i] oTAppV T2 v ∷ K.|[v/].
   Proof.
     iIntros "#HTK #Hv !> * #Hg"; rewrite kSubstOne_eq /=.
     iSpecialize ("HTK" with "Hg"); iSpecialize ("Hv" with "Hg"); iNext i.
     rewrite path_wp_pv_eq /=.
     by iApply (Proper_sfkind with "(HTK Hv)").
   Qed.
+
+  Lemma sK_AppV Γ {n} (K : sf_kind Σ n) S T i v :
+    Γ s⊨ T ∷[i] sf_kpi S K -∗
+    Γ s⊨p pv v : S, i -∗
+    Γ s⊨ oTAppV T v ∷[i] K.|[v/].
+  Proof. apply sSK_AppV. Qed.
 
   Definition oTApp {n} (T : oltyO Σ n.+1) (p : path) : oltyO Σ n :=
     Olty (λ args ρ v, path_wp p.|[ρ] (λ w, T (vcons w args) ρ v)).

--- a/theories/misc_unused/hoInterps_experiments.v
+++ b/theories/misc_unused/hoInterps_experiments.v
@@ -1,139 +1,42 @@
 (* (* Must be loaded first, so that other modules can reset some flags. *)
 Require Import Equations.Equations. *)
+From Coq Require FunctionalExtensionality.
 From iris.proofmode Require Import tactics.
 From iris.base_logic Require Import lib.saved_prop.
-From D Require Import iris_prelude saved_interp_n.
-From D Require Import saved_interp_dep asubst_intf dlang ty_interp_subst_lemmas.
-From Coq Require FunctionalExtensionality.
+From D Require Import iris_prelude.
+From D Require Import saved_interp_dep asubst_intf asubst_base dlang lty.
+From D Require Import swap_later_impl.
+
 Import EqNotations.
 
 Set Suggest Proof Using.
 Set Default Proof Using "Type".
+Set Implicit Arguments.
+Unset Strict Implicit.
 
-Module try1 (Import VS : VlSortsSig).
-Section saved_pred3_use.
-  Context {Σ : gFunctors}.
+Implicit Types (Σ : gFunctors) .
+(** ssreflect postfix notation for the successor and predecessor functions.
+SSreflect uses "pred" for the generic predicate type, and S as a local bound
+variable.*)
+Notation succn := Datatypes.S.
+Notation predn := Peano.pred.
 
-  Notation envD Σ := (env -d> vl -d> iPropO Σ).
-  Notation hoEnvD Σ := (list vl -d> envD Σ).
-  Implicit Types (Φ : hoEnvD Σ) (n : nat).
-  Definition eFalse : envD Σ := λ ρ v, False%I.
+Notation "n .+1" := (succn n) (at level 2, left associativity,
+  format "n .+1") : nat_scope.
+Notation "n .+2" := n.+1.+1 (at level 2, left associativity,
+  format "n .+2") : nat_scope.
+Notation "n .+3" := n.+2.+1 (at level 2, left associativity,
+  format "n .+3") : nat_scope.
+Notation "n .+4" := n.+2.+2 (at level 2, left associativity,
+  format "n .+4") : nat_scope.
 
-  (* We can track function arity by just storing a number,
-     but that's a bit cumbersome. *)
-  Definition hoEnvND Σ : Type := nat * hoEnvD Σ.
-  Definition vcurry : hoEnvND Σ → vl → hoEnvND Σ := λ '(n, Φ) a,
-    match n with
-    | 0 => (0, λ _, eFalse)
-    | S n => (n, λ args, Φ (a :: args))
-    end%I.
-  Definition vclose : hoEnvND Σ → envD Σ := λ '(n, Φ), Φ [].
-  Definition vuncurry n (Φ : vl → hoEnvD Σ) : hoEnvND Σ :=
-    (S n, λ args,
-      match args with
-      | w :: args => Φ w args
-      | [] => eFalse
-      end%I).
-End saved_pred3_use.
-End try1.
+Notation "n .-1" := (predn n) (at level 2, left associativity,
+  format "n .-1") : nat_scope.
+Notation "n .-2" := n.-1.-1 (at level 2, left associativity,
+  format "n .-2") : nat_scope.
 
-From D Require Import saved_interp_dep lty asubst_base.
-
-(* *)
-Module noDepTypes.
-Module Type HoSemTypes (Import VS : VlSortsFullSig) (Import LWP : LiftWp VS).
-Include Lty VS LWP.
-Section saved_dep_use.
-  Context {Σ : gFunctors}.
-  Notation hoEnvND Σ := (sigTO (hoEnvD Σ)).
-  Implicit Types (Φ : hoEnvND Σ) (n : nat).
-  Definition eFalse : envD Σ := λ ρ v, False%I.
-
-  Unset Program Cases.
-  Program Definition vcurry : hoEnvND Σ → vl → hoEnvND Σ := λ '(existT n φ),
-    match n with
-    | 0 => λ _ _, existT 0 (λ _, eFalse)
-    | S m => λ φ a, existT m (λ args : vec vl m, φ (vcons a args))
-    end φ.
-
-  Definition vclose : hoEnvND Σ → envD Σ := λ '(existT n φ),
-    match n with
-    | 0 => λ φ, φ vnil
-    | S n => λ _, eFalse
-    end φ.
-  Lemma vclose_id φ : vclose (existT 0 φ) = φ vnil. Proof. done. Qed.
-
-  Program Definition vuncurry' : {n & vl → hoEnvD Σ n} → hoEnvND Σ := λ '(existT n φ),
-    existT (S n) (λ args, φ (vhead args) (vtail args)).
-  Program Definition vuncurry n : (vl → hoEnvND Σ) → hoEnvND Σ := λ φ,
-    existT (S n) (λ args,
-      let '(existT m φ') := φ (vhead args) in
-      match decide (m = n) with
-      | left Heq => φ' (rew <- [vec vl] Heq in vtail args)
-      | right _ => eFalse
-      end).
-  Lemma vec_eta {A n} (args : vec A (S n)) : vcons (vhead args) (vtail args) = args.
-  Proof. by dependent destruction args. Qed.
-
-  Lemma vcurry_vuncurry n (φ : hoEnvD Σ (S n)) : vuncurry n (vcurry (existT (S n) φ)) = existT (S n) φ.
-  Proof.
-    rewrite /vuncurry; cbn; destruct n; f_equiv;
-      apply FunctionalExtensionality.functional_extensionality_dep => args;
-      by rewrite (decide_left (P := (_ = _)) eq_refl) vec_eta.
-  Qed.
-
-  Lemma vuncurry_vcurry n (φ : vl → hoEnvD Σ n) :
-    vcurry (vuncurry n (λ v, existT n (φ v))) = (λ v, existT n (φ v)).
-  Proof.
-    apply FunctionalExtensionality.functional_extensionality_dep => v.
-    cbn; f_equiv.
-    apply FunctionalExtensionality.functional_extensionality_dep => args /=.
-    by rewrite (decide_left (P := (_ = _)) eq_refl).
-  Qed.
-End saved_dep_use.
-End HoSemTypes.
-End noDepTypes.
 
 Module Type HoSemTypes (Import VS : VlSortsFullSig) (Import LWP : LiftWp VS) (Import L : Lty VS LWP).
-Section saved_ho_sem_type_extra.
-  Context {Σ : gFunctors}.
-
-  Implicit Types (Ψ : packedHoEnvD Σ).
-
-  (** ** Accessing saved HO predicates. *)
-  Definition packedHoEnvD_arity : packedHoEnvD Σ -n> natO := packedHoEnvPred_arity.
-
-  Program Definition unNext: laterO (iPropO Σ) -n> iPropO Σ :=
-    λne φ, (▷ later_car φ)%I.
-  Next Obligation. solve_contractive. Qed.
-
-  Definition unpack : ∀ Ψ, hoEnvD Σ (packedHoEnvD_arity Ψ) :=
-    λ Ψ args ρ v, unNext (projT2 Ψ args ρ v).
-
-  Lemma packedHoEnvD_arity_ne {Φ Ψ : packedHoEnvD Σ} {n} :
-    Φ ≡{n}≡ Ψ → packedHoEnvD_arity Φ = packedHoEnvD_arity Ψ.
-  Proof. apply packedHoEnvD_arity. Qed.
-
-  Lemma unpack_ne {n Ψ1 Ψ2} (Heq : Ψ1 ≡{n}≡ Ψ2):
-    rew [hoEnvD Σ] (packedHoEnvD_arity_ne Heq) in unpack Ψ1 ≡{n}≡ unpack Ψ2.
-  Proof.
-    move: Ψ1 Ψ2 Heq (packedHoEnvD_arity_ne Heq) => [/= n1 Φ1] [/= n2 Φ2] [/= Heq1 Heq] HeqN.
-    move: Heq; rewrite (proof_irrel HeqN Heq1) /unpack /=.
-    destruct Heq1 => /= H ???. f_contractive. exact: H.
-  Qed.
-
-  Lemma unpack_ne_eta n Ψ1 Ψ2 (Heq : Ψ1 ≡{n}≡ Ψ2) a b c:
-    (rew [hoEnvD Σ] (packedHoEnvD_arity_ne Heq) in unpack Ψ1) a b c ≡{n}≡
-    unpack Ψ2 a b c.
-  Proof. exact: unpack_ne. Qed.
-
-  Definition oCurry {n} {A : ofeT} (Φ : vec vl (S n) → A) :
-    vl -d> vec vl n -d> A := vcurry Φ.
-
-  Definition oUncurry {n} {A : ofeT} (Φ : vl → vec vl n → A) :
-    vec vl (S n) -d> A := vuncurry Φ.
-  Definition oLaterN {n} i (τ : olty Σ n) := Olty (eLater i τ).
-End saved_ho_sem_type_extra.
 
 Definition hoLty Σ n := vec vl n → lty Σ.
 Definition hoLtyO Σ n := vec vl n -d> ltyO Σ.
@@ -141,291 +44,49 @@ Definition hoLtyO Σ n := vec vl n -d> ltyO Σ.
 Definition envApply {Σ n} : oltyO Σ n → env → hoLtyO Σ n :=
   λ T, flip T.
 
-(** The semantics of a kind includes a predicate on types, and a subtype predicate.
-  *)
-(* XXX make these non-expansive? *)
-Notation skind Σ n := (∀ (i : nat), env → hoLty Σ n → iProp Σ).
-Notation srelkind Σ n := (env → hoLtyO Σ n → hoLtyO Σ n → iProp Σ).
+Definition oCurry {n} {A : ofeT} (Φ : vec vl (S n) → A) :
+  vl -d> vec vl n -d> A := vcurry Φ.
 
-(* Semantic Full Kind. *)
-Record sfkind Σ n := Sfkind {
-  sfkind_car :> skind Σ n;
-  sfkind_sub : srelkind Σ n;
+Definition oUncurry {n} {A : ofeT} (Φ : vl → vec vl n → A) :
+  vec vl (S n) -d> A := vuncurry Φ.
+Definition oLaterN {Σ n} i (τ : olty Σ n) := Olty (eLater i τ).
+
+Inductive skind {Σ} : nat → Type :=
+  | skintv : olty Σ 0 → olty Σ 0 → skind 0
+  | skpi n : olty Σ 0 → skind n → skind (S n).
+Global Arguments skind: clear implicits.
+
+Record spine_skind {Σ} {n : nat} : Type := SpineSK {
+  spine_kargs : vec (olty Σ 0) n;
+  spine_L : olty Σ 0;
+  spine_U : olty Σ 0;
 }.
-Global Arguments Sfkind {_ _} _ _.
-Global Arguments sfkind_car {_ _} _ _ _ : simpl never.
-Global Arguments sfkind_sub {_ _} _ _ _ _ : simpl never.
+Arguments spine_skind : clear implicits.
 
-(** Kinded, indexed subtyping *)
-Program Definition sstpk `{dlangG Σ} {n} i j Γ T1 T2 (K : sfkind Σ n) : iProp Σ :=
-  □∀ ρ, s⟦Γ⟧*ρ → sfkind_sub K ρ (envApply (oLaterN i T1) ρ) (envApply (oLaterN j T2) ρ).
-(* :: is at level 60. *)
-(* Notation "Γ s⊨k T1 , i <: T2 , j ∷ K" := (sstpk i j Γ T1 T2 K)
-  (at level 74, i, j at level 59, T1, T2, i at next level). *)
-Notation "Γ s⊨ T1 , i <: T2 , j ∷ K" := (sstpk i j Γ T1 T2 K)
-  (at level 74, i, j, T1, T2 at next level).
+Section saved_ho_sem_type_extra.
+  Context {Σ}.
 
-(* XXX Should we delay [T] as well? Yes, based on [iSel_Sub]/[iSub_Sel].
-Should we delay K?*)
-(* V1: delay K and rely on swaps to make that affect all types. *)
-(* Definition sktp `{dlangG Σ} {n} i Γ T (K : sfkind Σ n) : iProp Σ :=
-  □∀ ρ, s⟦Γ⟧*ρ → ▷^i K ρ T. *)
-(* V2: push the delay down. *)
-Definition sktp `{dlangG Σ} {n} i Γ T (K : sfkind Σ n) : iProp Σ :=
-  □∀ ρ, s⟦Γ⟧*ρ → K i ρ (envApply (oLaterN i T) ρ).
-(* XXX What delays are wanted here? *)
-(* Definition ssktp `{dlangG Σ} {n} i Γ (K1 K2 : sfkind Σ n) : iProp Σ :=
-  □∀ ρ T, s⟦Γ⟧*ρ → ▷^i K1 ρ (envApply T ρ) → ▷^i K2 ρ (envApply T ρ). *)
-Definition ssktp `{dlangG Σ} {n} i Γ (K1 K2 : sfkind Σ n) : iProp Σ :=
-  □∀ ρ (T : olty Σ n), s⟦Γ⟧*ρ → K1 i ρ (envApply T ρ) → K2 i ρ (envApply T ρ).
+  Definition sp_skintv (L U : olty Σ 0) : spine_skind Σ 0 := SpineSK vnil L U.
+  Definition sp_skpi {n} (S : olty Σ 0) (K : spine_skind Σ n) : spine_skind Σ n.+1 :=
+    SpineSK (vcons S (spine_kargs K)) (spine_L K) (spine_U K).
 
+  Fixpoint skind_to_spine_skind {n} (K : skind Σ n) : spine_skind Σ n :=
+    match K with
+    | skintv L U => sp_skintv L U
+    | skpi s K => sp_skpi s (skind_to_spine_skind K)
+    end.
+
+End saved_ho_sem_type_extra.
 End HoSemTypes.
 
 From D.Dot Require Import dot_lty unary_lr.
+
+Implicit Types
+         (v w : vl) (e : tm) (d : dm) (ds : dms) (p : path)
+         (vs : vls) (ρ : var → vl) (l : label).
+
 Module HkDot.
 Include HoSemTypes VlSorts dlang_inst dot_lty.
 
-Section semkinds.
-  Context `{dlangG Σ}.
-
-  Definition subtype {n} : srelkind Σ n := λI ρ φ1 φ2,
-    □ ∀ args v, φ1 args v → φ2 args v.
-
-  Definition skstar : skind Σ 0 := λI i ρ φ, True.
-  Definition srstar : srelkind Σ 0 := λ ρ φ1 φ2,
-    (□ ∀ v, oClose φ1 v → oClose φ2 v)%I.
-  Definition sstar : sfkind Σ 0 := Sfkind skstar srstar.
-
-  (* Show that kinded subtyping correctly generalizes the existing kind-*
-  subtyping. *)
-  Lemma sstpk_star_eq_sstp Γ i j T1 T2 :
-    Γ s⊨ T1 , i <: T2 , j ∷ sstar ⊣⊢ Γ s⊨ T1 , i <: T2 , j.
-  Proof.
-    rewrite /sstpk /sfkind_sub/= /srstar; iSplit; iIntros "/= #Hsub !>" (ρ).
-    by iIntros (v) "#Hg"; iApply ("Hsub" $! ρ with "Hg").
-    by iIntros "#Hg" (v) "!>"; iApply ("Hsub" $! ρ v with "Hg").
-  Qed.
-
-  Definition skpi {n} (φArg : olty Σ 0) (K : skind Σ n) : skind Σ (S n) :=
-    λI i ρ φ, □∀ arg, oClose φArg ρ arg → K i (arg .: ρ) (vcurry φ arg).
-  Definition srpi {n} (φArg : olty Σ 0) (Kr : srelkind Σ n) : srelkind Σ (S n) :=
-    λI ρ φ1 φ2, □∀ arg, oClose φArg ρ arg → Kr (arg .: ρ) (vcurry φ1 arg) (vcurry φ2 arg).
-  Definition spi {n} (φArg : olty Σ 0) (K : sfkind Σ n) : sfkind Σ (S n) :=
-    Sfkind (skpi φArg (sfkind_car K)) (srpi φArg (sfkind_sub K)).
-
-  Definition fold_srelkind (base : srelkind Σ 0) : ∀ n, vec (olty Σ 0) n → srelkind Σ n :=
-    vec_fold base (@srpi).
-  Definition subtype_w_expKind : ∀ n, vec (olty Σ 0) n → srelkind Σ n :=
-    fold_srelkind srstar.
-  (* Definition eqtype_w_expKind : ∀ n, vec (olty Σ 0) n → srelkind Σ n :=
-    fold_srelkind kind_star_eqtype. *)
-
-  (* The point of Sandro's kind syntax is to use this only at kind 0. *)
-  Program Definition skintv (φ1 φ2 : olty Σ 0) : skind Σ 0 := λI i ρ φ,
-    subtype ρ (envApply (oLaterN i φ1) ρ) φ
-    (* subtype ρ (envApply (oLaterN (S i) φ1) ρ) (oLater i φ). *)
-    ∧
-    (* subtype ρ (oLaterN i φ) (envApply (oLaterN (S i) φ2) ρ). *)
-    subtype ρ φ (envApply (oLaterN i φ2) ρ).
-  Definition sintv (φ1 φ2 : olty Σ 0) : sfkind Σ 0 :=
-    Sfkind (skintv φ1 φ2) srstar.
-
-  Inductive kind {Σ} : nat → Type :=
-    | kintv : olty Σ 0 → olty Σ 0 → kind 0
-    | kpi n : olty Σ 0 → kind n → kind (S n).
-  Global Arguments kind: clear implicits.
-
-  Fixpoint sem {n} (k : kind Σ n) : skind Σ n :=
-    match k with
-      | kintv φ1 φ2 => skintv φ1 φ2
-      | kpi n φ1 k' => skpi φ1 (sem k')
-    end.
-
-  (* Notice the argument type is not used here. *)
-  Inductive hoSTy {Σ} : nat → Type :=
-    | TSWrap : olty Σ 0 → hoSTy 0
-    | TSLam {n} : olty Σ 0 → hoSTy n → hoSTy (S n)
-    | TSApp {n} : hoSTy (S n) → path → hoSTy n.
-
-  Definition oLam {n} (τ : oltyO Σ n) : oltyO Σ (S n) :=
-    (* vuncurry (λ v, τ.|[v/]). *)
-    vuncurry (λ v, Olty (λ args ρ, τ args (v .: ρ))).
-    (* Olty (λ args ρ, τ (vtail args) (vhead args .: ρ)). *)
-  Lemma oLam_equiv1 {n τ} : oLam (n := n) τ ≡
-    Olty (λ args ρ, τ (vtail args) (vhead args .: ρ)).
-  Proof. done. Qed.
-
-  (* *not* equivalent! *)
-  Lemma oLam_equiv2 {n τ} : oLam (n := n) τ ≡
-    vuncurry (λ v, τ.|[v/]).
-  Proof.
-    move=> args ρ v; rewrite /= /hsubst /hsubst_hoEnvD.
-    asimpl.
-    do 3 f_equiv.
-  Abort.
-
-  Definition oTApp {n} (τ : oltyO Σ (S n)) v : olty Σ n := vcurry τ v.
-  Definition oTAppP {n} (τ : oltyO Σ (S n)) (p : path) : olty Σ n :=
-    Olty (λ args ρ v, path_wp p.|[ρ] (λ w, vcurry τ w args ρ v)).
-
-  Lemma swap_oLam_oLater {n} (τ : olty Σ n) :
-    oLater (oLam τ) ≡ oLam (oLater τ).
-  Proof. done. Qed.
-
-  Lemma swap_oTApp_oLater {n} (τ : olty Σ (S n)) v:
-    oLater (oTApp τ v) ≡ oTApp (oLater τ) v.
-  Proof. done. Qed.
-
-  Fixpoint hoSTySem {n} (T : hoSTy n): olty Σ n :=
-    match T with
-    | TSWrap φ => φ
-    | TSLam _ T => oLam (hoSTySem T)
-    | TSApp T p => oTAppP (hoSTySem T) p
-    end.
-End semkinds.
-Arguments hoSTy: clear implicits.
 End HkDot.
 
-From D Require swap_later_impl.
-(* These are "bad" experiments. *)
-Module HoGenExperimnents.
-Import swap_later_impl HkDot.
-Section sec.
-  Context `{!CTyInterp Σ}.
-  Context `{dlangG Σ} `{HswapProp: SwapPropI Σ}.
-
-  Definition srstar1 : srelkind Σ 0 := subtype.
-  Lemma srstar_eq ρ φ1 φ2 :
-    srstar1 ρ φ1 φ2 ≡ srstar ρ φ1 φ2.
-  Proof.
-    rewrite /srstar1 /srstar /subtype /vclose.
-    apply intuitionistically_proper, equiv_spec; split. by iIntros "H".
-    iIntros "H" (args). by rewrite (vec_vnil args).
-  Qed.
-
-  (* Definition skLaterN {Σ n} i (K : skind Σ n) : skind Σ n :=
-    λ ρ φ, K ρ (oLaterN i φ). *)
-  (* Definition srLaterN {Σ n} i j (K : srelkind Σ n) : srelkind Σ n :=
-    λ ρ T1 T2, K ρ (oLaterN i T1) (oLaterN j T2). *)
-  (* Definition sfLaterN {n} i (K : sfkind Σ n) : sfkind Σ n :=
-    Sfkind (skLaterN i K) K. *)
-
-  (* Definition sstpk `{dlangG Σ} {n} i j Γ τ₁ τ₂ (K : sfkind Σ n) : iProp Σ :=
-    □∀ ρ, s⟦Γ⟧*ρ → srLaterN i j (sfkind_sub K) ρ τ₁ τ₂. *)
-  (* Definition semEquiv {n} : srelkind Σ n := λI ρ (φ1 φ2 : olty Σ n),
-    □ ∀ args v, φ1 args ρ v ↔ φ2 args ρ v. *)
-  (* Definition kind_star_eqtype : srelkind Σ 0 := λ ρ φ1 φ2,
-    (□ ∀ v, oClose φ1 ρ v ↔ oClose φ2 ρ v)%I. *)
-
-
-  Definition sstpk1 {n} i Γ (T1 T2 : oltyO Σ n) (K : sfkind Σ n) : iProp Σ :=
-    □∀ ρ, s⟦Γ⟧*ρ → ▷^i sfkind_sub K ρ (envApply T1 ρ) (envApply T2 ρ).
-  Lemma sstpk1_star_eq_sstp Γ i T1 T2 :
-    sstpk1 i Γ T1 T2 sstar ⊣⊢ Γ s⊨ T1 , i <: T2 , i.
-  Proof using HswapProp.
-    rewrite /sstpk1 /sfkind_sub/= /srstar.
-    iSplit; iIntros "/= #Hsub !>" (ρ); [iIntros (v)|]; iIntros "#Hg".
-    iSpecialize ("Hsub" $! ρ with "Hg"); iSpecialize ("Hsub" $! v).
-    rewrite -mlaterN_pers laterN_impl.
-    by iApply "Hsub".
-    rewrite -mlaterN_pers; iIntros (v) "!>"; rewrite -mlaterN_impl.
-    iDestruct "Hsub" as "#Hsub".
-    iApply ("Hsub" $! ρ v with "Hg").
-  Qed.
-
-  (* Inductive kind : nat → Type :=
-    | kintv : ty → ty → kind 0
-    | kpi n : ty → kind n → kind (S n). *)
-
-
-  Inductive htype : nat → Type :=
-    | TWrap : ty → htype 0
-    | TLam {n} : olty Σ 0 → htype n → htype (S n)
-    | TApp {n} : htype (S n) → path → htype n.
-
-  Fixpoint htype_to_hosty {n} (T : htype n) : hoSTy Σ n :=
-    match T with
-    | TWrap T => TSWrap V⟦T⟧
-    | TLam φ T => TSLam φ (htype_to_hosty T)
-    | TApp T v => TSApp (htype_to_hosty T) v
-    end.
-  Definition typeSem {n} (T : htype n) : hoEnvD Σ n := hoSTySem (htype_to_hosty T).
-
-  Lemma K_App_Lam {n} (argT : olty Σ 0) (φ1 φ2: hoLtyO Σ (S n)) (K : srelkind Σ n) ρ :
-    srpi argT K ρ φ1 φ2 ⊣⊢ (□∀ v, oClose argT ρ v → K (v .: ρ) (vcurry φ1 v) (vcurry φ2 v))%I.
-  Proof. done. Qed.
-  (** XXX Need a subtyping judgment to throw in environments... *)
-
-  (* Here, we inherit eta from the metalanguage, in both directions. *)
-  (* Er, let's please carry it closer to the syntax? *)
-  Lemma eta1 {n} argT (φ : hoLtyO Σ (S n)) ρ : srpi argT subtype ρ φ (vuncurry (vcurry φ)).
-  Proof.
-    rewrite /srpi /subtype.
-    iIntros "!> * #Harg !>" (args v) "$".
-  Qed.
-
-  Lemma eta2 {n} argT (φ : hoLtyO Σ (S n)) ρ : srpi argT subtype ρ (vuncurry (vcurry φ)) φ.
-  Proof.
-    rewrite /srpi /subtype.
-    iIntros "!> * #Harg !>" (args v) "$".
-  Qed.
-
-  (* Lemma eta {n} argT (φ : olty Σ (S n)) ρ : srpi argT semEquiv ρ φ (vuncurry (vcurry φ)).
-  Proof.
-    rewrite /srpi /semEquiv.
-    iIntros "!> * #Harg !> **". rewrite -(iff_refl emp%I). done.
-  Qed. *)
-
-  Program Fixpoint sem_program {n} {struct n} : kind Σ n → skind Σ n :=
-    match n return _ with
-    | 0 => λ k, match k with
-      | kintv φ1 φ2 => skintv φ1 φ2
-      | kpi n _ _ => _
-      end
-    | S n => λ k, match k with
-      | kintv φ1 φ2 => _
-      | kpi n φ1 k' =>
-        skpi φ1 (sem_program (rew _ in k'))
-      end
-    end.
-  Next Obligation. done. Qed.
-  Next Obligation. done. Qed.
-  Next Obligation. intros. congruence. Defined.
-  (* Derive Signature NoConfusion Subterm EqDec for kind. *)
-
-  (* Derive Signature for kind.
-  Equations sem_eq {n} : kind Σ n → skind Σ n :=
-    sem_eq (kintv φ1 φ2) := skintv φ1 φ2;
-    sem_eq (kpi n φ1 k') := skpi φ1 (sem_eq k').
-
-  Lemma unfold_sem_kintv φ1 φ2: sem_eq (kintv φ1 φ2) = skintv φ1 φ2.
-  Proof. by simp sem_eq. Qed. *)
-End sec.
-End HoGenExperimnents.
-
-Module dot_experiments.
-Import HkDot.
-(* Include TyInterpLemmas VlSorts dlang_inst.
-Export ty_interp_lemmas. *)
-
-Section sec.
-  Context `{!savedHoSemTypeG Σ} `{!dlangG Σ} `{CTyInterp Σ}.
-
-  Definition dm_to_type (d : dm) n (ψ : hoD Σ n) : iProp Σ :=
-    (∃ s σ, ⌜ d = dtysem σ s ⌝ ∧ s ↗n[ σ, n ] ψ)%I.
-  Notation "d ↗n[ n ] φ" := (dm_to_type d n φ) (at level 20).
-  Global Arguments dm_to_type: simpl never.
-
-  (* [K]'s argument must ignore [ρ]. Patch the definition of skind instead. *)
-  Notation HoLty φ := (λ args, Lty (λI v, φ args v)).
-  Definition packHoLtyO {Σ n} φ : hoLtyO Σ n := HoLty (λI args v, □ φ args v).
-
-  Definition def_interp_tmem {n} (K : skind Σ n): envPred dm Σ :=
-    (* λI ρ d, ∃ (φ : hoLtyO Σ n), d.|[ρ] ↗n[ n ] φ ∧ K 0 ρ φ. *)
-    λI ρ d, ∃ (φ : hoD Σ n), d.|[ρ] ↗n[ n ] φ ∧ K 0 ρ (packHoLtyO φ).
-  Definition def_interp_tmem_spec (φ1 φ2 : olty Σ 0) : envPred dm Σ :=
-    def_interp_tmem (skintv (oLater φ1) (oLater φ2)).
-End sec.
-
-Notation "d ↗n[ n ] φ" := (dm_to_type d n φ) (at level 20).
-End dot_experiments.

--- a/theories/misc_unused/hoInterps_experiments.v
+++ b/theories/misc_unused/hoInterps_experiments.v
@@ -399,12 +399,12 @@ Section gen_lemmas.
 
   (** * Kinded subtyping. *)
 
-  Lemma sSubK_Refl Γ {n} T (K : s_kind Σ n) i :
+  Lemma sKStp_Refl Γ {n} T (K : s_kind Σ n) i :
     Γ s⊨ T ∷[ i ] K -∗
     Γ s⊨ T <:[ i ] T ∷ K.
   Proof. done. Qed.
 
-  Lemma sSubK_Trans Γ {n} T1 T2 T3 (K : s_kind Σ n) i :
+  Lemma sKStp_Trans Γ {n} T1 T2 T3 (K : s_kind Σ n) i :
     Γ s⊨ T1 <:[ i ] T2 ∷ K -∗
     Γ s⊨ T2 <:[ i ] T3 ∷ K -∗
     Γ s⊨ T1 <:[ i ] T3 ∷ K.
@@ -416,15 +416,15 @@ Section gen_lemmas.
   (* Notation "" := sf_star. *)
   (* Notation "L  U" := (sf_kintv L U) (at level 70). *)
 
-  Lemma sSubK_Top Γ (T : olty Σ 0) i :
+  Lemma sKStp_Top Γ (T : olty Σ 0) i :
     Γ s⊨ T <:[ i ] ⊤ ∷ sf_star.
   Proof. rewrite -ksubtyping_intro. iIntros "!> * _ * !> _ //". Qed.
-  Lemma sSubK_Bot Γ (T : olty Σ 0) i :
+  Lemma sKStp_Bot Γ (T : olty Σ 0) i :
     Γ s⊨ ⊥ <:[ i ] T ∷ sf_star.
   Proof. rewrite -ksubtyping_intro; iIntros "!> * _ * !> []". Qed.
 
   (* <:-..-U *)
-  Lemma sSubK_IntvU Γ T L U i :
+  Lemma sKStp_IntvU Γ T L U i :
     Γ s⊨ T ∷[ i ] sf_kintv L U -∗
     Γ s⊨ T <:[ i ] U ∷ sf_star.
   Proof.
@@ -434,7 +434,7 @@ Section gen_lemmas.
   Qed.
 
   (* <:-..-L *)
-  Lemma sSubK_IntvL Γ T L U i :
+  Lemma sKStp_IntvL Γ T L U i :
     Γ s⊨ T ∷[ i ] sf_kintv L U -∗
     Γ s⊨ L <:[ i ] T ∷ sf_star.
   Proof.
@@ -503,8 +503,8 @@ Section dot_types.
   Proof. solve_proper_ho. Qed.
 
   Global Instance: Params (@sf_kind_sub) 4 := {}.
-  (** XXX Copy-paste of sSubK_AppV, plus hacks for missing Proper instances I guess? *)
-  Lemma sSubK_App Γ {n} (K : sf_kind Σ n) S T i v :
+  (** XXX Copy-paste of sKStp_AppV, plus hacks for missing Proper instances I guess? *)
+  Lemma sKStp_App Γ {n} (K : sf_kind Σ n) S T i v :
     Γ s⊨ T ∷[i] sf_kpi S K -∗
     Γ s⊨p pv v : S, i -∗
     Γ s⊨ oTApp T (pv v) ∷[i] K.|[v/].
@@ -543,7 +543,7 @@ Section dot_types.
     ∀ (H : alias_paths p q) ρ T1 T2,
     K1 ρ T1 T2 ≡ K2 ρ T1 T2 .
 
-  Lemma sSubK_App Γ {n} (K1 K2 : sf_kind Σ n) S T i p :
+  Lemma sKStp_App Γ {n} (K1 K2 : sf_kind Σ n) S T i p :
     Γ s⊨ T ∷[i] sf_kpi S K1 -∗
     Γ s⊨p p : S, i -∗
     Γ s⊨ oTAppV T v ∷[i] K2.
@@ -590,7 +590,7 @@ Section dot_types.
   (** Here [n]'s argument to oSel should be explicit. *)
   Global Arguments oSel {_ _} n p l args ρ : rename.
 
-  Lemma sSubK_TMem {n} Γ l (K1 K2 : s_kind Σ n) i :
+  Lemma sKStp_TMem {n} Γ l (K1 K2 : s_kind Σ n) i :
     Γ s⊨ K1 <∷[ i ] K2 -∗
     Γ s⊨ cTMemK l K1 <:[ i ] cTMemK l K2 ∷ sf_star.
   Proof using HswapProp.

--- a/theories/misc_unused/hoInterps_experiments.v
+++ b/theories/misc_unused/hoInterps_experiments.v
@@ -116,6 +116,10 @@ Proof.
   move=> T1 T2 /equiv_dist HT U1 U2 /equiv_dist HU.
   apply /equiv_dist => m. exact: sf_kind_sub_ne.
 Qed.
+Global Lemma Proper_sfkind' {Σ n} (K : sf_kind Σ n) ρ T1 T2 :
+  T1 ≡ T2 → K ρ T1 T1 ≡ K ρ T2 T2.
+Proof. intros Heq. by apply Proper_sfkind. Qed.
+
 Global Instance Proper_sfkind_A {Σ n} (K : sf_kind Σ n) ρ :
   Proper (pointwise_relation _ (≡) ==> pointwise_relation _ (≡) ==> (≡)) (K ρ).
 Proof. apply Proper_sfkind. Qed.
@@ -567,7 +571,7 @@ Section dot_types.
     by move => args ρ w; rewrite /= /hsubst /hsubst_hoEnvD/=; autosubst.
     iIntros "!> * #Hg"; rewrite sK_Lam kSubstOne_eq /=.
     iSpecialize ("Hp" with "Hg"); iSpecialize ("HK" with "Hg"); iNext i.
-    rewrite path_wp_pv_eq; by iApply (Proper_sfkind with "(HK Hp)").
+    rewrite path_wp_pv_eq. by iApply (Proper_sfkind' with "(HK Hp)").
   Qed.
 
   Definition oTApp {n} (T : oltyO Σ n.+1) (p : path) : oltyO Σ n :=

--- a/theories/misc_unused/hoInterps_experiments.v
+++ b/theories/misc_unused/hoInterps_experiments.v
@@ -321,6 +321,17 @@ Section gen_lemmas.
   (** Reflexivity and transitivity of subkinding are admissible. *)
 
   (** * Kinded subtyping. *)
+  Lemma ksubtyping_intro i Γ (T1 T2 : olty Σ 0) :
+    (□∀ ρ, s⟦ Γ ⟧* ρ -∗
+    ▷^i (∀ v, oClose T1 ρ v → oClose T2 ρ v)) -∗
+    Γ s⊨ T1 <:[ i ] T2 ∷ sf_star.
+  Proof.
+    iIntros "#Hsub !> * #Hg".
+    iDestruct ("Hsub" with "Hg") as "{Hsub Hg} Hsub"; iFrame "Hsub"; iClear "#".
+    iNext i; iSplit;
+      iIntros (v); [iIntros "!> []" | iIntros "!> _ //"].
+  Qed.
+
   Lemma sSubK_Refl Γ {n} T (K : s_kind Σ n) i :
     Γ s⊨ T ∷[ i ] K -∗
     Γ s⊨ T <:[ i ] T ∷ K.
@@ -354,9 +365,8 @@ Section dot_types.
     Γ s⊨ T1 <:[ i ] T2 ∷ sf_star ⊣⊢ Γ s⊨ T1 , i <: T2 , i.
   Proof using HswapProp.
     iSplit; first iApply sstpkD_star_to_sstp.
-    rewrite /sstpkD /sf_kind_sub/=; iIntros "#Hsub !>" (ρ) "#Hg"; repeat iSplit;
-      iIntros (v); [iIntros "!>!> []" | | iIntros "!>!> _ //"].
-    rewrite -mlaterN_pers -impl_laterN.
+    rewrite -ksubtyping_intro; iIntros "#Hsub !> * Hg" (v).
+    rewrite -impl_laterN.
     iApply ("Hsub" $! ρ v with "Hg").
   Qed.
 

--- a/theories/misc_unused/hoInterps_experiments.v
+++ b/theories/misc_unused/hoInterps_experiments.v
@@ -318,7 +318,23 @@ Section gen_lemmas.
     by iApply (Proper_sfkind with "HsubK").
   Qed.
 
-  (** Reflexivity and transitivity of subkinding are admissible. *)
+  (** Reflexivity and transitivity of subkinding seem admissible, but let's
+  prove them anyway, to show they hold regardless of extensions. *)
+  Lemma sKSub_Refl {n} Γ i (K : sf_kind Σ n) :
+    Γ s⊨ K <∷[ i ] K.
+  Proof using HswapProp.
+    rewrite /ssktp; setoid_rewrite <-(impl_laterN _).
+    iIntros "!> * Hg * $".
+  Qed.
+
+  Lemma sKSub_Trans {n} Γ i (K1 K2 K3 : sf_kind Σ n) :
+    Γ s⊨ K1 <∷[ i ] K2 -∗
+    Γ s⊨ K2 <∷[ i ] K3 -∗
+    Γ s⊨ K1 <∷[ i ] K3.
+  Proof using HswapProp.
+    iIntros "#Hs1 #Hs2 !> * #Hg *"; rewrite -impl_laterN; iIntros "#HK1".
+    iApply ("Hs2" with "Hg (Hs1 Hg HK1)").
+  Qed.
 
   (** * Kinded subtyping. *)
   Lemma ksubtyping_intro i Γ (T1 T2 : olty Σ 0) :
@@ -338,6 +354,38 @@ Section gen_lemmas.
   Proof.
     iIntros "#HK !>". iIntros (ρ) "#Hg".
     iApply (s_kind_refl with "(HK Hg)").
+  Qed.
+
+  Lemma sSubK_Trans Γ {n} T1 T2 T3 (K : s_kind Σ n) i :
+    Γ s⊨ T1 <:[ i ] T2 ∷ K -∗
+    Γ s⊨ T2 <:[ i ] T3 ∷ K -∗
+    Γ s⊨ T1 <:[ i ] T3 ∷ K.
+  Proof.
+    iIntros "#Hs1 #Hs2 !> * #Hg".
+    iApply (s_kind_trans with "(Hs1 Hg) (Hs2 Hg)").
+  Qed.
+
+  (* Notation "" := sf_star. *)
+  (* Notation "L  U" := (sf_kintv L U) (at level 70). *)
+
+  (* <:-..-U *)
+  Lemma sSubK_IntvU Γ T L U (K : s_kind Σ 0) i :
+    Γ s⊨ T ∷[ i ] (sf_kintv L U) -∗
+    Γ s⊨ T <:[ i ] U ∷ sf_star.
+  Proof.
+    rewrite -ksubtyping_intro; iIntros "#HK !> * Hg".
+    iDestruct ("HK" with "Hg") as "[_ Hsub]".
+    iNext i; iApply "Hsub".
+  Qed.
+
+  (* <:-..-L *)
+  Lemma sSubK_IntvL Γ T L U (K : s_kind Σ 0) i :
+    Γ s⊨ T ∷[ i ] (sf_kintv L U) -∗
+    Γ s⊨ L <:[ i ] T ∷ sf_star.
+  Proof.
+    rewrite -ksubtyping_intro; iIntros "#HK !> * Hg".
+    iDestruct ("HK" with "Hg") as "[Hsub _]".
+    iNext i; iApply "Hsub".
   Qed.
 End gen_lemmas.
 

--- a/theories/misc_unused/hoInterps_experiments.v
+++ b/theories/misc_unused/hoInterps_experiments.v
@@ -582,10 +582,10 @@ Section dot_types.
 
   Global Instance: Params (@sf_kind_sub) 4 := {}.
   (** XXX Copy-paste of sKStp_AppV, plus hacks for missing Proper instances I guess? *)
-  Lemma sKStp_App Γ {n} (K : sf_kind Σ n) S T i v :
-    Γ s⊨ T ∷[i] sf_kpi S K -∗
+  Lemma sKStp_App Γ {n} (K : sf_kind Σ n) S T1 T2 i v :
+    Γ s⊨ T1 <:[i] T2 ∷ sf_kpi S K -∗
     Γ s⊨p pv v : S, i -∗
-    Γ s⊨ oTApp T (pv v) ∷[i] K.|[v/].
+    Γ s⊨ oTApp T1 (pv v) <:[i] oTApp T2 (pv v) ∷ K.|[v/].
   Proof.
     iIntros "#HTK #Hv !> * #Hg". rewrite kSubstOne_eq /=.
     iSpecialize ("HTK" with "Hg"); iSpecialize ("Hv" with "Hg"); iNext i.


### PR DESCRIPTION
This PR proves typing rules about higher kinds, *except* `Sngl_pq_Sub` — that will need to be generalized to allow replacement in new types, also of non-zero arity; we'll also need an analogous subkinding rule for substitution into kinds.