### PR TITLE
Prevent unwarranted generalization in mentions of dlangG in Dot

### DIFF
--- a/theories/Dot/examples/no_russell_paradox.v
+++ b/theories/Dot/examples/no_russell_paradox.v
@@ -8,7 +8,7 @@ Set Suggest Proof Using.
 Set Default Proof Using "Type".
 
 Section Russell.
-  Context `{HdlangG: dlangG Σ}.
+  Context `{HdlangG: !dlangG Σ}.
 
   (**
     A version of Russell's paradox, that however does not go through because of

--- a/theories/Dot/lr/dot_lty.v
+++ b/theories/Dot/lr/dot_lty.v
@@ -103,7 +103,7 @@ End clty_ofe.
 Canonical Structure cltyO Σ := OfeT (clty Σ) clty_ofe_mixin.
 
 Section DefsTypes.
-  Context `{HdotG: dlangG Σ}.
+  Context `{HdotG: !dlangG Σ}.
 
   Definition lift_dinterp_vl (TD : ldltyO Σ) : oltyO Σ 0 := olty0 (λI ρ v,
     match ldlty_label TD with

--- a/theories/Dot/lr/hkdot.v
+++ b/theories/Dot/lr/hkdot.v
@@ -742,7 +742,7 @@ Section dot_types.
   (** [cTMem] and [cVMem] are full [clty]. *)
   Definition cTMemK {n} l (K : sf_kind Σ n) : clty Σ := ldlty2clty (oLDTMemK l K).
   (** Here [n]'s argument to oSel should be explicit. *)
-  Global Arguments oSel {_ _ _} n p l args ρ : rename.
+  Global Arguments oSel {_ _} n p l args ρ : rename.
 
   Lemma sKStp_TMem {n} Γ l (K1 K2 : sf_kind Σ n) i :
     Γ s⊨ K1 <∷[ i ] K2 -∗

--- a/theories/Dot/lr/later_sub_sem.v
+++ b/theories/Dot/lr/later_sub_sem.v
@@ -10,20 +10,20 @@ Set Suggest Proof Using.
 Set Default Proof Using "Type".
 
 (* This is specialized to [vnil] because contexts only contain proper types anyway. *)
-Definition s_ty_sub `{HdlangG: dlangG Σ} (T1 T2 : oltyO Σ 0) := ∀ ρ v, T1 vnil ρ v -∗ T2 vnil ρ v.
+Definition s_ty_sub `{HdlangG: !dlangG Σ} (T1 T2 : oltyO Σ 0) := ∀ ρ v, T1 vnil ρ v -∗ T2 vnil ρ v.
 Notation "s⊨T T1 <: T2" := (s_ty_sub T1 T2) (at level 74, T1, T2 at next level).
 
-Definition ty_sub `{HdlangG: dlangG Σ} T1 T2 := s⊨T V⟦ T1 ⟧ <: V⟦ T2 ⟧.
+Definition ty_sub `{HdlangG: !dlangG Σ} T1 T2 := s⊨T V⟦ T1 ⟧ <: V⟦ T2 ⟧.
 Notation "⊨T T1 <: T2" := (ty_sub T1 T2) (at level 74, T1, T2 at next level).
 
-Definition s_ctx_sub `{HdlangG: dlangG Σ} (Γ1 Γ2 : sCtx Σ) : Prop := ∀ ρ, s⟦ Γ1 ⟧* ρ -∗ s⟦ Γ2 ⟧* ρ.
+Definition s_ctx_sub `{HdlangG: !dlangG Σ} (Γ1 Γ2 : sCtx Σ) : Prop := ∀ ρ, s⟦ Γ1 ⟧* ρ -∗ s⟦ Γ2 ⟧* ρ.
 Notation "s⊨G Γ1 <:* Γ2" := (s_ctx_sub Γ1 Γ2) (at level 74, Γ1, Γ2 at next level).
 
-Definition ctx_sub `{HdlangG: dlangG Σ} Γ1 Γ2 : Prop := s⊨G V⟦ Γ1 ⟧* <:* V⟦ Γ2 ⟧*.
+Definition ctx_sub `{HdlangG: !dlangG Σ} Γ1 Γ2 : Prop := s⊨G V⟦ Γ1 ⟧* <:* V⟦ Γ2 ⟧*.
 Notation "⊨G Γ1 <:* Γ2" := (ctx_sub Γ1 Γ2) (at level 74, Γ1, Γ2 at next level).
 
 Section CtxSub.
-  Context `{HdlangG: dlangG Σ}.
+  Context `{HdlangG: !dlangG Σ}.
   Implicit Type (T : ty) (Γ : ctx).
 
   (** * Basic lemmas about [s_ctx_sub]. *)

--- a/theories/Dot/lr/path_wp.v
+++ b/theories/Dot/lr/path_wp.v
@@ -340,7 +340,7 @@ Section path_wp.
     iDestruct 1 as (v Hcl) "H". eauto.
   Qed.
 
-  Context {Hdlang : dlangG Σ}.
+  Context `{Hdlang : !dlangG Σ}.
   Lemma path_wp_to_wp p φ `{PersistentP φ}:
     path_wp p (λ v, φ v) -∗
     WP (path2tm p) {{ v, φ v }}.

--- a/theories/Dot/lr/unary_lr.v
+++ b/theories/Dot/lr/unary_lr.v
@@ -94,12 +94,12 @@ Notation "Γ s⊨ds ds : T" := (sdstp ds Γ T) (at level 74, ds, T at next level
 (** Path typing *)
 Notation "Γ s⊨p p : τ , i" := (sptp p i Γ τ) (at level 74, p, τ, i at next level).
 
-Definition dm_to_type `{HdotG: dlangG Σ} d i (ψ : hoD Σ i) : iProp Σ :=
+Definition dm_to_type `{HdotG: !dlangG Σ} d i (ψ : hoD Σ i) : iProp Σ :=
   ∃ s σ, ⌜ d = dtysem σ s ⌝ ∧ s ↗n[ σ , i ] ψ.
 Notation "d ↗n[ i  ] ψ" := (dm_to_type d i ψ) (at level 20).
 
 Section dm_to_type.
-  Context `{HdotG: dlangG Σ}.
+  Context `{HdotG: !dlangG Σ}.
 
   Global Instance dm_to_type_persistent d i ψ: Persistent (d ↗n[ i ] ψ) := _.
 
@@ -124,7 +124,7 @@ Section dm_to_type.
 End dm_to_type.
 
 Section SemTypes.
-  Context `{HdotG: dlangG Σ}.
+  Context `{HdotG: !dlangG Σ}.
 
   Implicit Types (τ : oltyO Σ 0).
 
@@ -230,7 +230,7 @@ Section SemTypes.
   Global Instance sptp_persistent : IntoPersistent' (sptp p i   Γ T) | 0 := _.
 End SemTypes.
 
-Global Instance: Params (@oAll) 3 := {}.
+Global Instance: Params (@oAll) 2 := {}.
 
 (* Backward compatibility. *)
 Notation "D*⟦ T ⟧" := (ldlty_car LD⟦ T ⟧).
@@ -260,7 +260,7 @@ Notation oBool := (oPrim tbool).
 
 (** Show these typing judgments are equivalent to what we present in the paper. *)
 Section JudgDefs.
-  Context `{HdotG: dlangG Σ}.
+  Context `{HdotG: !dlangG Σ}.
   Implicit Types (T : ty) (Γ : ctx).
 
   Lemma path_includes_equiv p ρ ds : path_includes (pv (ids 0)) ρ ds ↔
@@ -292,7 +292,7 @@ Section JudgDefs.
 End JudgDefs.
 
 Section MiscLemmas.
-  Context `{HdotG: dlangG Σ}.
+  Context `{HdotG: !dlangG Σ}.
   Implicit Types (τ L T U : olty Σ 0).
 
   Lemma def_interp_tvmem_eq l T p ρ :
@@ -349,7 +349,7 @@ Section Propers.
     f_equiv. exact: IHn.
   Qed.
 
-  Context `{HdotG: dlangG Σ}.
+  Context `{HdotG: !dlangG Σ}.
 
   (** ** Judgments *)
   Global Instance Proper_sstpi i j : Proper ((≡) ==> (≡) ==> (≡) ==> (≡)) (sstpi i j).
@@ -393,7 +393,7 @@ Section Propers.
 End Propers.
 
 Section defs.
-  Context `{HdotG: dlangG Σ}.
+  Context `{HdotG: !dlangG Σ}.
 
   Lemma iterate_TLater_oLater i T:
     V⟦iterate TLater i T⟧ ≡ oLaterN i V⟦T⟧.

--- a/theories/Dot/lr/unary_lr.v
+++ b/theories/Dot/lr/unary_lr.v
@@ -433,7 +433,7 @@ Import dlang_adequacy.
 
 Theorem s_adequacy_dot_sem Σ `{HdlangG: dlangPreG Σ} `{SwapPropI Σ} {e Ψ}
   (τ : ∀ `{!dlangG Σ}, olty Σ 0)
-  (Himpl : ∀ (Hdlang: dlangG Σ) v, oClose τ ids v -∗ ⌜Ψ v⌝)
+  (Himpl : ∀ `(Hdlang: !dlangG Σ) v, oClose τ ids v -∗ ⌜Ψ v⌝)
   (Hlog : ∀ `(!dlangG Σ) `(!SwapPropI Σ), allGs ∅ ==∗ [] s⊨ e : τ):
   adequate e (λ v, Ψ v).
 Proof.
@@ -443,7 +443,7 @@ Proof.
 Qed.
 
 Theorem adequacy_dot_sem Σ `{HdlangG: dlangPreG Σ} `{SwapPropI Σ} {e Ψ T}
-  (Himpl : ∀ (Hdlang: dlangG Σ) v, V⟦ T ⟧ vnil ids v -∗ ⌜Ψ v⌝)
+  (Himpl : ∀ `(Hdlang: !dlangG Σ) v, V⟦ T ⟧ vnil ids v -∗ ⌜Ψ v⌝)
   (Hlog : ∀ `(!dlangG Σ) `(!SwapPropI Σ), allGs ∅ ==∗ [] ⊨ e : T):
   adequate e (λ v, Ψ v).
 Proof. exact: (s_adequacy_dot_sem Σ (λ _, V⟦T⟧)). Qed.
@@ -482,7 +482,7 @@ Qed.
 
 (** Adequacy of normalization for gDOT paths. *)
 Lemma ipwp_gs_adequacy Σ `{dlangPreG Σ} `{SwapPropI Σ} {g p T i}
-  (Hwp : ∀ (Hdlang : dlangG Σ) `(!SwapPropI Σ), ⊢ [] ⊨p[ Vs⟦ g ⟧ ] p : T , i):
+  (Hwp : ∀ `(Hdlang : !dlangG Σ) `(!SwapPropI Σ), ⊢ [] ⊨p[ Vs⟦ g ⟧ ] p : T , i):
   terminates (path2tm p).
 Proof.
   eapply (@soundness (iResUR Σ) _ i).

--- a/theories/Dot/misc_unused/experiments.v
+++ b/theories/Dot/misc_unused/experiments.v
@@ -14,7 +14,7 @@ Set Suggest Proof Using.
 Set Default Proof Using "Type".
 
 Section NoSwapVariants.
-  Context `{HdlangG: dlangG Σ}.
+  Context `{HdlangG: !dlangG Σ}.
 
   (* Yes, no swap! *)
   Lemma sTyp_Sub_Typ {Γ L1 L2 U1 U2 l}:

--- a/theories/Dot/semtyp_lemmas/defs_lr.v
+++ b/theories/Dot/semtyp_lemmas/defs_lr.v
@@ -7,7 +7,7 @@ Set Suggest Proof Using.
 Set Default Proof Using "Type".
 
 Section Sec.
-  Context `{HdlangG: dlangG Σ}.
+  Context `{HdlangG: !dlangG Σ}.
 
   (** Lemmas about definition typing. *)
   Lemma sD_Path {Γ} T p l:

--- a/theories/Dot/semtyp_lemmas/no_binding_lr.v
+++ b/theories/Dot/semtyp_lemmas/no_binding_lr.v
@@ -6,7 +6,7 @@ Set Suggest Proof Using.
 Set Default Proof Using "Type".
 
 Section Sec.
-  Context `{HdlangG: dlangG Σ} (Γ : sCtx Σ).
+  Context `{HdlangG: !dlangG Σ} (Γ : sCtx Σ).
 
   (* Only provable semantically *)
   Lemma sAnd_Or_Sub_Distr {S T U i}: ⊢ Γ s⊨ oAnd (oOr S T) U , i <: oOr (oAnd S U) (oAnd T U), i.

--- a/theories/Dot/semtyp_lemmas/prims_lr.v
+++ b/theories/Dot/semtyp_lemmas/prims_lr.v
@@ -44,7 +44,7 @@ Proof.
 Qed.
 
 Section Sec.
-  Context `{HdlangG: dlangG Σ}.
+  Context `{HdlangG: !dlangG Σ}.
 
   Lemma sT_Nat_I Γ n: ⊢ Γ s⊨ tv (vint n): oInt.
   Proof. iIntros "!> * _ /="; rewrite -wp_value /= /pure_interp_prim /prim_evals_to; eauto. Qed.

--- a/theories/Dot/semtyp_lemmas/tsel_lr.v
+++ b/theories/Dot/semtyp_lemmas/tsel_lr.v
@@ -7,7 +7,7 @@ Set Suggest Proof Using.
 Set Default Proof Using "Type".
 
 Section Sec.
-  Context `{HdlangG: dlangG Σ}.
+  Context `{HdlangG: !dlangG Σ}.
 
   Lemma sSub_Sel {Γ L U p l i}:
     Γ s⊨p p : cTMem l L U, i -∗


### PR DESCRIPTION
These changes were forgotten in #203, but became a problem during other refactorings.