### PR TITLE
Cleanup: replace iterate oLater with oLaterN

### DIFF
--- a/theories/Dot/examples/examples.v
+++ b/theories/Dot/examples/examples.v
@@ -390,7 +390,7 @@ Section small_ex.
   Proof.
     iIntros "#Hs".
     iApply (sT_Sub (i := 0) (T1 := sminiVT2Concr)); first last.
-    - iApply sMu_Sub_Mu; rewrite /sminiVT2ConcrBody /miniVT1Body iterate_0.
+    - iApply sMu_Sub_Mu; rewrite /sminiVT2ConcrBody /miniVT1Body oLaterN_0.
       iApply sSub_And; last iApply sSub_And; last iApply sSub_Top.
     + iApply sSub_Trans; first iApply sAnd1_Sub.
       iApply sTyp_Sub_Typ; [iApply sBot_Sub | iApply Sub_later_ipos_nat].

--- a/theories/Dot/lr/lr_lemmas.v
+++ b/theories/Dot/lr/lr_lemmas.v
@@ -54,14 +54,14 @@ Section Sec.
   (* An inverse of subsumption: subtyping is *equivalent* to convertibility
   for values. *)
   Lemma sSub_Skolem_P {Γ T1 T2 i j}:
-    iterate oLater i (shift T1) :: Γ s⊨p pv (ids 0) : shift T2, j -∗
+    oLaterN i (shift T1) :: Γ s⊨p pv (ids 0) : shift T2, j -∗
     (*───────────────────────────────*)
     Γ s⊨ T1, i <: T2, j.
   Proof.
     iIntros "#Htyp !>" (ρ v) "#Hg #HvT1".
     iEval rewrite -path_wp_pv_eq.
     iApply ("Htyp" $! (v .: ρ) with "[$Hg ]").
-    by rewrite iterate_oLater_later; iApply "HvT1".
+    by iApply "HvT1".
   Qed.
 
   Lemma sSub_Skolem_P' Γ T1 T2:
@@ -80,7 +80,7 @@ Section Sec.
   Qed.
 
   Lemma sSub_Skolem_T {Γ T1 T2 i}:
-    iterate oLater i (shift T1) :: Γ s⊨ tv (ids 0) : shift T2 -∗
+    oLaterN i (shift T1) :: Γ s⊨ tv (ids 0) : shift T2 -∗
     (*───────────────────────────────*)
     Γ s⊨ T1, i <: T2, 0.
   Proof. by rewrite sP_Val sSub_Skolem_P. Qed.
@@ -157,12 +157,11 @@ Section Sec.
      Γ ⊨ μ (x: T₁ˣ) <: μ(x: T₂ˣ)
   *)
   Lemma sMu_Sub_Mu {Γ T1 T2 i j} :
-    iterate oLater i T1 :: Γ s⊨ T1, i <: T2, j -∗
+    oLaterN i T1 :: Γ s⊨ T1, i <: T2, j -∗
     Γ s⊨ oMu T1, i <: oMu T2, j.
   Proof.
     iIntros "/= #Hstp !>" (vs v) "#Hg #HT1".
