### PR TITLE
Drop hacks made unnecessary by `subrelation` instances

### DIFF
--- a/theories/DSubSyn/lr/semtyp_lemmas.v
+++ b/theories/DSubSyn/lr/semtyp_lemmas.v
@@ -108,7 +108,7 @@ Section Sec.
     rewrite -wp_value; unfold_interp.
     iExists _; iSplit. by iExists _.
     iModIntro; repeat iSplit; iIntros (v) "#H";
-      rewrite later_intuitionistically -(interp_subst_ids _ _ _).
+      rewrite later_intuitionistically -interp_subst_ids.
     - iIntros "!>"; by iApply "HLT".
     - by iApply "HTU".
   Qed.

--- a/theories/Dot/lr/dot_lty.v
+++ b/theories/Dot/lr/dot_lty.v
@@ -158,7 +158,7 @@ Section logrel_binding_lemmas.
   Proof. apply interp_subst_compose. autosubst. Qed.
 
   Lemma interp_subst_one T v w ρ {args} :
-    V⟦ T.|[v/] ⟧ args ρ w ≡ V⟦ T ⟧ args (v.[ρ] .: ρ) w.
+    V⟦ T.|[v/] ⟧ args ρ ≡ V⟦ T ⟧ args (v.[ρ] .: ρ).
   Proof. apply interp_subst_compose. autosubst. Qed.
 
   Lemma interp_subst_ids T ρ {args} : V⟦ T ⟧ args ρ ≡ V⟦ T.|[ρ] ⟧ args ids.
@@ -174,7 +174,7 @@ Section logrel_binding_lemmas.
   Lemma interp_finsubst_commute_cl T σ ρ v (HclT : nclosed T (length σ)) args :
     V⟦ T.|[∞ σ] ⟧ args ρ v ≡ V⟦ T ⟧ args (∞ σ.|[ρ]) v.
   Proof.
-    rewrite interp_subst_compose_ind !(interp_subst_ids T _ _) -hsubst_comp.
+    rewrite interp_subst_compose_ind !(interp_subst_ids T) -hsubst_comp.
     (* *The* step requiring [HclT]. *)
     by rewrite (subst_compose _ _ HclT).
   Qed.

--- a/theories/Dot/lr/hkdot.v
+++ b/theories/Dot/lr/hkdot.v
@@ -202,7 +202,7 @@ Section sf_kind_subst.
   Definition oShift {n} (T : oltyO Σ n) :=
     Olty (λ args ρ v, T args (stail ρ) v).
   Lemma oShift_eq {n} (T : oltyO Σ n) : oShift T ≡ shift T.
-  Proof. move=>args ρ v /=. by rewrite (hoEnvD_weaken_one _ _ _ v). Qed.
+  Proof. move=>args ρ v /=. by rewrite hoEnvD_weaken_one. Qed.
 End sf_kind_subst.
 
 Section kinds_types.

--- a/theories/Dot/lr/unary_lr.v
+++ b/theories/Dot/lr/unary_lr.v
@@ -221,6 +221,11 @@ Section SemTypes.
     | TSing p => olty2clty $ oSing p
     end.
 
+  (** Unfolding lemma for [TAnd]: defined because [simpl] on the LHS produces
+      [oAnd C⟦ T1 ⟧ C⟦ T2 ⟧]. *)
+  Lemma interp_TAnd_eq T1 T2 : V⟦ TAnd T1 T2 ⟧ ≡ oAnd V⟦ T1 ⟧ V⟦ T2 ⟧.
+  Proof. done. Qed.
+
   Global Instance pinterp_lemmas: CTyInterpLemmas Σ.
   Proof.
     split; rewrite /pty_interp;
@@ -423,11 +428,7 @@ Section defs.
 
   Lemma iterate_TLater_oLater i T:
     V⟦iterate TLater i T⟧ ≡ oLaterN i V⟦T⟧.
