### PR TITLE
Unbundle instances of an operational typeclass

### DIFF
--- a/theories/Dot/lr/unary_lr.v
+++ b/theories/Dot/lr/unary_lr.v
@@ -230,7 +230,7 @@ Section SemTypes.
   Global Instance sptp_persistent : IntoPersistent' (sptp p i   Γ T) | 0 := _.
 End SemTypes.
 
-Global Instance: Params (@oAll) 2 := {}.
+Global Instance: Params (@oAll) 3 := {}.
 
 (* Backward compatibility. *)
 Notation "D*⟦ T ⟧" := (ldlty_car LD⟦ T ⟧).
@@ -365,7 +365,7 @@ Section Propers.
   Global Instance Proper_sstpi_flip i j :
     Proper ((≡) --> (≡) --> (≡) --> flip (≡)) (sstpi i j).
   Proof. apply: flip_proper_4. Qed.
-  Global Instance: Params (@sstpi) 4 := {}.
+  Global Instance: Params (@sstpi) 5 := {}.
 
 
   Global Instance Proper_setp e : Proper ((≡) ==> (≡) ==> (≡)) (setp e).
@@ -376,7 +376,7 @@ Section Propers.
   Global Instance Proper_setp_flip e :
     Proper (flip (≡) ==> flip (≡) ==> flip (≡)) (setp e).
   Proof. apply: flip_proper_3. Qed.
-  Global Instance: Params (@setp) 3 := {}.
+  Global Instance: Params (@setp) 4 := {}.
 
 
   Global Instance Proper_sdtp l d : Proper ((≡) ==> (≡) ==> (≡)) (sdtp l d).
@@ -386,14 +386,14 @@ Section Propers.
   Qed.
   Global Instance Proper_sdtp_flip l d : Proper (flip (≡) ==> flip (≡) ==> flip (≡)) (sdtp l d).
   Proof. apply: flip_proper_3. Qed.
-  Global Instance: Params (@sdtp) 4 := {}.
+  Global Instance: Params (@sdtp) 5 := {}.
 
 
   Global Instance Proper_sptp p i : Proper ((≡) ==> (≡) ==> (≡)) (sptp p i).
   Proof. solve_proper_ho. Qed.
   Global Instance Proper_sptp_flip p i : Proper ((≡) --> (≡) --> flip (≡)) (sptp p i).
   Proof. apply: flip_proper_3. Qed.
-  Global Instance: Params (@sptp) 4 := {}.
+  Global Instance: Params (@sptp) 5 := {}.
 End Propers.
 
 Section defs.

