### PR TITLE
Exploit Iris upgrades

### DIFF
--- a/theories/DSub/lr/adequacy.v
+++ b/theories/DSub/lr/adequacy.v
@@ -1,4 +1,3 @@
-From iris.proofmode Require Import tactics.
 From D Require Import swap_later_impl.
 From D.DSub Require Import unary_lr rules.
 

--- a/theories/DSub/lr/unary_lr.v
+++ b/theories/DSub/lr/unary_lr.v
@@ -1,4 +1,3 @@
-From iris.proofmode Require Import tactics.
 From D Require Export iris_prelude.
 From D Require Import ty_interp_subst_lemmas.
 From D.DSub Require Export dlang_inst.

--- a/theories/DSub/lr/unary_lr.v
+++ b/theories/DSub/lr/unary_lr.v
@@ -169,7 +169,7 @@ Section logrel_lemmas.
   Lemma semantic_typing_uniform_step_index Γ T e i:
     Γ ⊨ e : T -∗ Γ ⊨ e : T, i.
   Proof.
-    iIntros "#H !>" (ρ) "#HΓ".
+    iIntros "#H !> %ρ #HΓ".
     iInduction i as [|i] "IHi". by iApply "H". iExact "IHi".
   Qed.
 

--- a/theories/DSubSyn/fundamental.v
+++ b/theories/DSubSyn/fundamental.v
@@ -23,7 +23,7 @@ Section swap_based_typing_lemmas.
     Γ ⊨ TAll T1 U1, i <: TAll T2 U2, i .
   Proof.
     rewrite iterate_S /=.
-    iIntros "#HsubT #HsubU /= !>" (ρ v) "#Hg".
+    iIntros "#HsubT #HsubU /= !> %ρ %v #Hg".
     unfold_interp.
     iDestruct 1 as (t) "#[Heq #HT1]". iExists t; iSplit => //.
     iIntros (w).
@@ -50,7 +50,7 @@ Section swap_based_typing_lemmas.
     Γ ⊨[i] TAll T1 U1 <: TAll T2 U2.
   Proof.
     rewrite iterate_S /=.
-    iIntros "#HsubT #HsubU /= !>" (ρ) "#Hg"; iIntros (v).
+    iIntros "#HsubT #HsubU /= !> %ρ #Hg"; iIntros (v).
     rewrite -mlaterN_impl; unfold_interp.
     iDestruct 1 as (t) "#[Heq #HT1]"; iExists t; iFrame "Heq".
     iIntros (w).
@@ -71,7 +71,7 @@ Section swap_based_typing_lemmas.
     Γ ⊨ U1, i <: U2, i -∗
     Γ ⊨ TTMem L1 U1, i <: TTMem L2 U2, i.
   Proof.
-    iIntros "#IHT #IHT1 /= !>" (ρ v) "#Hg".
+    iIntros "#IHT #IHT1 /= !> %ρ %v #Hg".
     unfold_interp.
     iDestruct 1 as (φ) "#[Hφl [HLφ #HφU]]".
     setoid_rewrite mlaterN_impl.

--- a/theories/DSubSyn/lr/semtyp_lemmas.v
+++ b/theories/DSubSyn/lr/semtyp_lemmas.v
@@ -118,7 +118,7 @@ Section Sec.
     Γ ⊨ tv (vty T) : TTMem L U.
   Proof.
     (* Ltac solve_fv_congruence := rewrite /nclosed /nclosed_vl /= => *; f_equiv; solve [(idtac + asimpl); auto using eq_up]. *)
-    iIntros "#HTU #HLT /= !>" (ρ) "#HG".
+    iIntros "#HTU #HLT /= !> %ρ #HG".
     rewrite -wp_value; unfold_interp.
     iExists _; iSplit. by iExists _.
     iModIntro; repeat iSplit; iIntros (v) "#H";
@@ -170,7 +170,7 @@ Section Sec.
   Lemma T_Nat_I n:
     ⊢ Γ ⊨ tv (vint n): TInt.
   Proof.
-    iIntros "/= !>" (ρ) "_". rewrite -wp_value; unfold_interp. by iExists n.
+    iIntros "/= !> %ρ _". rewrite -wp_value; unfold_interp. by iExists n.
   Qed.
 
   Lemma Sub_Index_Incr T U i j:
@@ -183,7 +183,7 @@ Section Sec.
     Γ ⊨[i] U1 <: U2 -∗
     Γ ⊨[i] TTMem L1 U1 <: TTMem L2 U2.
   Proof.
-    iIntros "#HsubL #HsubU /= !>" (ρ) "#Hg"; iIntros (v).
+    iIntros "#HsubL #HsubU /= !> %ρ #Hg"; iIntros (v).
     iSpecialize ("HsubL" with "Hg"); iSpecialize ("HsubU" with "Hg").
     unfold_interp. iNext.
     iDestruct 1 as (φ) "#[Hφl [#HLφ #HφU]]".

--- a/theories/DSubSyn/lr/semtyp_lemmas.v
+++ b/theories/DSubSyn/lr/semtyp_lemmas.v
@@ -3,7 +3,6 @@
    This file *must not* depend on either typing.v (typing ruls) or
    swap_later_impl.v (extra swap lemmas).
  *)
-From iris.proofmode Require Import tactics.
 From D.pure_program_logic Require Import lifting.
 From D.DSub Require Import rules syn_lemmas.
 From D.DSubSyn Require Import unary_lr.

--- a/theories/DSubSyn/lr/unary_lr.v
+++ b/theories/DSubSyn/lr/unary_lr.v
@@ -1,4 +1,3 @@
-From iris.proofmode Require Import tactics.
 From D Require Export iris_prelude.
 From D Require Import ty_interp_subst_lemmas saved_interp_dep.
 From D.DSub Require Export syn.

--- a/theories/DSubSyn/lr/unary_lr.v
+++ b/theories/DSubSyn/lr/unary_lr.v
@@ -264,7 +264,7 @@ Section logrel_lemmas.
   Lemma semantic_typing_uniform_step_index Γ T e i:
     Γ ⊨ e : T -∗ Γ ⊨ e : T, i.
   Proof.
-    iIntros "#H !>" (ρ) "#HΓ".
+    iIntros "#H !> %ρ #HΓ".
     iInduction i as [|i] "IHi". by iApply "H". iExact "IHi".
   Qed.
 

--- a/theories/Dot/examples/ex_iris_utils.v
+++ b/theories/Dot/examples/ex_iris_utils.v
@@ -1,4 +1,3 @@
-From iris.proofmode Require Import tactics.
 From D.pure_program_logic Require Import lifting adequacy.
 From iris.program_logic Require Import ectxi_language.
 

--- a/theories/Dot/examples/from_pdot_mutual_rec.v
+++ b/theories/Dot/examples/from_pdot_mutual_rec.v
@@ -1,6 +1,5 @@
 (**
  *)
-From stdpp Require Import strings.
 
 From D Require Import tactics.
 From D.Dot Require Import syn path_repl.

--- a/theories/Dot/examples/from_pdot_mutual_rec_sem.v
+++ b/theories/Dot/examples/from_pdot_mutual_rec_sem.v
@@ -246,7 +246,7 @@ Lemma newTypeRef_semTyped Γ g :
 Proof.
   have := Hx0 Γ g; set Γ2 := newTypeRefΓ Γ; unfold newTypeRefΓ in Γ2 => Hx0.
 