-    iApply ("Hstp" $! (v .: vs) v with "[# $Hg] [#//]").
-    by rewrite iterate_oLater_later.
+    iApply ("Hstp" $! (v .: vs) v with "[$Hg $HT1] [$HT1]").
   Qed.
 
   (** Novel subtyping rules. [Sub_Bind_1] and [Sub_Bind_2] become
@@ -344,10 +343,9 @@ Section swap_based_typing_lemmas.
 
   Lemma sAll_Sub_All {Γ T1 T2 U1 U2 i}:
     Γ s⊨ oLater T2, i <: oLater T1, i -∗
-    iterate oLater (S i) (shift T2) :: Γ s⊨ oLater U1, i <: oLater U2, i -∗
+    oLaterN (S i) (shift T2) :: Γ s⊨ oLater U1, i <: oLater U2, i -∗
     Γ s⊨ oAll T1 U1, i <: oAll T2 U2, i.
   Proof.
-    rewrite iterate_S /=.
     iIntros "#HsubT #HsubU /= !>" (ρ v) "#Hg #HT1".
     iDestruct "HT1" as (t) "#[Heq #HT1]". iExists t; iSplit => //.
     iIntros (w).
@@ -356,7 +354,7 @@ Section swap_based_typing_lemmas.
     iSpecialize ("HsubT" $! ρ w with "Hg HwT2").
     iSpecialize ("HsubU" $! (w .: ρ)); iEval (rewrite -forall_swap_impl) in "HsubU".
     iSpecialize ("HsubU" with "[# $Hg]").
-    by rewrite iterate_oLater_later -swap_later /=; iApply hoEnvD_weaken_one.
+    by rewrite -swap_later /=; iApply hoEnvD_weaken_one.
     setoid_rewrite mlaterN_impl; setoid_rewrite mlater_impl.
     iNext i; iNext 1. iModIntro. iApply wp_wand.
     - iApply ("HT1" with "[]"). iApply "HsubT".

--- a/theories/Dot/lr/unary_lr.v
+++ b/theories/Dot/lr/unary_lr.v
@@ -322,10 +322,6 @@ Section MiscLemmas.
     iApply ("Hsub2" with "[//] (Hsub1 [//] [//])").
   Qed.
 
-  Lemma iterate_oLater_later {i} (τ : oltyO Σ i) n args ρ v:
-    iterate oLater n τ args ρ v ⊣⊢ ▷^n τ args ρ v.
-  Proof. elim: n => [//|n IHn]. by rewrite iterate_S /= IHn. Qed.
-
   Lemma sSub_Eq {Γ T U i j} :
     Γ s⊨ T, i <: U, j ⊣⊢
     Γ s⊨ iterate oLater i T, 0 <: iterate oLater j U, 0.
@@ -409,6 +405,10 @@ Section defs.
     by rewrite (iterate_TLater_oLater n T _ _ _) iterate_oLater_later.
   Qed.
 
+  Lemma sSub_Eq' {Γ T U i j} :
+    V⟦ Γ ⟧* s⊨ V⟦ T ⟧, i <: V⟦ U ⟧, j ⊣⊢
+    V⟦ Γ ⟧* s⊨ V⟦ iterate TLater i T ⟧, 0 <: V⟦ iterate TLater j U ⟧, 0.
+  Proof. by rewrite sSub_Eq !iterate_TLater_oLater. Qed.
 
 
   Lemma P_Val {Γ} v T: Γ ⊨ tv v : T -∗ Γ ⊨p pv v : T, 0.

--- a/theories/Dot/lr/unary_lr.v
+++ b/theories/Dot/lr/unary_lr.v
@@ -324,8 +324,8 @@ Section MiscLemmas.
 
   Lemma sSub_Eq {Γ T U i j} :
     Γ s⊨ T, i <: U, j ⊣⊢
-    Γ s⊨ iterate oLater i T, 0 <: iterate oLater j U, 0.
-  Proof. cbn. by setoid_rewrite iterate_oLater_later. Qed.
+    Γ s⊨ oLaterN i T, 0 <: oLaterN j U, 0.
+  Proof. done. Qed.
 
   Lemma ipwp_terminates {p T i}:
     [] s⊨p p : T , i ⊢ ▷^i ⌜ terminates (path2tm p) ⌝.
@@ -396,16 +396,14 @@ Section defs.
   Context `{HdotG: dlangG Σ}.
 
   Lemma iterate_TLater_oLater i T:
-    V⟦iterate TLater i T⟧ ≡ iterate oLater i V⟦T⟧.
+    V⟦iterate TLater i T⟧ ≡ oLaterN i V⟦T⟧.
   Proof. elim: i => [//|i IHi] ???. by rewrite !iterate_S /= (IHi _ _ _). Qed.
 
   Lemma iterate_TLater_later T n args ρ v:
     V⟦ iterate TLater n T ⟧ args ρ v ⊣⊢ ▷^n V⟦ T ⟧ args ρ v.
-  Proof.
-    by rewrite (iterate_TLater_oLater n T _ _ _) iterate_oLater_later.
-  Qed.
+  Proof. by rewrite (iterate_TLater_oLater n T _ _ _). Qed.
 
-  Lemma sSub_Eq' {Γ T U i j} :
+  Lemma sSub_iterate_TLater_Eq {Γ T U i j} :
     V⟦ Γ ⟧* s⊨ V⟦ T ⟧, i <: V⟦ U ⟧, j ⊣⊢
     V⟦ Γ ⟧* s⊨ V⟦ iterate TLater i T ⟧, 0 <: V⟦ iterate TLater j U ⟧, 0.
   Proof. by rewrite sSub_Eq !iterate_TLater_oLater. Qed.
@@ -425,7 +423,7 @@ Section defs.
   Lemma Sub_Eq {Γ T U i j} :
     Γ ⊨ T, i <: U, j ⊣⊢
     Γ ⊨ iterate TLater i T, 0 <: iterate TLater j U, 0.
-  Proof. by rewrite /istpi sSub_Eq !iterate_TLater_oLater. Qed.
+  Proof. by rewrite /istpi sSub_iterate_TLater_Eq. Qed.
 End defs.
 
 (** Backward compatibility. *)

--- a/theories/iris_extra/lty.v
+++ b/theories/iris_extra/lty.v
@@ -265,14 +265,6 @@ Section olty_ofe_2.
     oLaterN (S n) T ≡ oLaterN n (oLater T).
   Proof. move => ???/=. by rewrite swap_later. Qed.
 
-  Lemma oLaterN_iterate_oLater_eq (T : olty Σ i) n :
-    iterate oLater n T ≡ oLaterN n T.
-  Proof. elim: n => [//|n IHn]. by rewrite iterate_S /= IHn => ???. Qed.
-
-  Lemma iterate_oLater_later (τ : oltyO Σ i) n args ρ v:
-    iterate oLater n τ args ρ v ⊣⊢ ▷^n τ args ρ v.
-  Proof. apply: oLaterN_iterate_oLater_eq. Qed.
-
   Global Instance env_oltyped_persistent (Γ : sCtx Σ) ρ: Persistent (s⟦ Γ ⟧* ρ).
   Proof. elim: Γ ρ => [|τ Γ IHΓ] ρ /=; apply _. Qed.
 

--- a/theories/iris_extra/lty.v
+++ b/theories/iris_extra/lty.v
@@ -276,16 +276,13 @@ Section olty_ofe_2.
   Global Instance Proper_oOr : Proper ((≡) ==> (≡) ==> (≡)) oOr.
   Proof. solve_proper_ho. Qed.
 
+  Definition oLaterN n (τ : oltyO Σ i) := Olty (λI args ρ v, ▷^n τ args ρ v).
 
-  Definition eLater n (φ : hoEnvD Σ i) : hoEnvD Σ i := (λI args ρ v, ▷^n φ args ρ v).
-  Global Arguments eLater /.
-  Definition oLater τ : oltyO Σ i := Olty (eLater 1 τ).
-
-  Global Instance oLater_ne n : Proper (dist n ==> dist n) oLater.
+  Global Instance oLaterN_ne m : NonExpansive (oLaterN m).
   Proof. solve_proper_ho. Qed.
-  Global Instance oLater_proper : Proper ((≡) ==> (≡)) oLater := ne_proper _.
+  Global Instance oLaterN_proper m : Proper ((≡) ==> (≡)) (oLaterN m) := ne_proper _.
 
-  Lemma oLater_eq τ args ρ v : oLater τ args ρ v = (▷ τ args ρ v)%I.
+  Lemma oLaterN_eq n τ args ρ v : oLaterN n τ args ρ v = (▷^n τ args ρ v)%I.
   Proof. done. Qed.
 
 
@@ -310,4 +307,5 @@ Section olty_ofe_2.
 End olty_ofe_2.
 
 Notation "E⟦ τ ⟧" := (interp_expr τ).
+Notation oLater := (oLaterN 1).
 End Lty.

--- a/theories/iris_extra/lty.v
+++ b/theories/iris_extra/lty.v
@@ -301,6 +301,17 @@ Section olty_ofe_2.
     λI ρ t, □ WP t {{ vclose φ ρ }}.
   Global Arguments interp_expr /.
 
+  Lemma swap_oMu_oLaterN (τ : oltyO Σ i) n :
+    oLaterN n (oMu τ) ≡ oMu (oLaterN n τ).
+  Proof. done. Qed.
+
+  Lemma swap_oAnd_oLaterN (τ1 τ2 : oltyO Σ i) n :
+    oLaterN n (oAnd τ1 τ2) ≡ oAnd (oLaterN n τ1) (oLaterN n τ2).
+  Proof. move => args ρ v /=. by rewrite laterN_and. Qed.
+
+  Lemma swap_oOr_oLaterN (τ1 τ2 : oltyO Σ i) n :
+    oLaterN n (oOr τ1 τ2) ≡ oOr (oLaterN n τ1) (oLaterN n τ2).
+  Proof. move => args ρ v /=. by rewrite laterN_or. Qed.
 
   Definition oSel_raw `{dlangG Σ} s σ :=
     Olty (λI args ρ v, ∃ ψ, s ↗n[σ, i] ψ ∧ ▷ □ ψ args v).

--- a/theories/misc_unused/hoInterps_experiments.v
+++ b/theories/misc_unused/hoInterps_experiments.v
@@ -948,7 +948,7 @@ Section derived.
     iIntros "#HT #Hs".
     iApply (sP_Sub (i := 0) (j := 0) (T1 := oMu (cAnd (cTMemK l (ho_sing K (oLater T))) cTop))).
     rewrite sK_HoIntv; iApply (sP_New1 with "HT Hs").
-    iApply sMu_Sub_Mu; rewrite iterate_0.
+    iApply sMu_Sub_Mu; rewrite oLaterN_0.
     iApply sSub_Trans; first iApply sAnd1_Sub.
     iApply sSub_And; last iApply sSub_Top.
     rewrite -sstpiK_star_eq_sstp.

--- a/theories/misc_unused/hoInterps_experiments.v
+++ b/theories/misc_unused/hoInterps_experiments.v
@@ -850,21 +850,10 @@ Section derived.
     end.
 
   (* XXX *)
-  Lemma oLaterN_eq {n} (T : olty Σ n) i :
-    oLaterN i T ≡ iterate oLater i T.
-  Proof using Hdlang. move=>???. by rewrite iterate_oLater_later. Qed.
-
-  (* XXX *)
-  Lemma oLaterN_succ_eq {n} (T : olty Σ n) i :
-    oLaterN i.+1 T ≡ oLater (oLaterN i T).
-  Proof. done. Qed.
-
-  (* XXX *)
   Lemma sSub_LaterN {Γ T} i j:
     ⊢ Γ s⊨ T, j + i <: oLaterN j T, i.
   Proof.
-    rewrite oLaterN_eq.
-    elim: j T => [|j IHj] T; rewrite ?iterate_0 ?iterate_Sr ?plusSn.
+    elim: j T => [|j IHj] T; rewrite 1?oLaterN_0 1?oLaterN_Sr ?plusSn.
     apply sSub_Refl.
     iApply sSub_Trans; [iApply sSub_Later|iApply IHj].
   Qed.
@@ -873,8 +862,7 @@ Section derived.
   Lemma sLaterN_Sub {Γ T} i j :
     ⊢ Γ s⊨ oLaterN j T, i <: T, j + i.
   Proof.
-    rewrite oLaterN_eq.
-    elim: j T => [|j IHj] T; rewrite ?iterate_0 ?iterate_Sr ?plusSn.
+    elim: j T => [|j IHj] T; rewrite 1?oLaterN_0 1?oLaterN_Sr ?plusSn.
     apply sSub_Refl.
     iApply sSub_Trans; [iApply IHj|iApply sLater_Sub].
   Qed.
@@ -994,8 +982,6 @@ Section examples.
   Import DBNotation dot_lty.
 
   Definition oId := oLam (oSel 0 x0 "A").
-  Lemma oLater0 {n} (T : oltyO Σ n) : oLaterN 0 T ≡ T.
-  Proof. done. Qed.
 
   Lemma oId_K Γ :
     ⊢ Γ s⊨ oId ∷[0] sf_kpi (cTMemK "A" sf_star) sf_star.

--- a/theories/misc_unused/hoInterps_experiments.v
+++ b/theories/misc_unused/hoInterps_experiments.v
@@ -42,7 +42,6 @@ Definition oCurry {n} {A : ofeT} (Φ : vec vl n.+1 → A) :
 
 Definition oUncurry {n} {A : ofeT} (Φ : vl → vec vl n → A) :
   vec vl n.+1 -d> A := vuncurry Φ.
-Definition oLaterN {Σ n} i (τ : oltyO Σ n) := Olty (eLater i τ).
 
 (** Semantic kinds can be interpreted into predicates. *)
 (** Semantic Kinds as unary Predicates. *)
@@ -293,12 +292,12 @@ Section kinds_types.
   Definition oTAppV {n} (T : oltyO Σ n.+1) w : oltyO Σ n :=
     Olty (λI args ρ, T (vcons w.[ρ] args) ρ).
 
-  Lemma swap_oLam_oLater {n} (τ : oltyO Σ n) :
-    oLater (oLam τ) ≡ oLam (oLater τ).
+  Lemma swap_oLam_oLaterN {n} (τ : oltyO Σ n) m :
+    oLaterN m (oLam τ) ≡ oLam (oLaterN m τ).
   Proof. done. Qed.
 
-  Lemma swap_oTApp_oLater {n} (τ : oltyO Σ (S n)) v:
-    oLater (oTAppV τ v) ≡ oTAppV (oLater τ) v.
+  Lemma swap_oTApp_oLaterN {n} (τ : oltyO Σ (S n)) m v:
+    oLaterN m (oTAppV τ v) ≡ oTAppV (oLaterN m τ) v.
   Proof. done. Qed.
 
 End kinds_types.

--- a/theories/misc_unused/lty_experiments.v
+++ b/theories/misc_unused/lty_experiments.v
@@ -22,7 +22,7 @@ Module SemTypes2.
 (*
 (** Indexed expression typing (not used for Dot). *)
 Definition setpi `{dlangG Σ} e i Γ τ : iProp Σ :=
-  □∀ ρ, s⟦Γ⟧* ρ → E⟦ eLater i τ ⟧ ρ (e.|[ρ]).
+  □∀ ρ, s⟦Γ⟧* ρ → E⟦ oLaterN i τ ⟧ ρ (e.|[ρ]).
 Global Arguments setpi /.
 
 Notation "Γ s⊨ e : τ , i" := (setpi e i Γ τ) (at level 74, e, τ at next level).


### PR DESCRIPTION
This allows dropping `iterate_oLater_later : iterate oLater n τ args ρ v ⊣⊢ ▷^n τ args ρ v`: for `oLaterN` the analogous equality holds definitionally.