--- a/theories/Dot/stamping/skeleton.v
+++ b/theories/Dot/stamping/skeleton.v
@@ -461,9 +461,7 @@ Theorem simulation_skeleton_erased_steps {t1 t1' t2 σ σ' } :
   rtc L.erased_step ([t1], σ) ([t2], σ') →
   ∃ t2', rtc erased_step ([t1'], σ) ([t2'], σ') ∧ same_skel_tm t2 t2'.
 Proof.
-  (* XXX Hack. *)
-  have Heq := !!pure_steps_erased'; destruct σ, σ', dummyState.
-  setoid_rewrite <-Heq.
+  uniqueState; setoid_rewrite <-pure_steps_erased'.
 
   intros Hst Hsteps; revert t1' Hst.
   induction Hsteps; intros ??.

--- a/theories/iris_extra/det_reduction.v
+++ b/theories/iris_extra/det_reduction.v
@@ -62,7 +62,7 @@ Definition safe_gen {Λ} (e : L.expr Λ) :=
   ∀ e' thp σ σ', rtc erased_step ([e], σ) (thp, σ') → e' ∈ thp →
     L.not_stuck e' σ'.
 
-Definition safe_simpl `{!LangDet Λ} (e : L.expr Λ) :=
+Definition safe_simpl `{LangDet Λ} (e : L.expr Λ) :=
   ∀ e', rtc pure_step e e' → not_stuck e'.
 
 Hint Constructors rtc : core.
@@ -80,7 +80,7 @@ Proof.
   edestruct Hpure; [exact: Hsafe|] => {Hpure}. naive_solver.
 Qed.
 
-Context `{!LangDet Λ}.
+Context `{HlangDet : LangDet Λ}.
 Lemma prim_step_pure {e1 e2 σ1 κ σ2 efs} :
   L.prim_step e1 σ1 κ e2 σ2 efs → pure_step e1 e2.
 Proof. move => /prim_step_PureExec /(_ I). exact: nsteps_once_inv. Qed.
@@ -182,7 +182,7 @@ End LangDet.
 Hint Resolve ->pure_step_erased : core.
 Hint Resolve <-pure_step_erased : core.
 
-Lemma rtc_erased_step_inversion' `{!LangDet Λ} {t1 : L.expr Λ} {res σ}
+Lemma rtc_erased_step_inversion' `{LangDet Λ} {t1 : L.expr Λ} {res σ}
   (Hs : rtc erased_step ([t1], σ) res) :
   ∃ t2, res = ([t2], σ).
 Proof.
@@ -204,7 +204,7 @@ Proof.
 Qed.
 
 Section LangDet.
-Context `{!LangDet Λ}.
+Context `{HlangDet : LangDet Λ}.
 Implicit Type (e t : L.expr Λ).
 
 Theorem rtc_erased_step_inversion {t1 t2 σ σ' thp} :

--- a/theories/iris_extra/det_reduction.v
+++ b/theories/iris_extra/det_reduction.v
@@ -21,24 +21,23 @@ Qed.
 Instance unit_pi: ProofIrrel ().
 Proof. by intros [] []. Qed.
 
-Class UniqueInhabited A := {
-  unique_inhabited : Inhabited A;
-  unique_proof_irrel : ProofIrrel A;
-}.
-Existing Instances unique_inhabited unique_proof_irrel.
-
-Class LangDet Λ := {
+(* Instances of [Inhabited] must not be bundled, as usual for operational type
+classes. *)
+Notation InhabitedState Λ := (Inhabited (L.state Λ)).
+Class LangDet (Λ : L.language) `{InhabitedState Λ} := {
   prim_step_PureExec (e1 e2 : L.expr Λ) σ1 κ σ2 efs :
     L.prim_step e1 σ1 κ e2 σ2 efs → PureExec True 1 e1 e2;
-  lang_inh_state : UniqueInhabited (L.state Λ)
+  lang_inh_state : ProofIrrel (L.state Λ)
 }.
+Arguments LangDet Λ {_}.
 Existing Instance lang_inh_state.
 
-Class EctxLangDet (Λ : EL.ectxLanguage) := {
+Class EctxLangDet (Λ : EL.ectxLanguage) `{InhabitedState Λ} := {
   head_step_PureExec (e1 e2 : L.expr Λ) σ1 κ σ2 efs :
     EL.head_step e1 σ1 κ e2 σ2 efs → L.PureExec True 1 e1 e2;
-  ectx_inh_state : UniqueInhabited (L.state Λ)
+  ectx_inh_state :> ProofIrrel (L.state Λ)
 }.
+Arguments EctxLangDet Λ {_}.
 Existing Instance ectx_inh_state.
 
 Notation dummyState := (inhabitant (A := L.state _)).

--- a/theories/iris_extra/det_reduction.v
+++ b/theories/iris_extra/det_reduction.v
@@ -44,7 +44,11 @@ Notation dummyState := (inhabitant (A := L.state _)).
 
 Ltac uniqueState :=
   repeat match goal with
-  | s : L.state _ |- _ => assert (s = dummyState) as -> by apply: proof_irrel
+  | s : ?T |- _ =>
+    let Λ := fresh "Λ" in
+    evar (Λ : language);
+    unify T (L.state ?Λ); clear Λ;
+    assert (s = dummyState) as -> by exact: proof_irrel
   end.
 
 (** This defines, in fact, pure and deterministic termination. *)

--- a/theories/iris_extra/dlang.v
+++ b/theories/iris_extra/dlang.v
@@ -49,7 +49,7 @@ Module Type LiftWp (Import VS : VlSortsSig).
   Local Definition test_interp_expr `{dlangG Σ} :=
     λI (t: expr dlang_lang), WP t {{ v, False }}.
 
-  Definition leadsto_n `{!dlangG Σ}
+  Definition leadsto_n `{dlangG Σ}
     s n (φ : hoEnvD Σ n) : iProp Σ := ∃ γ, s ↦ γ ∧ γ ⤇n[ n ] φ.
   Notation "s ↝n[ n  ] φ" := (leadsto_n s n φ) (at level 20) : bi_scope.
 
@@ -57,18 +57,18 @@ Module Type LiftWp (Import VS : VlSortsSig).
     λne φ, λ args, φ args (∞ σ).
   Next Obligation. move => i Σ σ n x y Heq args. exact: Heq. Qed.
 
-  Definition stamp_σ_to_type_n `{!dlangG Σ} s σ n (ψ : hoD Σ n) : iProp Σ :=
+  Definition stamp_σ_to_type_n `{dlangG Σ} s σ n (ψ : hoD Σ n) : iProp Σ :=
     ∃ φ : hoEnvD Σ n, s ↝n[ n ] φ ∧ ▷ (ψ ≡ hoEnvD_inst σ φ).
   Notation "s ↗n[ σ , n  ] ψ" := (stamp_σ_to_type_n s σ n ψ) (at level 20): bi_scope.
 
-  Definition leadsto_envD_equiv `{!dlangG Σ} {i} s σ (φ : hoEnvD Σ i) : iProp Σ :=
+  Definition leadsto_envD_equiv `{dlangG Σ} {i} s σ (φ : hoEnvD Σ i) : iProp Σ :=
     ∃ (φ' : hoEnvD Σ i),
       ⌜φ ≡ (λ args ρ, φ' args (∞ σ.|[ρ]))⌝ ∧ s ↝n[ i ] φ'.
   Arguments leadsto_envD_equiv /.
   Notation "s ↝[ σ  ] φ" := (leadsto_envD_equiv s σ φ) (at level 20).
 
   Section mapsto.
-    Context `{!dlangG Σ}.
+    Context `{Hdlang : dlangG Σ}.
 
     Global Instance: Contractive (leadsto_n s n).
     Proof. solve_contractive. Qed.
@@ -173,7 +173,7 @@ Module Type LiftWp (Import VS : VlSortsSig).
     Qed.
 
     Section sem.
-      Context `{Hdlang : !dlangG Σ}.
+      Context `{Hdlang : dlangG Σ}.
       Implicit Types (gφ : gmap stamp (hoEnvD Σ 0)).
 
       Definition wellMappedφ gφ : iProp Σ :=

--- a/theories/iris_extra/dlang.v
+++ b/theories/iris_extra/dlang.v
@@ -34,12 +34,12 @@ Module Type LiftWp (Import VS : VlSortsSig).
 
   Instance InhEnvPred s Σ : Inhabited (envPred s Σ) := populate (λI _ _, False).
 
-  Class dlangG Σ := DLangG {
+  Class dlangG Σ `{InhabitedState dlang_lang} := DLangG {
     dlangG_savior :> savedHoSemTypeG Σ;
     dlangG_interpNames :> gen_iheapG stamp gname Σ;
     dlangG_langdet :> LangDet dlang_lang;
   }.
-  Arguments DLangG _ {_ _ _}.
+  Arguments DLangG _ {_ _ _ _}.
 
   Instance dlangG_irisG `{dlangG Σ} : irisG dlang_lang Σ := {
     irisG_langdet := _;

--- a/theories/misc_unused/hoInterps_bad.v
+++ b/theories/misc_unused/hoInterps_bad.v
@@ -213,7 +213,7 @@ Arguments spine_s_kind : clear implicits.
 
 
 Section semkinds.
-  Context `{dlangG Σ}.
+  Context `{!dlangG Σ}.
 
   Definition sp_s_kintv (L U : olty Σ 0) : spine_s_kind Σ 0 := SpineSK vnil L U.
   Definition sp_s_kpi {n} (S : olty Σ 0) (K : spine_s_kind Σ n) : spine_s_kind Σ n.+1 :=
@@ -287,7 +287,7 @@ Module HoGenExperiments.
 Import swap_later_impl HkDot2.
 
 Section sec.
-  Context `{dlangG Σ} `{HswapProp: SwapPropI Σ}.
+  Context `{!dlangG Σ} `{HswapProp: SwapPropI Σ}.
 
   (* Unused *)
   Program Definition hLaterN {n} i: hoLtyO Σ n -n> hoLtyO Σ n :=

--- a/theories/misc_unused/hoInterps_experiments.v
+++ b/theories/misc_unused/hoInterps_experiments.v
@@ -327,7 +327,7 @@ Notation "Γ s⊨ K1 <∷[ i  ] K2" := (sSkd i Γ K1 K2)
   (at level 74, K1, K2 at next level).
 
 Section gen_lemmas.
-  Context `{dlangG Σ} `{HswapProp: SwapPropI Σ}.
+  Context `{Hdlang : dlangG Σ} `{HswapProp: SwapPropI Σ}.
 
   Local Notation IntoPersistent' P := (IntoPersistent false P P).
 
@@ -615,7 +615,7 @@ Notation "K1 ~sKd[ p := q  ]* K2" :=
   (sem_kind_path_repl p q K1 K2) (at level 70).
 
 Section dot_types.
-  Context `{dlangG Σ} `{HswapProp: SwapPropI Σ}.
+  Context `{!dlangG Σ} `{HswapProp: SwapPropI Σ}.
 
   Program Definition kpSubstOne {n} p (K : sf_kind Σ n) : sf_kind Σ n :=
     SfKind
@@ -841,7 +841,7 @@ Fixpoint s_kind_to_sf_kind {Σ n} (K : s_kind Σ n) : sf_kind Σ n :=
 Coercion s_kind_to_sf_kind : s_kind >-> sf_kind.
 
 Section derived.
-  Context `{Hdlang : dlangG Σ} `{HswapProp : SwapPropI Σ}.
+  Context `{Hdlang : !dlangG Σ} `{HswapProp : SwapPropI Σ}.
 
   (* XXX Missing: Proper oShift, Proper oTAppV, Proper ho_intv *)
 
@@ -995,7 +995,7 @@ Section derived.
 End derived.
 
 Section examples.
-  Context `{dlangG Σ} `{HswapProp: SwapPropI Σ}.
+  Context `{!dlangG Σ} `{HswapProp: SwapPropI Σ}.
   Import DBNotation dot_lty.
 
   Definition oId := oLam (oSel 0 x0 "A").
@@ -1013,7 +1013,7 @@ Section examples.
 End examples.
 
 Section dot_experimental_kinds.
-  Context `{dlangG Σ}.
+  Context `{!dlangG Σ}.
 
   (* WTF why am I proving this? To support more kinds? *)
   (* Make this derivable from sth. like.

--- a/theories/misc_unused/hoInterps_experiments.v
+++ b/theories/misc_unused/hoInterps_experiments.v
@@ -344,7 +344,7 @@ Section gen_lemmas.
     (* Time by apply sf_kind_sub_proper => //; f_equiv. *)
     by apply Proper_sfkind; f_equiv.
   Qed.
-  Global Instance: Params (@sstpiK) 4 := {}.
+  Global Instance: Params (@sstpiK) 5 := {}.
 
   Global Instance Proper_sSkd n i :
     Proper ((≡) ==> (≡) ==> (≡) ==> (≡)) (sSkd (Σ := Σ) (n := n) i).
@@ -352,7 +352,7 @@ Section gen_lemmas.
     rewrite /sSkd => Γ1 Γ2 HΓ K1 K2 HK1 K3 K4 HK2.
     by properness; rewrite (HΓ, HK1, HK2).
   Qed.
-  Global Instance: Params (@sSkd) 4 := {}.
+  Global Instance: Params (@sSkd) 5 := {}.
 
   Lemma shift_sstpiK S Γ {n i} (T1 T2 : olty Σ n) K :
     Γ s⊨ T1 <:[ i ] T2 ∷ K -∗
@@ -747,7 +747,7 @@ Section dot_types.
   (** [cTMem] and [cVMem] are full [clty]. *)
   Definition cTMemK {n} l (K : sf_kind Σ n) : clty Σ := ldlty2clty (oLDTMemK l K).
   (** Here [n]'s argument to oSel should be explicit. *)
-  Global Arguments oSel {_ _} n p l args ρ : rename.
+  Global Arguments oSel {_ _ _} n p l args ρ : rename.
 
   Lemma sKStp_TMem {n} Γ l (K1 K2 : sf_kind Σ n) i :
     Γ s⊨ K1 <∷[ i ] K2 -∗

--- a/theories/misc_unused/hoInterps_experiments.v
+++ b/theories/misc_unused/hoInterps_experiments.v
@@ -308,7 +308,7 @@ Section kinds_types.
 End kinds_types.
 
 (** Kinded, Indexed SubTyPing *)
-Definition sstpiK `{!dlangG Σ} {n} i Γ T1 T2 (K : sf_kind Σ n) : iProp Σ :=
+Definition sstpiK `{dlangG Σ} {n} i Γ T1 T2 (K : sf_kind Σ n) : iProp Σ :=
   □∀ ρ, s⟦Γ⟧*ρ → ▷^i K ρ (envApply T1 ρ) (envApply T2 ρ).
 Notation "Γ s⊨ T1 <:[ i  ] T2 ∷ K" := (sstpiK i Γ T1 T2 K)
   (at level 74, i, T1, T2, K at next level).
@@ -321,7 +321,7 @@ Notation "Γ s⊨ T ∷[ i  ] K" := (Γ s⊨ T <:[ i ] T ∷ K)
   (at level 74, T, K at next level).
 
 (* Semantic SubKinding *)
-Definition sSkd `{!dlangG Σ} {n} i Γ (K1 K2 : sf_kind Σ n) : iProp Σ :=
+Definition sSkd `{dlangG Σ} {n} i Γ (K1 K2 : sf_kind Σ n) : iProp Σ :=
   □∀ ρ, s⟦Γ⟧*ρ → ∀ (T1 T2 : hoLtyO Σ n), ▷^i (K1 ρ T1 T2 → K2 ρ T1 T2).
 Notation "Γ s⊨ K1 <∷[ i  ] K2" := (sSkd i Γ K1 K2)
   (at level 74, K1, K2 at next level).

--- a/theories/pure_program_logic/adequacy.v
+++ b/theories/pure_program_logic/adequacy.v
@@ -29,7 +29,7 @@ Proof.
 Qed. *)
 
 Section adequacy.
-Context `{!irisG Λ Σ}.
+Context `{Hiris : irisG Λ Σ}.
 
 Implicit Types e : expr Λ.
 Implicit Types P Q : iProp Σ.

--- a/theories/pure_program_logic/weakestpre.v
+++ b/theories/pure_program_logic/weakestpre.v
@@ -13,10 +13,10 @@ precondition: it uses no (basic/fancy) updates, does not supports Iris invariant
 and is specialized to deterministic languages.
 *)
 
-Class irisG (Λ : language) (Σ : gFunctors) := IrisG {
+Class irisG (Λ : language) (Σ : gFunctors) `{InhabitedState Λ} := IrisG {
   irisG_langdet :> LangDet Λ
 }.
-Arguments IrisG _ _ {_}.
+Arguments IrisG _ _ {_ _}.
 Local Notation σ := dummyState.
 
 Definition wp_pre `{irisG Λ Σ}


### PR DESCRIPTION
This fixes a bundling issue that appeared in `skeleton.v`. While the fix is a bit annoying, and requires now correctly abstracting over `dlangG` instances via `Context`, it's sadly the correct one — and maybe those abstractions should be written differently.