-  Proof. elim: i => [//|i IHi] ???. by rewrite !iterate_S /= (IHi _ _ _). Qed.
-
-  Lemma iterate_TLater_later T n args ρ v:
-    V⟦ iterate TLater n T ⟧ args ρ v ⊣⊢ ▷^n V⟦ T ⟧ args ρ v.
-  Proof. by rewrite (iterate_TLater_oLater n T _ _ _). Qed.
+  Proof. elim: i => [//|i IHi] ???; by rewrite !iterate_S /= IHi. Qed.
 
   Lemma sSub_iterate_TLater_Eq {Γ T U i j} :
     V⟦ Γ ⟧* s⊨ V⟦ T ⟧, i <: V⟦ U ⟧, j ⊣⊢

--- a/theories/Dot/misc_unused/experiments.v
+++ b/theories/Dot/misc_unused/experiments.v
@@ -169,7 +169,7 @@ Section Sec.
   Proof.
     rewrite T_Path.
     iIntros "Hp". iApply (T_Sub with "Hp").
-    iIntros "!> **"; by rewrite iterate_TLater_later.
+    iIntros "!> **"; by rewrite iterate_TLater_oLater.
   Qed.
 
   Lemma wp_later_swap t Φ: WP t {{ v, ▷ Φ v }} ⊢ ▷ WP t {{ v, Φ v }}.
@@ -193,7 +193,7 @@ Section Sec.
     (* iApply (wp_later_swap _ (⟦ T2 ⟧ (v .: vs))).
     iApply ("HeT" $! (v .: vs) with "[$HG]"). *)
     iSpecialize ("HeT" $! (v .: vs) with "[#$HG]").
-    by rewrite (interp_weaken_one _ _ _).
+    by rewrite interp_weaken_one.
     by rewrite wp_later_swap; iNext.
     (* by iDestruct (wp_later_swap with "HeT") as "{HeT} HeT"; iNext. *)
   Qed.
@@ -281,7 +281,7 @@ Section Sec.
     V⟦ iterate TLater j (TAnd T1 T2) ⟧ args ρ v ⊣⊢
     V⟦ TAnd (iterate TLater j T1) (iterate TLater j T2) ⟧ args ρ v.
   Proof.
-    rewrite /= !iterate_TLater_later /=.
+    rewrite !interp_TAnd_eq /= !iterate_TLater_oLater.
     iSplit; iIntros "/= [??]"; iSplit; by [].
   Qed.
 

--- a/theories/Dot/semtyp_lemmas/binding_lr.v
+++ b/theories/Dot/semtyp_lemmas/binding_lr.v
@@ -25,7 +25,7 @@ Section LambdaIntros.
     (* Factor ▷ out of [s⟦ Γ ⟧* ρ] before [iNext]. *)
     rewrite senv_TLater_commute. iNext.
     iApply ("HeT" $! (v .: ρ) with "[$HG]").
-    by rewrite (hoEnvD_weaken_one T1 vnil _ v).
+    by rewrite hoEnvD_weaken_one.
   Qed.
 
   Lemma sT_All_I {Γ} T1 T2 e:
@@ -181,7 +181,7 @@ Section Sec.
   Proof.
     iSplit; iIntros "#Htp !>" (ρ) "#Hg !> /=";
     iDestruct (wp_value_inv' with "(Htp Hg)") as "{Htp} Hgoal";
-    by rewrite -wp_value/= (hoEnvD_subst_one _ v (v.[ρ])).
+    by rewrite -wp_value /= hoEnvD_subst_one.
   Qed.
 
   Lemma sT_Mu_I {Γ T v} : Γ s⊨ tv v : T.|[v/] -∗ Γ s⊨ tv v : oMu T.
@@ -265,7 +265,7 @@ Section Sec.
     iNext. iApply wp_wand.
     - iApply "HvFun".
     - iIntros (v) "{HG HvFun Hv2Arg} H".
-      by rewrite /= (hoEnvD_subst_one T2 v2 v).
+      by rewrite /= hoEnvD_subst_one.
   Qed.
 
   Lemma T_All_Ex {Γ e1 v2 T1 T2}:

--- a/theories/Dot/semtyp_lemmas/path_repl_lr.v
+++ b/theories/Dot/semtyp_lemmas/path_repl_lr.v
@@ -216,7 +216,7 @@ Section path_repl.
     by iNext i; iDestruct "Heq" as %Heq;
       rewrite (alias_paths_elim_eq _ Heq) path_wp_pv_eq.
     iApply ("Hsub" $! (v .: ρ) v with "[$Hg] HT1").
-    iEval rewrite iterate_TLater_later /= hsubst_comp. iFrame "Heq HT1".
+    iEval rewrite iterate_TLater_oLater /= hsubst_comp. iFrame "Heq HT1".
   Qed.
 
   (** What Dotty actually checks uses substitution twice. A simple case is the following: *)

--- a/theories/Dot/semtyp_lemmas/tdefs_lr.v
+++ b/theories/Dot/semtyp_lemmas/tdefs_lr.v
@@ -48,8 +48,8 @@ Section typing_type_member_defs.
     by iApply (dm_to_type_intro with "Hγ").
     (* Dropping [iNext], as follows, requires the instance in
     https://gitlab.mpi-sws.org/iris/iris/issues/287. *)
-    (* by iModIntro; repeat iSplit; iIntros (v) "#H"; rewrite /= (Hγφ _ _ _). *)
-    by iModIntro; repeat iSplit; iIntros (v) "#H"; iNext; rewrite /= (Hγφ _ _ _).
+    (* by iModIntro; repeat iSplit; iIntros (v) "#H"; rewrite /= (Hγφ _ _). *)
+    by iModIntro; repeat iSplit; iIntros (v) "#H"; iNext; rewrite /= (Hγφ _ _).
   Qed.
 
   Lemma sD_Typ_Abs {Γ} T L U s σ l:

--- a/theories/iris_extra/lty.v
+++ b/theories/iris_extra/lty.v
@@ -178,8 +178,8 @@ Section olty_subst.
      shift φ args ρ ≡ φ args (stail ρ).
   Proof. apply hoEnvD_subst_compose. autosubst. Qed.
 
-  Lemma hoEnvD_subst_one φ v w args ρ:
-    φ.|[v/] args ρ w ≡ φ args (v.[ρ] .: ρ) w.
+  Lemma hoEnvD_subst_one φ v args ρ:
+    φ.|[v/] args ρ ≡ φ args (v.[ρ] .: ρ).
   Proof. apply hoEnvD_subst_compose. autosubst. Qed.
 
   Definition Olty (olty_car : vec vl i → (var → vl) → vl → iProp Σ)

--- a/theories/ty_interp_subst_lemmas.v
+++ b/theories/ty_interp_subst_lemmas.v
@@ -52,7 +52,7 @@ Section logrel_binding_lemmas.
   Lemma interp_finsubst_commute_cl T σ ρ v (HclT : nclosed T (length σ)) :
     ⟦ T.|[∞ σ] ⟧ ρ v ≡ ⟦ T ⟧ (∞ σ.|[ρ]) v.
   Proof.
-    rewrite interp_subst_compose_ind !(interp_subst_ids T _ _) -hsubst_comp.
+    rewrite interp_subst_compose_ind !(interp_subst_ids T) -hsubst_comp.
     (* *The* step requiring [HclT]. *)
     by rewrite (subst_compose _ _ HclT).
   Qed.


### PR DESCRIPTION
There’s no significant performance difference with this patch, which is really cool!