### PR TITLE
Enable rewriting `f` in `f x` via `subrelation` instances

### DIFF
--- a/theories/iris_extra/iris_prelude.v
+++ b/theories/iris_extra/iris_prelude.v
@@ -7,6 +7,31 @@ From D Require Export prelude proofmode_extra.
 
 Export uPred.
 
+Instance equiv_ext_dfun2_pointwise {A B} :
+  subrelation (≡@{A -d> B}) (pointwise_relation A (≡)).
+Proof. done. Qed.
+
+Instance dist_ext_dfun2_pointwise {A B n} :
+  subrelation (dist n (A := A -d> B)) (pointwise_relation A (dist n)).
+Proof. done. Qed.
+
+Instance equiv_ext_dfun2_forall {A B} :
+  subrelation (≡@{A -d> B}) (forall_relation (const (≡))).
+Proof. done. Qed.
+Instance dist_ext_dfun2_forall {A B n} :
+  subrelation (dist n (A := A -d> B)) (forall_relation (const (dist n))).
+Proof. done. Qed.
+
+Instance equiv_ext_dfun3_forall {A B C} :
+  subrelation (≡@{A -d> B -d> C})
+    (forall_relation (const (forall_relation (const (≡))))).
+Proof. done. Qed.
+Instance dist_ext_dfun3_forall {A B C n} :
+  subrelation (dist n (A := A -d> B -d> C))
+    (forall_relation (const (forall_relation (const (dist n))))).
+Proof. done. Qed.
+
+
 Tactic Notation "smart_wp_bind" uconstr(ctx) ident(v) constr(Hv) uconstr(Hp) :=
   iApply (wp_bind (fill[ctx]));
   iApply (wp_wand with "[-]"); [iApply Hp; trivial|]; cbn;


### PR DESCRIPTION
This PR enables rewriting `f` in `f x`, but does not yet exploit this new power. I can confirm it does not introduce slowdowns on successful rewrites; #218 fixed the one problem that did exist (see below) with _lots_ of _repeated_ and blind failing rewrites.

Old notice:
~Warning: b1f13d9dcc9c23e7dd73cf29876417c1c1b402ec introduces a \~10-second slowdown in _three_ use of `solve_proper_ho` — almost all in one (the failed rewrites become really expensive).~

