### PR TITLE
Drop support for Coq 8.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ env:
   - CONTRIB_NAME="dot-iris"
   - OPAM_NAME="dot-iris-builddep"
   matrix:
-  - COQ_IMAGE="blaisorblade/docker-dot-iris:coq-8.10.2-iris-2020-04-04.3.9b2ad256"
   - COQ_IMAGE="blaisorblade/docker-dot-iris:coq-8.11.1-iris-2020-04-04.3.9b2ad256"
   # this config uses: $COMPILER_EDGE (cf. "opam switch" command below)
   # See https://github.com/coq-community/docker-coq/wiki#supported-tags

--- a/README.md
+++ b/README.md
@@ -41,10 +41,13 @@ Inside the `Dot` folder:
 * `fundamental.v`: prove fundamental theorem, adequacy and type safety.
 
 ## Installation
-### Iris version
+### Coq/Iris version
 
-Install the Coq and Iris version specified in `opam`, for instance via
-`opam install coq.<insert Coq version here> coq-iris.<insert version here>`.
+The supported Coq and Iris versions are specified in `opam`; we currently assume
+Coq 8.11.1 (and we know of bugs in both 8.10.2 and 8.11.0).
+
+Install those exact versions, for instance via
+`opam install coq.8.11.1 coq-iris.<insert version here>`.
 
 ### To use opam 2.0
 

--- a/opam
+++ b/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/Blaisorblade/dot-iris"
 bug-reports: "https://github.com/Blaisorblade/dot-iris/issues"
 synopsis: "(Dependencies for) Mechanization of gDOT in Iris"
 depends: [
-  "coq" { (>= "8.10" & != "8.11.0" & < "8.12~") }
+  "coq" { (>= "8.11.1" & < "8.12~") }
   "coq-iris" { = "dev.2020-04-04.3.9b2ad256" }
   "coq-autosubst" { = "dev.coq86" }
 ]

--- a/theories/asubst_base.v
+++ b/theories/asubst_base.v
@@ -370,7 +370,7 @@ Lemma nclosed_ren_rev_var i j k n:
   nclosed_vl (ids n).[upn k (ren (+j))] (i + j + k) → nclosed_vl (ids n) (i + k).
 Proof.
   rewrite !id_subst iter_up !rename_subst id_subst /=.
-  case_match; rewrite /= !nclosed_vl_ids_equiv; omega.
+  case_match; rewrite /= !nclosed_vl_ids_equiv; lia.
 Qed.
 
 (* Rewrite lemmas to be faster than asimpl: *)

--- a/theories/prelude.v
+++ b/theories/prelude.v
@@ -140,13 +140,11 @@ Section Autosubst_Lemmas.
           {rename_term : Rename term} {subst_term : Subst term}
           {subst_lemmas_term : SubstLemmas term}.
 
-  (* lia fails here, because some inequalities are used
-      in other hypotheses. *)
   Lemma iter_up (m x : nat) (f : var → term) :
     upn m f x = if lt_dec x m then ids x else rename (+m) (f (x - m)).
   Proof.
     elim: m x => [|m IH] [|x]; case_match => //; asimpl; rewrite // IH;
-      case_match; (omega || autosubst).
+      case_match; (lia || autosubst).
   Qed.
 
   Lemma upn_comp n m f : upn n (upn m f) = upn (n + m) f.


### PR DESCRIPTION
Supporting 8.10 requires more testing than it is worth, including workarounds for things like `lia` bugs.

Agreed with Robbert.