-  iIntros "#Hs !>" (ρ) "#Hg !>".
+  iIntros "#Hs !> %ρ #Hg !>".
   iPoseProof (fundamental_typed Hx0 with "Hs Hg") as "#Hx0".
   reshape [AppRCtx _]; reshape [IfCtx _ _]; reshape [UnCtx _];
     reshape [ProjCtx _]; reshape [ProjCtx _]; iSimpl.

--- a/theories/Dot/examples/hoas.v
+++ b/theories/Dot/examples/hoas.v
@@ -1,5 +1,4 @@
 (* A HOAS frontend for de Bruijn terms. *)
-From stdpp Require Import strings.
 
 From D Require Import tactics.
 From D.Dot Require Import syn ex_utils.

--- a/theories/Dot/examples/list.v
+++ b/theories/Dot/examples/list.v
@@ -1,4 +1,3 @@
-From stdpp Require Import strings.
 
 From D Require Import tactics.
 From D.Dot Require Import syn unstampedness_binding.

--- a/theories/Dot/examples/no_russell_paradox.v
+++ b/theories/Dot/examples/no_russell_paradox.v
@@ -1,4 +1,3 @@
-From iris.proofmode Require Import tactics.
 From D.Dot Require Import unary_lr.
 
 Implicit Types

--- a/theories/Dot/examples/positive_div.v
+++ b/theories/Dot/examples/positive_div.v
@@ -372,7 +372,7 @@ Section small_ex.
       iApply sD_Cons; [done| |iApply sD_Nil].
       iApply sD_Val.
       iApply (sT_Sub (i := 0) (T1 := ipos)).
-      rewrite setp_value /ipos /pos; iIntros "!>" (ρ) "_ /= !%". naive_solver.
+      rewrite setp_value /ipos /pos; iIntros "!> %ρ _ /= !%". naive_solver.
       iApply sSub_Trans; first iApply sSub_Add_Later.
       iApply sSub_Trans; first iApply sSub_Add_Later.
       iApply sSub_Later_Sub.

--- a/theories/Dot/examples/prim_boolean_option.v
+++ b/theories/Dot/examples/prim_boolean_option.v
@@ -1,4 +1,3 @@
-From stdpp Require Import strings.
 
 From D Require Import tactics.
 From D.Dot Require Import syn ex_utils hoas storeless_typing_ex_utils.

--- a/theories/Dot/examples/scala_lib.v
+++ b/theories/Dot/examples/scala_lib.v
@@ -1,4 +1,3 @@
-From stdpp Require Import strings.
 
 From D Require Import tactics.
 From D.Dot Require Import syn ex_utils hoas.

--- a/theories/Dot/examples/storeless_typing_ex.v
+++ b/theories/Dot/examples/storeless_typing_ex.v
@@ -2,7 +2,6 @@
 WIP examples constructing syntactic typing derivations.
 I am also experimenting with notations, but beware the current definitions are pretty bad.
  *)
-From stdpp Require Import strings.
 
 From D Require Import tactics.
 From D.Dot Require Import syn storeless_typing_ex_utils stampedness_binding.

--- a/theories/Dot/examples/unstamped_typing_ex.v
+++ b/theories/Dot/examples/unstamped_typing_ex.v
@@ -1,7 +1,6 @@
 (**
 WIP examples constructing _unstamped_ syntactic typing derivations.
  *)
-From stdpp Require Import strings.
 
 From D Require Import tactics.
 From D.Dot Require Import syn unstampedness_binding.

--- a/theories/Dot/fundamental.v
+++ b/theories/Dot/fundamental.v
@@ -1,4 +1,3 @@
-From iris.proofmode Require Import tactics.
 From D Require Import swap_later_impl.
 (* For fundamental theorem. *)
 From D.Dot Require Import unary_lr storeless_typing tdefs_lr

--- a/theories/Dot/lr/hkdot.v
+++ b/theories/Dot/lr/hkdot.v
@@ -353,7 +353,7 @@ Section gen_lemmas.
     Γ s⊨ T1 <:[ i ] T2 ∷ K -∗
     S :: Γ s⊨ oShift T1 <:[ i ] oShift T2 ∷ kShift K.
   Proof.
-    iIntros "#HK !>" (ρ) "/= #[Hg _]".
+    iIntros "#HK !> %ρ /= #[Hg _]".
     by iApply (Proper_sfkind with "(HK Hg)").
   Qed.
 
@@ -427,7 +427,7 @@ Section gen_lemmas.
   Lemma sK_Sing Γ (T : oltyO Σ 0) i :
     ⊢ Γ s⊨ T ∷[ i ] sf_sngl T.
   Proof.
-    rewrite -kinding_intro; iIntros "!>" (ρ) "_". by rewrite -subtype_refl.
+    rewrite -kinding_intro; iIntros "!> %ρ _". by rewrite -subtype_refl.
   Qed.
 
   Lemma sKStp_Intv Γ (T1 T2 L U : oltyO Σ 0) i :
@@ -444,7 +444,7 @@ Section gen_lemmas.
     Γ s⊨ K1 <∷[ i ] K2 -∗
     Γ s⊨ T1 <:[ i ] T2 ∷ K2.
   Proof.
-    iIntros "#H1 #Hsub !>" (ρ) "#Hg". iApply ("Hsub" with "Hg (H1 Hg)").
+    iIntros "#H1 #Hsub !> %ρ #Hg". iApply ("Hsub" with "Hg (H1 Hg)").
   Qed.
 
   (** Kind subsumption (for kinding). *)
@@ -489,7 +489,7 @@ Section gen_lemmas.
     oLaterN i (oShift S2) :: Γ s⊨ K1 <∷[ i ] K2 -∗
     Γ s⊨ sf_kpi S1 K1 <∷[ i ] sf_kpi S2 K2.
   Proof using HswapProp.
-    iIntros "#HsubS #HsubK !>" (ρ) "#Hg /=".
+    iIntros "#HsubS #HsubK !> %ρ #Hg /=".
     iPoseProof (ksubtyping_spec with "HsubS Hg") as "{HsubS} HsubS".
     iAssert (□∀ arg : vl, let ρ' := arg .: ρ in
             ▷^i (oClose S2 ρ arg → ∀ T1 T2 : hoLtyO Σ n,
@@ -725,7 +725,7 @@ Section dot_types.
   Lemma sstpiK_star_to_sstp Γ i T1 T2 :
     Γ s⊨ T1 <:[ i ] T2 ∷ sf_star ⊢ Γ s⊨ T1 , i <: T2 , i.
   Proof.
-    iIntros "#Hsub !>" (ρ v) "#Hg".
+    iIntros "#Hsub !> %ρ %v #Hg".
     iDestruct (ksubtyping_spec with "Hsub Hg") as "{Hsub Hg} Hsub".
     rewrite -laterN_impl. iNext i. iApply ("Hsub" $! v).
   Qed.
@@ -1015,7 +1015,7 @@ Section dot_experimental_kinds.
     Γ s⊨ oSing p <:[i] oSing q ∷ sf_kintv L U -∗
     Γ s⊨ oSing q <:[i] oSing p ∷ sf_kintv L U.
   Proof.
-    iIntros "#Hp #Hps !>" (ρ) "#Hg /=".
+    iIntros "#Hp #Hps !> %ρ #Hg /=".
     iDestruct (path_wp_eq with "(Hp Hg)") as (w) "[Hpw _] {Hp}".
     iSpecialize ("Hps" with "Hg"); rewrite -alias_paths_pv_eq_1; iNext i.
     (* Weird that this works. *)

--- a/theories/Dot/lr/later_sub_sem.v
+++ b/theories/Dot/lr/later_sub_sem.v
@@ -1,6 +1,5 @@
 (** * When is a context weaker than another? Semantic version. *)
 
-From iris.proofmode Require Import tactics.
 
 From D Require Import proper.
 From D.Dot Require Import unary_lr.

--- a/theories/Dot/lr/path_wp.v
+++ b/theories/Dot/lr/path_wp.v
@@ -1,4 +1,3 @@
-From iris.proofmode Require Import tactics.
 From D Require Import iris_prelude iris_extra.det_reduction.
 From D.Dot Require Import dlang_inst rules lr_syn_aux path_repl.
 From D.pure_program_logic Require Import lifting.

--- a/theories/Dot/lr/unary_lr.v
+++ b/theories/Dot/lr/unary_lr.v
@@ -338,7 +338,7 @@ Section MiscLemmas.
     Γ s⊨ tv v : T -∗
     Γ s⊨p pv v : T, 0.
   Proof.
-    iIntros "/= #Hp !>" (ρ) "Hg". rewrite path_wp_pv_eq -wp_value_inv'.
+    iIntros "/= #Hp !> %ρ Hg". rewrite path_wp_pv_eq -wp_value_inv'.
     iApply ("Hp" with "Hg").
   Qed.
 

--- a/theories/Dot/lr/unary_lr.v
+++ b/theories/Dot/lr/unary_lr.v
@@ -1,4 +1,3 @@
-From iris.proofmode Require Import tactics.
 From D Require Export iris_prelude proper lty lr_syn_aux.
 From D Require Import iris_extra.det_reduction.
 From D Require Import swap_later_impl.

--- a/theories/Dot/misc_unused/experiments.v
+++ b/theories/Dot/misc_unused/experiments.v
@@ -22,7 +22,7 @@ Section NoSwapVariants.
     Γ s⊨ oLater U1, 0 <: oLater U2, 0 -∗
     Γ s⊨ cTMem l L1 U1, 0 <: cTMem l L2 U2, 0.
   Proof using HdlangG.
-    iIntros "#IHT #IHT1 /= !>" (ρ v) "#Hg #HT1".
+    iIntros "#IHT #IHT1 /= !> %ρ %v #Hg #HT1".
     iDestruct "HT1" as (d) "[Hl2 H]".
     iDestruct "H" as (φ) "#[Hφl [HLφ #HφU]]".
     iExists d; repeat iSplit; first by [].
@@ -43,7 +43,7 @@ Section NoSwapVariants.
     oLater (shift T2) :: Γ s⊨ oLater U1, 0 <: oLater U2, 0 -∗
     Γ s⊨ oAll T1 U1, 0 <: oAll T2 U2, 0.
   Proof using HdlangG HswapProp.
-    iIntros "#HsubT #HsubU /= !>" (ρ v) "#Hg #HT1".
+    iIntros "#HsubT #HsubU /= !> %ρ %v #Hg #HT1".
     iDestruct "HT1" as (t) "#[Heq #HT1]". iExists t; iSplit => //.
     iIntros (w).
     (* rewrite -mlater_impl. *)
@@ -84,7 +84,7 @@ Section AlsoSyntactically.
     Γ ⊨p p : T1, i -∗
     Γ ⊨ TSing p, i <: TMu T2, i.
   Proof.
-    (* iIntros "#Hsub #Hp !>" (ρ v) "#Hg /= #Heq".
+    (* iIntros "#Hsub #Hp !> %ρ %v #Hg /= #Heq".
     iSpecialize ("Hp" with "Hg").
     iSpecialize ("Hsub" $! ρ v with "[#$Hg] [#]");
       iNext i; iDestruct "Heq" as %Heq;
@@ -129,7 +129,7 @@ Section Example.
     iIntros "He #HA #HB".
     iApply (T_All_E with "[] He").
     iApply T_All_I.
-    iSimpl; iIntros "!>" (ρ) "#[Hg [H|H]] !>";
+    iSimpl; iIntros "!> %ρ #[Hg [H|H]] !>";
       [iApply ("HA" with "[]") | iApply ("HB" with "[]")];
       iFrame "Hg H".
   Qed.
@@ -155,7 +155,7 @@ Section Sec.
   Lemma All_Later_Sub_Distr0 Γ T U `{SwapPropI Σ}:
     ⊢ Γ ⊨ TAll (TLater T) U, 0 <: TLater (TAll T U), 0.
   Proof.
-    iIntros "!>" (ρ v) "_ /= #HvTU".
+    iIntros "!> %ρ %v _ /= #HvTU".
     iDestruct "HvTU" as (t ->) "#HvTU".
     iExists t; iSplit => //. iNext.
     iIntros (w) "!>".
@@ -203,7 +203,7 @@ Section Sec.
   Lemma All_Later_Sub_Distr `{SwapPropI Σ} Γ T U i:
     ⊢ Γ ⊨ TAll (TLater T) (TLater U), i <: TLater (TAll T U), i.
   Proof.
-    iIntros "!>" (ρ v) "_ #HvTU". iNext i.
+    iIntros "!> %ρ %v _ #HvTU". iNext i.
     iDestruct "HvTU" as (t ->) "#HvTU".
     iExists t; iSplit => //.
     rewrite -mlater_pers. iModIntro (□ _)%I.
@@ -220,7 +220,7 @@ Section Sec.
   Lemma sFld_Later_Sub_Distr Γ l T i:
     ⊢ Γ s⊨ cVMem l (oLater T), i <: oLater (cVMem l T), i.
   Proof.
-    iIntros "!>" (ρ v) "_ /= #HvT". iNext i.
+    iIntros "!> %ρ %v _ /= #HvT". iNext i.
     iDestruct "HvT" as (d Hlook) "#HvT".
     iExists (d); (iSplit; try iSplit) => //.
     iDestruct "HvT" as (pmem ->) "HvT".
@@ -290,7 +290,7 @@ Section Sec.
     Γ ⊨ T, i <: U1, i ⊣⊢
     Γ ⊨ T, i <: U2, i .
   Proof.
-    iIntros (Heq); iSplit; iIntros "/= #H !>" (ρ v) "#Hg #HT";
+    iIntros (Heq); iSplit; iIntros "/= #H !> %ρ %v #Hg #HT";
       [rewrite -Heq //|rewrite Heq //]; by iApply "H".
   Qed.
 
@@ -299,7 +299,7 @@ Section Sec.
     Γ ⊨ T1, i <: U, i ⊣⊢
     Γ ⊨ T2, i <: U, i .
   Proof.
-    iIntros (Heq); iSplit; iIntros "/= #H !>" (ρ v) "#Hg #HT";
+    iIntros (Heq); iSplit; iIntros "/= #H !> %ρ %v #Hg #HT";
       [rewrite -Heq //|rewrite Heq //]; by iApply "H".
   Qed.
 
@@ -308,7 +308,7 @@ Section Sec.
     Γ ⊨ T1, i <: T2, i ∧
     Γ ⊨ T2, i <: T1, i .
   Proof.
-    iIntros (Heq) "_"; iSplit; iIntros "/= !>" (ρ v) "#Hg #HT";
+    iIntros (Heq) "_"; iSplit; iIntros "/= !> %ρ %v #Hg #HT";
       [rewrite -Heq //|rewrite Heq //]; by iApply "H".
   Qed.
 

--- a/theories/Dot/misc_unused/hkdot_bad.v
+++ b/theories/Dot/misc_unused/hkdot_bad.v
@@ -1,6 +1,5 @@
 (* (* Must be loaded first, so that other modules can reset some flags. *)
 Require Import Equations.Equations. *)
-From iris.proofmode Require Import tactics.
 From iris.base_logic Require Import lib.saved_prop.
 From D Require Import iris_prelude.
 From D Require Import saved_interp_dep asubst_intf dlang ty_interp_subst_lemmas.

--- a/theories/Dot/semtyp_lemmas/binding_lr.v
+++ b/theories/Dot/semtyp_lemmas/binding_lr.v
@@ -19,7 +19,7 @@ Section LambdaIntros.
     (*─────────────────────────*)
     Γ s⊨ tv (vabs e) : oAll T1 T2.
   Proof.
-    rewrite Hctx; iIntros "#HeT !>" (ρ) "#HG /= !>".
+    rewrite Hctx; iIntros "#HeT !> %ρ #HG /= !>".
     rewrite -wp_value'. iExists _; iSplit; first done.
     iIntros "!>" (v) "#Hv"; rewrite up_sub_compose.
     (* Factor ▷ out of [s⟦ Γ ⟧* ρ] before [iNext]. *)
@@ -58,7 +58,7 @@ Section Sec.
     (*───────────────────────────────*)
     Γ s⊨ T1, i <: T2, j.
   Proof.
-    iIntros "#Htyp !>" (ρ v) "#Hg #HvT1".
+    iIntros "#Htyp !> %ρ %v #Hg #HvT1".
     iEval rewrite -path_wp_pv_eq.
     iApply ("Htyp" $! (v .: ρ) with "[$Hg ]").
     by iApply "HvT1".
@@ -98,7 +98,7 @@ Section Sec.
     Γ s⊨ T, i <: U, j -∗
     oLater <$> Γ s⊨ oLater T, i <: oLater U, j.
   Proof.
-    iIntros "#Hsub !>" (ρ v) "#Hg/=".
+    iIntros "#Hsub !> %ρ %v #Hg/=".
     rewrite !swap_later -later_impl senv_TLater_commute.
     iNext. iApply ("Hsub" with "Hg").
   Qed.
@@ -113,7 +113,7 @@ Section Sec.
     (*──────────────────────*)
     ⊢ Γ s⊨ of_val (ids x) : shiftN x τ.
   Proof.
-    iIntros "/= !>" (ρ) "#Hg"; rewrite -wp_value'.
+    iIntros "/= !> %ρ #Hg"; rewrite -wp_value'.
     by rewrite s_interp_env_lookup // id_subst.
   Qed.
 
@@ -132,7 +132,7 @@ Section Sec.
     (*───────────────────────────────*)
     Γ s⊨ iterate tskip i e : T2.
   Proof.
-    iIntros "/= #HeT1 #Hsub !>" (ρ) "#Hg !>".
+    iIntros "/= #HeT1 #Hsub !> %ρ #Hg !>".
     rewrite tskip_subst -wp_bind.
     iApply (wp_wand with "(HeT1 Hg)").
     iIntros (v) "#HvT1".
@@ -160,7 +160,7 @@ Section Sec.
     oLaterN i T1 :: Γ s⊨ T1, i <: T2, j -∗
     Γ s⊨ oMu T1, i <: oMu T2, j.
   Proof.
-    iIntros "/= #Hstp !>" (ρ v) "#Hg #HT1".
+    iIntros "/= #Hstp !> %ρ %v #Hg #HT1".
     iApply ("Hstp" $! (v .: ρ) v with "[$Hg $HT1] [$HT1]").
   Qed.
 
@@ -179,7 +179,7 @@ Section Sec.
    *)
   Lemma sTMu_equiv {Γ T v} : (Γ s⊨ tv v : oMu T) ≡ (Γ s⊨ tv v : T.|[v/]).
   Proof.
-    iSplit; iIntros "#Htp !>" (ρ) "#Hg !> /=";
+    iSplit; iIntros "#Htp !> %ρ #Hg !> /=";
     iDestruct (wp_value_inv' with "(Htp Hg)") as "{Htp} Hgoal";
     by rewrite -wp_value /= hoEnvD_subst_one.
   Qed.
@@ -203,7 +203,7 @@ Section Sec.
     rewrite /istpi; cbn -[sstpi].
     rewrite (interp_subst_commute T (ren (+1))).
     apply sMu_Sub.
-    (* iIntros "!>" (ρ v) "**".
+    (* iIntros "!> %ρ %v **".
     by rewrite /= (lift_olty_eq (interp_subst_commute _ _)). *)
   Qed.
 
@@ -212,7 +212,7 @@ Section Sec.
     rewrite /istpi; cbn -[sstpi].
     rewrite (interp_subst_commute T (ren (+1))).
     apply sSub_Mu.
-    (* iIntros "!>" (ρ v) "**".
+    (* iIntros "!> %ρ %v **".
     by rewrite /= (lift_olty_eq (interp_subst_commute _ _)). *)
   Qed.
 
@@ -278,7 +278,7 @@ Section Sec.
     (*────────────────────────────────────────────────────────────*)
     Γ s⊨ tapp e1 e2 : T2.
   Proof.
-    iIntros "/= #He1 #Hv2 !>" (ρ) "#HG !>".
+    iIntros "/= #He1 #Hv2 !> %ρ #HG !>".
     smart_wp_bind (AppLCtx (e2.|[_])) v "#Hr" ("He1" with "[]").
     smart_wp_bind (AppRCtx v) w "#Hw" ("Hv2" with "[]").
     iDestruct "Hr" as (t ->) "#Hv".
@@ -294,7 +294,7 @@ Section Sec.
     Γ s⊨ T1, i <: T2, j + i -∗
     Γ s⊨ cVMem l T1, i <: cVMem l T2, j + i.
   Proof.
-    iIntros "#Hsub /= !>" (ρ v) "#Hg #HT1". setoid_rewrite laterN_plus.
+    iIntros "#Hsub /= !> %ρ %v #Hg #HT1". setoid_rewrite laterN_plus.
     iDestruct "HT1" as (d) "#[Hdl #HT1]".
     iExists d; repeat iSplit => //.
     iDestruct "HT1" as (pmem) "[Heq HvT1]".
@@ -317,7 +317,7 @@ Section Sec.
     (*─────────────────────────*)
     Γ s⊨ tproj e l : T.
   Proof.
-    iIntros "#HE /= !>" (ρ) "#HG !>".
+    iIntros "#HE /= !> %ρ #HG !>".
     smart_wp_bind (ProjCtx l) v "#Hv {HE}" ("HE" with "[]").
     iDestruct "Hv" as (? Hl pmem ->) "Hv".
     rewrite -wp_pure_step_later //= path_wp_later_swap path_wp_to_wp. by [].
@@ -346,7 +346,7 @@ Section swap_based_typing_lemmas.
     oLaterN (S i) (shift T2) :: Γ s⊨ oLater U1, i <: oLater U2, i -∗
     Γ s⊨ oAll T1 U1, i <: oAll T2 U2, i.
   Proof.
-    iIntros "#HsubT #HsubU /= !>" (ρ v) "#Hg #HT1".
+    iIntros "#HsubT #HsubU /= !> %ρ %v #Hg #HT1".
     iDestruct "HT1" as (t) "#[Heq #HT1]". iExists t; iSplit => //.
     iIntros (w).
     rewrite -!mlaterN_pers -mlaterN_impl.
@@ -376,7 +376,7 @@ Section swap_based_typing_lemmas.
     Γ s⊨ oLater U1, i <: oLater U2, i -∗
     Γ s⊨ cTMem l L1 U1, i <: cTMem l L2 U2, i.
   Proof.
-    iIntros "#IHT #IHT1 /= !>" (ρ v) "#Hg #HT1".
+    iIntros "#IHT #IHT1 /= !> %ρ %v #Hg #HT1".
     iDestruct "HT1" as (d) "[Hl2 H]".
     iDestruct "H" as (φ) "#[Hφl [HLφ #HφU]]".
     rewrite (comm plus).

--- a/theories/Dot/semtyp_lemmas/defs_lr.v
+++ b/theories/Dot/semtyp_lemmas/defs_lr.v
@@ -78,7 +78,7 @@ Section Sec.
      oLater T :: Γ s⊨ds ds : T -∗
      Γ s⊨ tv (vobj ds) : oMu T.
   Proof.
-    iDestruct 1 as (Hwf) "#Hds"; iIntros "!>" (ρ) "#Hg /= !>".
+    iDestruct 1 as (Hwf) "#Hds"; iIntros "!> %ρ #Hg /= !>".
     rewrite -wp_value' /=. iLöb as "IH".
     iApply clty_commute. rewrite norm_selfSubst.
     iApply ("Hds" $! (vobj _ .: ρ) with "[%] [$IH $Hg]").

--- a/theories/Dot/semtyp_lemmas/no_binding_lr.v
+++ b/theories/Dot/semtyp_lemmas/no_binding_lr.v
@@ -25,7 +25,7 @@ Section Sec.
   Lemma sAnd_All_Sub_Distr T U1 U2 i:
     ⊢ Γ s⊨ oAnd (oAll T U1) (oAll T U2), i <: oAll T (oAnd U1 U2), i.
   Proof.
-    iIntros "/= !>" (ρ v) "#Hg [#H1 #H2]". iNext.
+    iIntros "/= !> %ρ %v #Hg [#H1 #H2]". iNext.
     iDestruct "H1" as (t ?) "#H1"; iDestruct "H2" as (t' ->) "#H2"; simplify_eq.
     iExists _; iSplit => //.
     iIntros "!>" (w) "#HT".
@@ -40,7 +40,7 @@ Section Sec.
   Lemma sAnd_Fld_Sub_Distr l T1 T2 i:
     ⊢ Γ s⊨ oAnd (cVMem l T1) (cVMem l T2), i <: cVMem l (oAnd T1 T2), i.
   Proof.
-    iIntros "/= !>" (ρ v) "#Hg [#H1 H2]". iNext.
+    iIntros "/= !> %ρ %v #Hg [#H1 H2]". iNext.
     iDestruct "H1" as (d? pmem?) "#H1"; iDestruct "H2" as (d'? pmem'?) "#H2". objLookupDet.
     repeat (iExists _; repeat iSplit => //).
     by iApply (path_wp_and' with "H1 H2").
@@ -49,7 +49,7 @@ Section Sec.
   Lemma sAnd_Fld_Sub_Distr_2 l T1 T2 i:
     ⊢ Γ s⊨ cVMem l (oAnd T1 T2), i <: oAnd (cVMem l T1) (cVMem l T2), i.
   Proof.
-    iIntros "/= !>" (ρ v) "#Hg #H". iNext.
+    iIntros "/= !> %ρ %v #Hg #H". iNext.
     iDestruct "H" as (d? pmem Hlook) "H".
     rewrite -path_wp_and; iDestruct "H" as "[H1 H2]".
     iSplit; repeat (iExists _; repeat iSplit => //).
@@ -59,7 +59,7 @@ Section Sec.
   Lemma sAnd_Fld_Sub_Distr_Or_1 l T1 T2 i:
     ⊢ Γ s⊨ oOr (cVMem l T1) (cVMem l T2), i <: cVMem l (oOr T1 T2), i.
   Proof.
-    iIntros "/= !>" (ρ v) "#Hg [#H| #H]"; iNext;
+    iIntros "/= !> %ρ %v #Hg [#H| #H]"; iNext;
       iDestruct "H" as (d? pmem?) "#H"; repeat (iExists _; repeat iSplit => //);
       rewrite -path_wp_or; by [iLeft | iRight].
   Qed.
@@ -67,7 +67,7 @@ Section Sec.
   Lemma sAnd_Fld_Sub_Distr_Or_2 l T1 T2 i:
     ⊢ Γ s⊨ cVMem l (oOr T1 T2), i <: oOr (cVMem l T1) (cVMem l T2), i.
   Proof.
-    iIntros "/= !>" (ρ v) "#Hg #H". iNext.
+    iIntros "/= !> %ρ %v #Hg #H". iNext.
     iDestruct "H" as (d? pmem?) "#H"; rewrite -path_wp_or.
     iDestruct "H" as "#[H | H]"; [> iLeft | iRight];
       repeat (iExists _; repeat iSplit => //).
@@ -76,7 +76,7 @@ Section Sec.
   Lemma sAnd_Typ_Sub_Distr l L U1 U2 i:
     ⊢ Γ s⊨ oAnd (cTMem l L U1) (cTMem l L U2), i <: cTMem l L (oAnd U1 U2), i.
   Proof.
-    iIntros "/= !>" (ρ v) "Hg [H1 H2]". iNext.
+    iIntros "/= !> %ρ %v Hg [H1 H2]". iNext.
     iDestruct "H1" as (d? φ) "#[Hsφ1 [#HLφ1 #HφU1]]"; iDestruct "H2" as (d'? φ') "#[Hsφ2 [_ #HφU2]]".
     objLookupDet.
     iExists d; repeat iSplit => //.
@@ -93,7 +93,7 @@ Section Sec.
     Γ s⊨ tv v : T2 -∗
     Γ s⊨ tv v : oAnd T1 T2.
   Proof.
-    iIntros "#HT1 #HT2 /= !>" (ρ) "#Hg".
+    iIntros "#HT1 #HT2 /= !> %ρ #Hg".
     iApply (wp_and_val with "(HT1 Hg) (HT2 Hg)").
   Qed.
 
@@ -105,7 +105,7 @@ Section Sec.
     Γ s⊨ T1, S i <: T2, S j -∗
     Γ s⊨ oLater T1, i <: oLater T2, j.
   Proof.
-    iIntros "/= #Hsub !>" (ρ v) "#Hg #HT1".
+    iIntros "/= #Hsub !> %ρ %v #Hg #HT1".
     iSpecialize ("Hsub" $! _ v with "Hg").
     rewrite !swap_later.
     by iApply "Hsub".
@@ -113,7 +113,7 @@ Section Sec.
 
   Lemma sLater_Sub T i :
     ⊢ Γ s⊨ oLater T, i <: T, S i.
-  Proof. by iIntros "/= !>" (ρ v) "#HG #HT !>". Qed.
+  Proof. by iIntros "/= !> %ρ %v #HG #HT !>". Qed.
 
   Lemma sSub_Later T i :
     ⊢ Γ s⊨ T, S i <: oLater T, i.

--- a/theories/Dot/semtyp_lemmas/path_repl_lr.v
+++ b/theories/Dot/semtyp_lemmas/path_repl_lr.v
@@ -90,7 +90,7 @@ Section path_repl.
     Γ s⊨p p : τ, i -∗
     Γ s⊨p p : oSing p, i.
   Proof.
-    iIntros "#Hep !>" (ρ) "Hg". iSpecialize ("Hep" with "Hg"). iNext.
+    iIntros "#Hep !> %ρ Hg". iSpecialize ("Hep" with "Hg"). iNext.
     iApply (strong_path_wp_wand with "[] Hep"); iIntros (v Hpv) "!> _ !%".
     apply alias_paths_pv_eq_1, Hpv.
   Qed.
@@ -102,7 +102,7 @@ Section path_repl.
     Γ s⊨p p : T, i -∗
     Γ s⊨ oSing p, i <: T, i.
   Proof.
-    iIntros "#Hp !>" (ρ v) "Hg /= Heq".
+    iIntros "#Hp !> %ρ %v Hg /= Heq".
     iSpecialize ("Hp" with "Hg"); iNext i.
     iDestruct "Heq" as %->%(alias_paths_elim_eq (T _ ρ)).
     by rewrite path_wp_pv_eq.
@@ -116,7 +116,7 @@ Section path_repl.
     Γ s⊨ oSing p, i <: oSing q, i -∗
     Γ s⊨ oSing q, i <: oSing p, i.
   Proof.
-    iIntros "#Hp #Hps !>" (ρ v) "#Hg /= Heq".
+    iIntros "#Hp #Hps !> %ρ %v #Hg /= Heq".
     iDestruct (path_wp_eq with "(Hp Hg)") as (w) "[Hpw _] {Hp}".
     rewrite -alias_paths_pv_eq_1; iSpecialize ("Hps" $! _ w with "Hg Hpw");
       rewrite !alias_paths_pv_eq_1.
@@ -132,7 +132,7 @@ Section path_repl.
     Γ s⊨p p : oSing q, i -∗
     Γ s⊨p q : oTop, i.
   Proof.
-    iIntros "#Hpq !>" (ρ) "#Hg /=".
+    iIntros "#Hpq !> %ρ #Hg /=".
     iDestruct (singleton_aliasing with "Hpq Hg") as "Hal {Hpq Hg}".
     iNext i. iDestruct "Hal" as %(v & _ & Hqv)%alias_paths_sameres. iIntros "!%".
     exact: (path_wp_pure_wand Hqv).
@@ -148,7 +148,7 @@ Section path_repl.
     Γ s⊨p p : oSing q, i -∗
     Γ s⊨ T1, i <: T2, i.
   Proof.
-    iIntros "#Hal !>" (ρ v) "#Hg HT1". iSpecialize ("Hal" with "Hg"). iNext i.
+    iIntros "#Hal !> %ρ %v #Hg HT1". iSpecialize ("Hal" with "Hg"). iNext i.
     iDestruct "Hal" as %Hal%alias_paths_simpl.
     iApply (Hrepl with "HT1"). exact Hal.
   Qed.
@@ -161,7 +161,7 @@ Section path_repl.
   Lemma sP_Mu_E {Γ T p i} :
     Γ s⊨p p : oMu T, i -∗ Γ s⊨p p : T .sTp[ p /], i.
   Proof.
-    iIntros "#Hp !>" (ρ) "Hg /=".
+    iIntros "#Hp !> %ρ Hg /=".
     iApply (strong_path_wp_wand with "[] (Hp Hg)"); iIntros "!> **".
     by rewrite oMu_eq sem_psubst_one_repl ?alias_paths_pv_eq_1.
   Qed.
@@ -170,11 +170,11 @@ Section path_repl.
     Γ ⊨p p : TMu T, i -∗ Γ ⊨p p : T', i.
   Proof.
     (* Proof from scratch *)
-    (* iIntros "#Hp !>" (ρ) "Hg /=".
+    (* iIntros "#Hp !> %ρ Hg /=".
     iApply (strong_path_wp_wand with "[] (Hp Hg)"); iIntros "!> **".
     by rewrite oMu_eq -(psubst_one_repl Hrepl ) ?alias_paths_pv_eq_1. *)
     (* Even if we reuse sP_Mu_E, we must prove that [p] terminates. *)
-    rewrite /iptp sP_Mu_E; iIntros "#Hp !>" (ρ) "Hg /=".
+    rewrite /iptp sP_Mu_E; iIntros "#Hp !> %ρ Hg /=".
     iApply (strong_path_wp_wand with "[] (Hp Hg)"); iIntros "!> **".
     by rewrite (sem_psubst_one_eq Hrepl) ?alias_paths_pv_eq_1.
   Qed.
@@ -182,7 +182,7 @@ Section path_repl.
   Lemma sP_Mu_I {Γ T p i} :
     Γ s⊨p p : T .sTp[ p /], i -∗ Γ s⊨p p : oMu T, i.
   Proof.
-    iIntros "#Hp !>" (ρ) "Hg /=".
+    iIntros "#Hp !> %ρ Hg /=".
     iApply (strong_path_wp_wand with "[] (Hp Hg)"); iIntros "!> **".
     by rewrite oMu_eq sem_psubst_one_repl ?alias_paths_pv_eq_1.
   Qed.
@@ -190,10 +190,10 @@ Section path_repl.
   Lemma P_Mu_I {Γ T T' p i} (Hrepl : T .Tp[ p /]~ T') :
     Γ ⊨p p : T', i -∗ Γ ⊨p p : TMu T, i.
   Proof.
-    (* iIntros "#Hp !>" (ρ) "Hg /=".
+    (* iIntros "#Hp !> %ρ Hg /=".
     iApply (strong_path_wp_wand with "[] (Hp Hg)"); iIntros "!> **".
     by rewrite oMu_eq (psubst_one_repl Hrepl) ?alias_paths_pv_eq_1. *)
-    rewrite /iptp -sP_Mu_I; iIntros "#Hp !>" (ρ) "Hg /=".
+    rewrite /iptp -sP_Mu_I; iIntros "#Hp !> %ρ Hg /=".
     iApply (strong_path_wp_wand with "[] (Hp Hg)"); iIntros "!> **".
     by rewrite (sem_psubst_one_eq Hrepl) ?alias_paths_pv_eq_1.
   Qed.
@@ -210,7 +210,7 @@ Section path_repl.
     iApply Mu_Sub_Mu.
     (* We're stuck! *)
     Restart. *)
-    iIntros "#Hsub #Hp !>" (ρ v) "#Hg #Heq".
+    iIntros "#Hsub #Hp !> %ρ %v #Hg #Heq".
     iSpecialize ("Hp" with "Hg").
     iAssert (▷^i ⟦ T1 ⟧ (v .: ρ) v)%I as "#HT1".
     by iNext i; iDestruct "Heq" as %Heq;
@@ -226,7 +226,7 @@ Section path_repl.
     Γ ⊨p p : TMu T1, i -∗
     Γ ⊨ TSing p, i <: TMu T2, i.
   Proof.
-    iIntros "#Hsub #Hp !>" (ρ v) "#Hg /= #Heq".
+    iIntros "#Hsub #Hp !> %ρ %v #Hg /= #Heq".
     iSpecialize ("Hp" with "Hg").
     iSpecialize ("Hsub" $! ρ v with "[#$Hg] [#]");
       iNext i; iDestruct "Heq" as %Heq;
@@ -240,7 +240,7 @@ Section path_repl.
     (*────────────────────────────────────────────────────────────*)
     Γ s⊨ tapp e1 (path2tm p2) : T2 .sTp[ p2 /].
   Proof.
-    iIntros "#He1 #Hp2 !>" (ρ) "#Hg /= !>".
+    iIntros "#He1 #Hp2 !> %ρ #Hg /= !>".
     smart_wp_bind (AppLCtx _) v "#Hr {He1}" ("He1" with "Hg").
     iDestruct "Hr" as (t ->) "#HvFun".
     iDestruct (path_wp_eq with "(Hp2 Hg)") as (pw Hpwp) "{Hp2 Hg} Hpw".
@@ -270,7 +270,7 @@ Section path_repl.
   Lemma sT_Path Γ τ p :
     Γ s⊨p p : τ, 0 -∗ Γ s⊨ path2tm p : τ.
   Proof.
-    iIntros "#Hep !>" (ρ) "#Hg /="; rewrite path2tm_subst.
+    iIntros "#Hep !> %ρ #Hg /="; rewrite path2tm_subst.
     by iApply (path_wp_to_wp with "(Hep Hg)").
   Qed.
 
@@ -301,7 +301,7 @@ Section path_repl.
     (*─────────────────────────*)
     Γ s⊨p p : cVMem l T, i.
   Proof.
-    iIntros "#HE /= !>" (ρ) "Hg"; iSpecialize ("HE" with "Hg"); iNext i.
+    iIntros "#HE /= !> %ρ Hg"; iSpecialize ("HE" with "Hg"); iNext i.
     rewrite path_wp_pself_eq; iDestruct "HE" as (v q Hlook) "[Hpv #Htw]".
     iApply (path_wp_wand with "Hpv"). iIntros "/= !> % <-"; eauto.
   Qed.
@@ -314,7 +314,7 @@ Section path_repl.
     Γ s⊨p q : T, i -∗
     Γ s⊨p p : T, i.
   Proof.
-    iIntros "#Hep #Heq !>" (ρ) "#Hg".
+    iIntros "#Hep #Heq !> %ρ #Hg".
     iDestruct (singleton_aliasing with "Hep Hg") as "Hal1 {Hep}".
     iSpecialize ("Heq" with "Hg"). iNext i.
     by iDestruct "Hal1" as %->%(alias_paths_elim_eq (T _ _)).
@@ -329,7 +329,7 @@ Section path_repl.
     Γ s⊨p pself q l : τ, i -∗
     Γ s⊨p pself p l : oSing (pself q l), i.
   Proof.
-    iIntros "#Hep #HqlT !>" (ρ) "#Hg".
+    iIntros "#Hep #HqlT !> %ρ #Hg".
     iSpecialize ("HqlT" with "Hg").
     iDestruct (singleton_aliasing with "Hep Hg") as "Hal {Hep Hg}".
     rewrite !path_wp_eq /=.

--- a/theories/Dot/semtyp_lemmas/prims_lr.v
+++ b/theories/Dot/semtyp_lemmas/prims_lr.v
@@ -67,8 +67,7 @@ Section Sec.
     Γ s⊨ tun u e1 : oPrim Br.
   Proof.
     iIntros "#He1 !> %ρ #Hg !>".
-    smart_wp_bind (UnCtx _) v1 "#Ha1" ("He1" with "Hg"); iClear "He1 Hg".
-    iDestruct "Ha1" as %Ha1.
+    smart_wp_bind (UnCtx _) v1 "%Ha1" ("He1" with "Hg"); iClear "He1 Hg".
     by iApply wp_wand; [iApply wp_un|iIntros (? [??])].
   Qed.
 
@@ -93,10 +92,8 @@ Section Sec.
     Γ s⊨ tbin b e1 e2 : oPrim Br.
   Proof.
     iIntros "#He1 #He2 !> /= %ρ #Hg !>". rewrite /oPrim/= /pure_interp_prim.
-    smart_wp_bind (BinLCtx _ _) v1 "#Ha1" ("He1" with "Hg"); iClear "He1".
-    iDestruct "Ha1" as %Ha1.
-    smart_wp_bind (BinRCtx _ _) v2 "#Ha2" ("He2" with "Hg"); iClear "He2".
-    iDestruct "Ha2" as %Ha2; ev.
+    smart_wp_bind (BinLCtx _ _) v1 "%Ha1" ("He1" with "Hg"); iClear "He1".
+    smart_wp_bind (BinRCtx _ _) v2 "%Ha2" ("He2" with "Hg"); iClear "He2"; ev.
     by iApply wp_wand; [iApply wp_bin|iIntros (? [??])].
   Qed.
 

--- a/theories/Dot/semtyp_lemmas/prims_lr.v
+++ b/theories/Dot/semtyp_lemmas/prims_lr.v
@@ -66,7 +66,7 @@ Section Sec.
     Γ s⊨ e1 : oPrim B1 -∗
     Γ s⊨ tun u e1 : oPrim Br.
   Proof.
-    iIntros "#He1 !>" (ρ) "#Hg !>".
+    iIntros "#He1 !> %ρ #Hg !>".
     smart_wp_bind (UnCtx _) v1 "#Ha1" ("He1" with "Hg"); iClear "He1 Hg".
     iDestruct "Ha1" as %Ha1.
     by iApply wp_wand; [iApply wp_un|iIntros (? [??])].
@@ -92,7 +92,7 @@ Section Sec.
     Γ s⊨ e2 : oPrim B2 -∗
     Γ s⊨ tbin b e1 e2 : oPrim Br.
   Proof.
-    iIntros "#He1 #He2 !> /=" (ρ) "#Hg !>". rewrite /oPrim/= /pure_interp_prim.
+    iIntros "#He1 #He2 !> /= %ρ #Hg !>". rewrite /oPrim/= /pure_interp_prim.
     smart_wp_bind (BinLCtx _ _) v1 "#Ha1" ("He1" with "Hg"); iClear "He1".
     iDestruct "Ha1" as %Ha1.
     smart_wp_bind (BinRCtx _ _) v2 "#Ha2" ("He2" with "Hg"); iClear "He2".
@@ -116,7 +116,7 @@ Section Sec.
     Γ s⊨ e : oBool -∗ Γ s⊨ e1 : T -∗ Γ s⊨ e2 : T -∗
     Γ s⊨ tif e e1 e2 : T.
   Proof.
-    iIntros "#He #He1 #He2 !> /=" (ρ) "#Hg !>".
+    iIntros "#He #He1 #He2 !> /= %ρ #Hg !>".
     smart_wp_bind (IfCtx _ _) v "#Ha" ("He" with "[]").
     rewrite /pure_interp_prim/=; iDestruct "Ha" as %([] & ->);
       (rewrite -wp_pure_step_later; last done);

--- a/theories/Dot/semtyp_lemmas/tdefs_lr.v
+++ b/theories/Dot/semtyp_lemmas/tdefs_lr.v
@@ -1,5 +1,4 @@
 From stdpp Require Import gmap.
-From iris.proofmode Require Import tactics.
 From D.Dot Require Import unary_lr.
 
 Set Implicit Arguments.

--- a/theories/Dot/semtyp_lemmas/tsel_lr.v
+++ b/theories/Dot/semtyp_lemmas/tsel_lr.v
@@ -1,4 +1,3 @@
-From iris.proofmode Require Import tactics.
 From D.Dot Require Import unary_lr.
 
 Implicit Types (v: vl) (e: tm) (d: dm) (ds: dms).

--- a/theories/Dot/semtyp_lemmas/tsel_lr.v
+++ b/theories/Dot/semtyp_lemmas/tsel_lr.v
@@ -12,7 +12,7 @@ Section Sec.
     Γ s⊨p p : cTMem l L U, i -∗
     Γ s⊨ oLater L, i <: oSel p l, i.
   Proof.
-    iIntros "/= #Hp !>" (ρ v) "Hg #HL /=".
+    iIntros "/= #Hp !> %ρ %v Hg #HL /=".
     iSpecialize ("Hp" with "Hg"); iNext i.
     iApply (path_wp_wand with "Hp"); iIntros "!>" (w).
     iDestruct 1 as (d Hl φ) "[Hlφ [HLφ _]]".
@@ -28,7 +28,7 @@ Section Sec.
     Γ s⊨p p : cTMem l L U, i -∗
     Γ s⊨ oSel p l, i <: oLater U, i.
   Proof.
-    iIntros "#Hp !>" (ρ v) "Hg Hφ"; iSpecialize ("Hp" with "Hg").
+    iIntros "#Hp !> %ρ %v Hg Hφ"; iSpecialize ("Hp" with "Hg").
     iNext i.
     iDestruct (path_wp_and' with "Hp Hφ") as "H".
     iDestruct (path_wp_eq with "H") as (w Hw) "[Hp Hφ] /=".
@@ -58,7 +58,7 @@ Section Sec.
     (*─────────────────────────*)
     Γ s⊨p pself p l : T, i.
   Proof.
-    iIntros "#HE !>" (ρ) "HG /=".
+    iIntros "#HE !> %ρ HG /=".
     iSpecialize ("HE" with "HG"); iNext i.
     rewrite path_wp_eq path_wp_pself_eq.
     iDestruct "HE" as (vp Hpv d Hlook pmem ->) "#H".
@@ -95,6 +95,6 @@ Section Sec.
     rewrite (sP_Sub (j := 1) (T1 := oLater T) (T2 := T)); iIntros "Hsub".
     rewrite (plusnS i 0) (plusnO i).
     iApply "Hsub".
-    iIntros "/= !>" (ρ v) "Hg $".
+    iIntros "/= !> %ρ %v Hg $".
   Qed.
 End Sec.

--- a/theories/Dot/syn/path_repl_lemmas.v
+++ b/theories/Dot/syn/path_repl_lemmas.v
@@ -1,4 +1,3 @@
-From iris.proofmode Require Import tactics.
 From D.Dot Require Import syn path_repl.
 From D.Dot Require Import core_stamping_defs unstampedness_binding closed_subst.
 

--- a/theories/Dot/syn/syn.v
+++ b/theories/Dot/syn/syn.v
@@ -1,4 +1,4 @@
-From stdpp Require Import strings.
+From stdpp Require Export strings.
 From D Require Export prelude.
 From D Require Import asubst_intf asubst_base.
 From iris.program_logic Require ectx_language ectxi_language.

--- a/theories/Dot/typing/unstamped_typing_derived_rules.v
+++ b/theories/Dot/typing/unstamped_typing_derived_rules.v
@@ -1,4 +1,3 @@
-From stdpp Require Import strings.
 From D Require Import tactics.
 From D.Dot Require Import syn syn_lemmas ex_utils unstamped_typing.
 From D.Dot Require Import unstampedness_binding.

--- a/theories/iris_extra/dlang.v
+++ b/theories/iris_extra/dlang.v
@@ -1,4 +1,3 @@
-From iris.proofmode Require Import tactics.
 From iris.program_logic Require Import ectx_language language.
 From D.pure_program_logic Require adequacy.
 From D Require Import iris_prelude swap_later_impl asubst_intf.

--- a/theories/iris_extra/iris_prelude.v
+++ b/theories/iris_extra/iris_prelude.v
@@ -1,4 +1,4 @@
-From iris.proofmode Require Import tactics.
+From iris.proofmode Require Export tactics.
 From iris.program_logic Require Import ectx_language.
 From iris.base_logic Require Import upred.
 
@@ -41,11 +41,6 @@ Tactic Notation "smart_wp_bind" uconstr(ctx) ident(v) constr(Hv) uconstr(Hp) :=
 Hint Extern 5 (IntoVal _ _) => eapply of_to_val; fast_done : typeclass_instances.
 Hint Extern 10 (IntoVal _ _) =>
   rewrite /IntoVal; eapply of_to_val; rewrite /= !to_of_val /=; solve [ eauto ] : typeclass_instances.
-
-(* Do not export iris.proofmode.tactics! *)
-(* From iris.proofmode Require Export tactics. *)
-(* As discussed in https://github.com/Blaisorblade/dot-iris/pull/2#discussion_r239389417, exporting that confuses Coq, who then
-  prints [length] as [strings.length]. *)
 
 (** Notation for functions in the Iris scope. *)
 Notation "'λI' x .. y , t" := (fun x => .. (fun y => t%I) ..)

--- a/theories/iris_extra/iris_prelude.v
+++ b/theories/iris_extra/iris_prelude.v
@@ -2,6 +2,12 @@ From iris.proofmode Require Export tactics.
 From iris.program_logic Require Import ectx_language.
 From iris.base_logic Require Import upred.
 
+From iris_string_ident Require ltac2_string_ident.
+(* Now [ltac2_string_ident] has taken effect: *)
+(* Print ltac_tactics.string_to_ident_hook. *)
+(* Nevertheless, it must be exported, or it won't take effect in importing files. *)
+Export ltac2_string_ident.
+
 From D.pure_program_logic Require Export weakestpre.
 From D Require Export prelude proofmode_extra.
 

--- a/theories/iris_extra/saved_interp_dep.v
+++ b/theories/iris_extra/saved_interp_dep.v
@@ -1,4 +1,3 @@
-From iris.proofmode Require Import tactics.
 From iris.base_logic Require Import lib.saved_prop.
 From stdpp Require Import vector.
 From D Require Import prelude iris_prelude asubst_intf.

--- a/theories/ty_interp_subst_lemmas.v
+++ b/theories/ty_interp_subst_lemmas.v
@@ -1,4 +1,3 @@
-From iris.proofmode Require Import tactics.
 From D Require Import prelude iris_prelude asubst_base saved_interp_dep.
 
 Set Suggest Proof Using.


### PR DESCRIPTION
- Export proofmode tactics and stdpp.strings only once.
- Use new IPM introduction patterns for pure variables.