### PR TITLE
Cleanups, mostly to notation in examples

### DIFF
--- a/tests/test_notation.ref
+++ b/tests/test_notation.ref
@@ -51,19 +51,19 @@ Arguments tb _%expr_scope
      : vl_
 hanyToNothing = hclose (⊤ →: ⊥)
      : ty
-hloopDefT = (val "loop" : ⊤ →: ⊥ )%HT
+hloopDefT = (val "loop" : ⊤ →: ⊥ )%HS
      : hty
 The command has indeed failed with message:
 Found type "vl" where "hvl" was expected.
 0 : htm
      : htm
-(2 > 1)%HE
+(2 > 1)%HS
      : htm
-(1 > 2)%HE
+(1 > 2)%HS
      : htm
-(1 ≥ 2)%HE
+(1 ≥ 2)%HS
      : htm
-(1 > 0)%HE
+(1 > 0)%HS
      : htm
      = TAll TInt (TMu (TAnd (TSing DBNotation.x1) (TSing DBNotation.x0)))
      : ty

--- a/tests/test_notation.v
+++ b/tests/test_notation.v
@@ -9,7 +9,7 @@ Open Scope Z_scope.
 
 Check {@ TInt ; TInt ; TInt }%ty.
 
-(* Check (TSel (pself (pself p0 1) 2) 3). *)
+(* Check (TSel (pself (pself x0 1) 2) 3). *)
 (* Check (x0 @ 1 @ 2 ; 3). *)
 
 Check ν {@ val "a" = pv (vint 0) }.
@@ -23,11 +23,11 @@ Check ν {@ }.
 Check ν {@ val "a" = pv (vint 0) }.
 Check ν {@ val "a" = pv (vint 0) ; val "b" = pv (vint 1) }.
 
-Check (p0 @; "A").
-Check (pself (pself p0 "A") "B" @; "C").
-Check (p0 @ "A").
-Check (p0 @ "A" @ "B" @; "C").
-Check (val "symb" : p0 @ "symbols" @; "Symbol")%ty.
+Check (x0 @; "A").
+Check (pself (pself x0 "A") "B" @; "C").
+Check (x0 @ "A").
+Check (x0 @ "A" @ "B" @; "C").
+Check (val "symb" : x0 @ "symbols" @; "Symbol")%ty.
 
 Definition ta v := (0 < v)%E.
 Print ta.
@@ -92,7 +92,7 @@ Goal ex = ex0. done. Abort.
 Definition ex2 := hclose (λ: f, htv f).
 Eval cbv in ex2.
 Goal ex2 = vabs (tv DBNotation.x0). done. Qed.
-Definition ex3 := hclose (λ:: f x, htapp (htv f) (htv x)).
+Definition ex3 : tm := λ: f x, htapp f x.
 Eval cbv in ex3.
 Goal ex3 = tv (vabs (tv (vabs (tapp (tv DBNotation.x1) (tv DBNotation.x0))))). done. Abort.
 End hoasTests.

--- a/tests/test_notation.v
+++ b/tests/test_notation.v
@@ -62,13 +62,11 @@ Fail Definition curriedLambda' := λ: self v, htv self @: "loop" $: htv v.
 Definition curriedLambda' := λ: self w, htv self @: "loop" $: htv w.
 
 
-(* Bind Scope hexpr_scope with htm htm'. *)
-
 Check (0 : htm).
-Check (1 < 2)%HE.
-Check (1 > 2)%HE.
-Check (1 ≥ 2)%HE.
-Check (1 > 0)%HE.
+Check (1 < 2)%HS.
+Check (1 > 2)%HS.
+Check (1 ≥ 2)%HS.
+Check (1 > 0)%HS.
 
 Goal hvar_vl = λ n i, var_vl (n + i). done. Abort.
 Goal ∀ n, hvint n = liftA0 (vint n). done. Abort.
@@ -84,7 +82,7 @@ Eval cbv -[plus minus] in hTAll.
 Goal hTAll = λ T U i, (TAll (T i) (U (λ x, var_vl (x - S i)) (S i))). done. Abort.
 (* Goal hTAll = λ T U i, (∀ (T i), U (λ x, var_vl (x - S i)) (S i)). done. Abort. *)
 
-Eval cbv in hclose {@ hTInt ; hTInt ; hTInt } %HT.
+Eval cbv in hclose {@ hTInt ; hTInt ; hTInt } %HS.
 
 Definition ex := hclose $ ∀: x : hTInt, hTMu (λ y, hTAnd (hTSing (hpv x)) (hTSing (hpv y))).
 Goal ex = ex0. done. Abort.

--- a/theories/Dot/examples/ex_utils.v
+++ b/theories/Dot/examples/ex_utils.v
@@ -102,8 +102,6 @@ Notation "▶:" := TLater : ty_scope.
 Notation "▶: T" := (TLater T) (at level 49, right associativity) : ty_scope.
 
 Notation "'∀:' T , U" := (TAll T U) (at level 48, T at level 98, U at level 98).
-(* Do not use, too many conflicts. *)
-Notation "'∀' T ',' U" := (TAll T U) (at level 49, only printing) : ty_scope.
 
 Notation "'μ' Ts " := (TMu Ts) (at level 50, Ts at next level).
 Notation "'type' l >: L <: U" := (TTMem l L U) (at level 60, l at level 50, L, U at level 70) : ty_scope.

--- a/theories/Dot/examples/ex_utils.v
+++ b/theories/Dot/examples/ex_utils.v
@@ -128,13 +128,6 @@ Notation x3 := (var_vl 3).
 Notation x4 := (var_vl 4).
 Notation x5 := (var_vl 5).
 
-Notation p0 := (pv x0).
-Notation p1 := (pv x1).
-Notation p2 := (pv x2).
-Notation p3 := (pv x3).
-Notation p4 := (pv x4).
-Notation p5 := (pv x5).
-
 Notation TUnit := (⊤%ty : ty).
 Notation tUnit := (tv (vint 0) : tm).
 
@@ -168,8 +161,7 @@ Hint Extern 0 (dms_hasnt _ _) => done : core.
 
 Hint Resolve Nat.lt_0_succ : core.
 
-Definition vabs' x := tv (vabs x).
-Definition lett t u := tapp (vabs' u) t.
+Definition lett t u := tapp (vabs u) t.
 
 (* Simplify substitution operations on concrete terms. *)
 Ltac simplSubst := rewrite /= /up/= /ids/ids_vl/=.

--- a/theories/Dot/examples/from_pdot_mutual_rec.v
+++ b/theories/Dot/examples/from_pdot_mutual_rec.v
@@ -31,7 +31,7 @@ Definition fromPDotPaperAbsTypesTBody : ty := {@
   type "Type" >: ⊥ <: TTop;
   type "TypeTop" >: ⊥ <: x0 @; "Type";
   val "newTypeTop" : ⊤ →: x0 @; "TypeTop";
-  type "TypeRef" >: ⊥ <: TAnd (p0 @; "Type") typeRefTBody;
+  type "TypeRef" >: ⊥ <: TAnd (x0 @; "Type") typeRefTBody;
   val "newTypeRef" : x1 @ "symbols" @; "Symbol" →: x0 @; "TypeRef"
 }.
 
@@ -160,7 +160,7 @@ Proof.
 Qed.
 
 Definition getAnyTypeT pOpt : ty :=
-  TAll (μ (fromPDotPaperAbsTBody (shift pOpt))) (⊤ →: p0 @ "types" @; "TypeTop").
+  TAll (μ (fromPDotPaperAbsTBody (shift pOpt))) (⊤ →: x0 @ "types" @; "TypeTop").
 Definition getAnyType : vl := vabs (tskip (tproj (tproj x0 "types") "newTypeTop")).
 
 Ltac simplSubst := rewrite /= /up/= /ids/ids_vl/=.
@@ -175,21 +175,21 @@ Definition fromPDotPaperAbsTypesTBodySubst : ty := {@
   val "newTypeRef" : x0 @ "symbols" @; "Symbol" →: x0 @ "types" @; "TypeRef"
 }.
 
-Lemma fromPDotPSubst: fromPDotPaperAbsTypesTBody .Tp[ (p0 @ "types") /]~ fromPDotPaperAbsTypesTBodySubst.
+Lemma fromPDotPSubst: fromPDotPaperAbsTypesTBody .Tp[ (x0 @ "types") /]~ fromPDotPaperAbsTypesTBodySubst.
 Proof. exact: psubst_ty_rtc_sufficient. Qed.
 
 Example getAnyTypeFunTyp Γ T : T :: optionModT :: Γ u⊢ₜ getAnyType : getAnyTypeT x1.
 Proof.
   rewrite /getAnyType -(iterate_S tskip 0); tcrush.
-  eapply (iT_Sub (T1 := TLater (⊤ →: p0 @ "types" @; "TypeTop"))); tcrush.
+  eapply (iT_Sub (T1 := TLater (⊤ →: x0 @ "types" @; "TypeTop"))); tcrush.
   set Γ' := shift (μ fromPDotPaperAbsTBody (shiftV x1)) :: T :: optionModT :: Γ.
-  have Hpx: Γ' u⊢ₚ p0 @ "types" : μ fromPDotPaperAbsTypesTBody, 0
+  have Hpx: Γ' u⊢ₚ x0 @ "types" : μ fromPDotPaperAbsTypesTBody, 0
     by tcrush; eapply iT_Sub_nocoerce;
       [ by eapply iT_Mu_E; first var; stcrush | tcrush].
-  have HpxSubst: Γ' u⊢ₚ p0 @ "types" : fromPDotPaperAbsTypesTBodySubst, 0.
+  have HpxSubst: Γ' u⊢ₚ x0 @ "types" : fromPDotPaperAbsTypesTBodySubst, 0.
   by eapply (iP_Mu_E (T := fromPDotPaperAbsTypesTBody)
-    (p := p0 @ "types")), Hpx; tcrush.
-  eapply (iT_Path (p := p0)), iP_Fld_I, (iP_Sub (i := 0)), HpxSubst.
+    (p := x0 @ "types")), Hpx; tcrush.
+  eapply (iT_Path (p := x0)), iP_Fld_I, (iP_Sub (i := 0)), HpxSubst.
   ltcrush.
 Qed.
 

--- a/theories/Dot/examples/from_pdot_mutual_rec_sem.v
+++ b/theories/Dot/examples/from_pdot_mutual_rec_sem.v
@@ -462,7 +462,7 @@ Qed.
 Example pCoreSemTyped Γ : ⊢ Γ ⊨[fromPDotGφ]
   lett hoptionModV fromPDotPaper : ⊤.
 Proof.
-  rewrite /lett /vabs'.
+  rewrite /lett.
   iIntros "#Hs".
   iApply T_All_E; first last.
   iApply (fundamental_typed with "Hs").
@@ -501,7 +501,7 @@ Definition fromPDotPaperAbsTypesTBodySubst : ty := {@
   val "getTypeFromTypeRef" : x0 @ "types" @; "TypeRef" →: x0 @ "types" @; "Type"
 }.
 
-Lemma fromPDotPSubst: fromPDotPaperAbsTypesTBody .Tp[ (p0 @ "types") /]~ fromPDotPaperAbsTypesTBodySubst.
+Lemma fromPDotPSubst: fromPDotPaperAbsTypesTBody .Tp[ x0 @ "types" /]~ fromPDotPaperAbsTypesTBodySubst.
 Proof. exact: psubst_ty_rtc_sufficient. Qed.
 
 Example getAnyTypeFunTyp Γ :

--- a/theories/Dot/examples/hoas.v
+++ b/theories/Dot/examples/hoas.v
@@ -258,11 +258,6 @@ Notation "'λ:' x .. y , t" := (hvabs (fun x => .. (hvabs (fun y => t%HE)) ..))
   (at level 200, x binder, y binder, right associativity,
   format "'[  ' '[  ' 'λ:'  x  ..  y ']' ,  '/' t ']'").
 
-(** Term lambda. Does not rely on coercions, and is more annoying. *)
-Notation "'λ::' x .. y , t" := (htv (hvabs (fun x => .. (htv (hvabs (fun y => t%HE))) ..)))
-  (at level 200, x binder, y binder, right associativity,
-  format "'[  ' '[  ' 'λ::'  x  ..  y ']' ,  '/' t ']'").
-
 Notation "'ν' ds " := (hvobj ds) (at level 60, ds at next level).
 Notation "'ν:' x , ds " := (hvobj (λD x, ds)) (at level 60, ds at next level).
 Notation "'val' l = v" := (l, hdpt v) (at level 60, l at level 50).
@@ -322,30 +317,18 @@ Notation hx6 := (hx 6).
 recommended. *)
 Definition hxm i : hvl := λ j, var_vl (j - i).
 
-Notation hpx n := (hpv (hx n)).
-Notation hp0 := (hpx 0).
-Notation hp1 := (hpx 1).
-Notation hp2 := (hpx 2).
-Notation hp3 := (hpx 3).
-Notation hp4 := (hpx 4).
-Notation hp5 := (hpx 5).
-Notation hp6 := (hpx 6).
-
 (** Additional syntactic sugar, in HOAS version *)
-Definition hvabs' x := htv (hvabs x).
-Arguments hvabs' /.
-
-Definition hlett t u := htapp (hvabs' u) t.
+Definition hlett t u := htapp (hvabs u) t.
 Arguments hlett /.
-Notation "hlett: x := t in: u" := (htapp (λ:: x, u) t) (at level 80).
+Notation "hlett: x := t in: u" := (htapp (λ: x, u) t) (at level 80).
 
 Definition hpackTV l T := ν: self, {@ type l = T }.
 Definition htyApp t l T :=
   hlett: x := t in:
-  hlett: a := htv (hpackTV l T) in:
-    htv x $: htv a.
+  hlett: a := hpackTV l T in:
+    x $: a.
 
-Definition hAnfBind t := hlett: x := t in: htv x.
+Definition hAnfBind t := hlett: x := t in: x.
 
 (* Notation "∀: x .. y , P" := (hTAll x, .. (hTAll y, P) ..)
   (at level 200, x binder, y binder, right associativity,

--- a/theories/Dot/examples/hoas.v
+++ b/theories/Dot/examples/hoas.v
@@ -38,21 +38,14 @@ Global Arguments hclose /.
 Definition pureS {s1} : s1 → hterm s1 := λ x _, x.
 Global Arguments pureS /.
 
-Notation htm'   := (hterm tm).
-Notation hvl'   := (hterm vl).
-Notation hdm'   := (hterm dm).
-Notation hpath' := (hterm path).
-Notation hty'   := (hterm ty).
-Notation hdms'  := (list (label * hdm')).
-
 (** We can't set up coercions across [hterm A] and [hterm B], hence add
 definitions and identity coercions via [SubClass]. *)
-SubClass htm   := htm'.
-SubClass hvl   := hvl'.
-SubClass hdm   := hdm'.
-SubClass hpath := hpath'.
-SubClass hty   := hty'.
-SubClass hdms  := hdms'.
+SubClass htm   := hterm tm.
+SubClass hvl   := hterm vl.
+SubClass hdm   := hterm dm.
+SubClass hpath := hterm path.
+SubClass hty   := hterm ty.
+SubClass hdms  := list (label * hterm dm).
 
 Coercion hclose_tm   := hclose : htm   → tm.
 Coercion hclose_vl   := hclose : hvl   → vl.
@@ -109,19 +102,21 @@ End hterm_lifting.
 
 (* Binders in our language: λ, ν, ∀, μ. *)
 
-(** We bind also to [hty'] to support well combinators like [hclose]. *)
-Declare Scope hty_scope.
-Bind Scope hty_scope with hty hty'.
-Delimit Scope hty_scope with HT.
+(** We define a scope for term and type syntax.
+
+We bind it to [hty], [htm], and also to [hterm], to get the right scopes for
+combinators like [hclose].
+
+We can only bind one scope to [hterm], and that is why we use a unique scope
+for all this syntax.
+*)
+Declare Scope hsyn_scope.
+Bind Scope hsyn_scope with hty htm hterm.
+Delimit Scope hsyn_scope with HS.
 
 Declare Scope hdms_scope.
-Bind Scope hdms_scope with hdms hdms'.
+Bind Scope hdms_scope with hdms list.
 Delimit Scope hdms_scope with HD.
-
-(* [htm'] here interferes: we can only bind one scope to [hterm]. Merge them!*)
-Declare Scope hexpr_scope.
-Bind Scope hexpr_scope with htm.
-Delimit Scope hexpr_scope with HE.
 
 Instance ids_hvl : Ids hvl := λ x, (* [x]: input to the substitution. *)
   (* Resulting [vl]. *)
@@ -176,8 +171,8 @@ Definition hTInt : hty := liftA0 TInt.
 Definition hTBool : hty := liftA0 TBool.
 
 Arguments hvobj _%HD.
-Arguments hTAll _%HT _%HT.
-Arguments hTMu _%HT.
+Arguments hTAll _%HS _%HS.
+Arguments hTMu _%HS.
 
 Arguments htv /.
 Arguments htapp /.
@@ -217,20 +212,20 @@ Module Import hoasNotation.
 Export syn.
 
 (* Primitive operations. *)
-Notation "e1 + e2" := (htbin bplus e1%HE e2%HE) : hexpr_scope.
-Notation "e1 - e2" := (htbin bminus e1%HE e2%HE) : hexpr_scope.
-Notation "e1 * e2" := (htbin btimes e1%HE e2%HE) : hexpr_scope.
-Notation "e1 `div` e2" := (htbin bdiv e1%HE e2%HE) : hexpr_scope.
+Notation "e1 + e2" := (htbin bplus e1%HS e2%HS) : hsyn_scope.
+Notation "e1 - e2" := (htbin bminus e1%HS e2%HS) : hsyn_scope.
+Notation "e1 * e2" := (htbin btimes e1%HS e2%HS) : hsyn_scope.
+Notation "e1 `div` e2" := (htbin bdiv e1%HS e2%HS) : hsyn_scope.
 
-Notation "e1 ≤ e2" := (htbin ble e1%HE e2%HE) : hexpr_scope.
-Notation "e1 < e2" := (htbin blt e1%HE e2%HE) : hexpr_scope.
-Notation "e1 = e2" := (htbin beq e1%HE e2%HE) : hexpr_scope.
-Notation "e1 ≠ e2" := (htun unot (htbin beq e1%HE e2%HE)) : hexpr_scope.
+Notation "e1 ≤ e2" := (htbin ble e1%HS e2%HS) : hsyn_scope.
+Notation "e1 < e2" := (htbin blt e1%HS e2%HS) : hsyn_scope.
+Notation "e1 = e2" := (htbin beq e1%HS e2%HS) : hsyn_scope.
+Notation "e1 ≠ e2" := (htun unot (htbin beq e1%HS e2%HS)) : hsyn_scope.
 
-Notation "~ e" := (htun unot e%HE) (at level 75, right associativity) : hexpr_scope.
+Notation "~ e" := (htun unot e%HS) (at level 75, right associativity) : hsyn_scope.
 
-Notation "e1 > e2" := (e2%HE < e1%HE)%HE : hexpr_scope.
-Notation "e1 ≥ e2" := (e2%HE ≤ e1%HE)%HE : hexpr_scope.
+Notation "e1 > e2" := (e2%HS < e1%HS)%HS : hsyn_scope.
+Notation "e1 ≥ e2" := (e2%HS ≤ e1%HS)%HS : hsyn_scope.
 
 (* Notations. *)
 Open Scope hdms_scope.
@@ -243,10 +238,10 @@ Notation " {@ x ; y ; .. ; z } " :=
 
 Close Scope hdms_scope.
 
-(* Useful for writing functions whose body is in scope [%HT]. *)
-Notation "'λT' x .. y , t" := (fun x => .. (fun y => t%HT) ..)
+(* Useful for writing functions whose body is in scope [%HS]. *)
+Notation "'λT' x .. y , t" := (fun x => .. (fun y => t%HS) ..)
   (at level 200, x binder, y binder, right associativity,
-  only parsing) : hty_scope.
+  only parsing) : hsyn_scope.
 
 (* Useful for writing functions whose body is in scope [%HD]. *)
 Notation "'λD' x .. y , t" := (fun x => .. (fun y => t%HD) ..)
@@ -254,7 +249,7 @@ Notation "'λD' x .. y , t" := (fun x => .. (fun y => t%HD) ..)
   only parsing) : hdms_scope.
 
 (** Value lambda. Relies on inserting [htv] coercions in the output. *)
-Notation "'λ:' x .. y , t" := (hvabs (fun x => .. (hvabs (fun y => t%HE)) ..))
+Notation "'λ:' x .. y , t" := (hvabs (fun x => .. (hvabs (fun y => t%HS)) ..))
   (at level 200, x binder, y binder, right associativity,
   format "'[  ' '[  ' 'λ:'  x  ..  y ']' ,  '/' t ']'").
 
@@ -272,26 +267,26 @@ Notation "'type' l '=[' T ']'" := (l, hdtysem' T) (at level 60, l at level 50, T
 (** Notation for object types. *)
 Global Instance: Top hty := hTTop.
 Global Instance: Bottom hty := hTBot.
-Open Scope hty_scope.
-Notation " {@ T1 } " := ( hTAnd T1 ⊤ ) (format "{@  T1  }"): hty_scope.
+Open Scope hsyn_scope.
+Notation " {@ T1 } " := ( hTAnd T1 ⊤ ) (format "{@  T1  }"): hsyn_scope.
 Notation " {@ T1 ; T2 ; .. ; Tn } " :=
   (hTAnd T1 (hTAnd T2 .. (hTAnd Tn ⊤)..))
-  (format "'[v' {@  '[' T1 ']'  ;  '/' T2  ;  '/' ..  ;  '/' Tn } ']'") : hty_scope.
-Close Scope hty_scope.
+  (format "'[v' {@  '[' T1 ']'  ;  '/' T2  ;  '/' ..  ;  '/' Tn } ']'") : hsyn_scope.
+Close Scope hsyn_scope.
 
-Notation "'𝐙'" := hTInt : hty_scope.
+Notation "'𝐙'" := hTInt : hsyn_scope.
 
-Notation "▶:" := hTLater : hty_scope.
-Notation "▶: T" := (hTLater T) (at level 49, right associativity) : hty_scope.
+Notation "▶:" := hTLater : hsyn_scope.
+Notation "▶: T" := (hTLater T) (at level 49, right associativity) : hsyn_scope.
 
 Notation "'∀:' x : T , U" := (hTAll T (λT x, U)) (at level 48, x, T at level 98, U at level 98).
 Notation "'μ' Ts" := (hTMu Ts) (at level 50, Ts at next level).
 Notation "'μ:' x , Ts" := (hTMu (λT x, Ts)) (at level 50, Ts at next level).
-Notation "'type' l >: L <: U" := (hTTMem l L U) (at level 60, l at level 50, L, U at level 70) : hty_scope.
+Notation "'type' l >: L <: U" := (hTTMem l L U) (at level 60, l at level 50, L, U at level 70) : hsyn_scope.
 Notation "'val' l : T" := (hTVMem l T)
-  (at level 60, l, T at level 50, format "'[' 'val'  l  :  T  ']' '/'") : hty_scope.
+  (at level 60, l, T at level 50, format "'[' 'val'  l  :  T  ']' '/'") : hsyn_scope.
 
-Notation "S →: T" := (hTAll S (λT _ , T)) (at level 49, T at level 98, right associativity) : hty_scope.
+Notation "S →: T" := (hTAll S (λT _ , T)) (at level 49, T at level 98, right associativity) : hsyn_scope.
 
 Notation "p @; l" := (hTSel p l) (at level 48).
 Notation "v @ l1 @ .. @ l2" := (hpself .. (hpself v l1) .. l2)
@@ -300,8 +295,8 @@ Notation "a @: b" := (htproj a b) (at level 59, b at next level).
 
 Infix "$:" := htapp (at level 68, left associativity).
 
-Notation tparam A := (type A >: ⊥ <: ⊤)%HT.
-Definition typeEq l T := (type l >: T <: T) %HT.
+Notation tparam A := (type A >: ⊥ <: ⊤)%HS.
+Definition typeEq l T := (type l >: T <: T) %HS.
 
 Notation hx := hvar_vl.
 

--- a/theories/Dot/examples/hoas.v
+++ b/theories/Dot/examples/hoas.v
@@ -115,7 +115,7 @@ Bind Scope hsyn_scope with hty htm hterm.
 Delimit Scope hsyn_scope with HS.
 
 Declare Scope hdms_scope.
-Bind Scope hdms_scope with hdms list.
+Bind Scope hdms_scope with hdms.
 Delimit Scope hdms_scope with HD.
 
 Instance ids_hvl : Ids hvl := λ x, (* [x]: input to the substitution. *)

--- a/theories/Dot/examples/list.v
+++ b/theories/Dot/examples/list.v
@@ -280,12 +280,12 @@ Proof.
 
   (* Here we produce a list of later nats, since we produce a list of p.A where p is the
   "type" argument and p : { A <: Nat} so p.A <: ▶: Nat. *)
-  set U := (type "A" >: ⊥ <: ▶: 𝐙)%HT.
+  set U := (type "A" >: ⊥ <: ▶: 𝐙)%HS.
   set V := (hTAnd (hlistT hx1 hx0) U).
   apply AnfBind_typed with (T := V); stcrush; first last.
   {
     eapply iT_Sub_nocoerce; first
-      eapply (iT_Mu_E' (T1 := (val "head" : ⊤ →: hx0 @; "A")%HT));
+      eapply (iT_Mu_E' (T1 := (val "head" : ⊤ →: hx0 @; "A")%HS));
       [ | done | tcrush ..].
       - varsub; asideLaters; lThis; ltcrush.
       - by apply (iSel_Sub (L := ⊥)), (path_tp_delay (i := 0)); wtcrush; varsub; ltcrush.
@@ -310,7 +310,7 @@ Proof.
   eapply iT_All_E, Hsnil.
   eapply (iT_All_E (T1 := 𝐙)); last tcrush.
   (* Perform avoidance on the type application. *)
-  eapply tyApp_typed with (T := 𝐙%HT); first done; intros; ltcrush; cbv -[Γ'].
+  eapply tyApp_typed with (T := 𝐙%HS); first done; intros; ltcrush; cbv -[Γ'].
   by eapply iSub_Sel', (path_tp_delay (i := 0)); try (typconstructor; var); wtcrush.
   by lNext.
   lNext; by eapply iSel_Sub, (path_tp_delay (i := 0)); try (typconstructor; var); wtcrush.

--- a/theories/Dot/examples/list.v
+++ b/theories/Dot/examples/list.v
@@ -15,13 +15,9 @@ From D.Dot.examples Require Import ex_utils scala_lib hoas.
 Import DBNotation hoasNotation.
 
 Implicit Types (L T U: hty) (Γ : list ty).
- (* (v: vl) (e: tm) (d: dm) (ds: dms) . *)
 
 Definition htrueTm (bool : hvl) := htskip (bool @: "true").
 Definition hfalseTm (bool : hvl) := htskip (bool @: "false").
-
-(* bool : boolImplT *)
-(* Let Γ' := boolImplT :: Γ. *)
 
 Lemma trueTyp Γ Γ'' : Γ'' ++ boolImplT :: Γ u⊢ₜ
   htrueTm (hx (length Γ'')) : hx (length Γ'') @; "Boolean".

--- a/theories/Dot/examples/prim_boolean_option.v
+++ b/theories/Dot/examples/prim_boolean_option.v
@@ -161,7 +161,7 @@ Proof.
   - tMember.
   - apply boolSing.
   - eapply iT_All_E; first var.
-    apply (iT_Sub (i := 1) (T1 := (▶: (hx3 @; "T"))%HT)); tcrush.
+    apply (iT_Sub (i := 1) (T1 := (▶: (hx3 @; "T"))%HS)); tcrush.
     varsub; ltcrush.
   - varsub.
     ettrans; first (apply iSub_Add_Later; tcrush).

--- a/theories/Dot/examples/prim_boolean_option.v
+++ b/theories/Dot/examples/prim_boolean_option.v
@@ -47,7 +47,7 @@ Encoding Option, using primitive booleans; we export Option as an abstract type.
 *)
 
 (* ∀ x : {type U}, x.U → (self.T → x.U) → x.U *)
-Definition hpmatchT self := ∀: x : tparam "U", hpv x @; "U" →: (hpv self @; "T" →: hpv x @; "U") →: hpv x @; "U".
+Definition hpmatchT self := ∀: x : tparam "U", x @; "U" →: (self @; "T" →: x @; "U") →: x @; "U".
 Definition hoptionTGen (L U : hty) := μ: self, {@
   type "T" >: L <: U;
   val "isEmpty" : hTBool;
@@ -83,7 +83,6 @@ Definition hoptionModTConcrBody : hty := {@
 (** Define interface for [hoptionModV]. To rewrite to have abstraction. *)
 
 Definition hoptionT := hoptionTGen ⊥ ⊤.
-Definition optionT := hclose hoptionT.
 
 Definition hnoneT self := hTAnd (self @; "Option") {@ typeEq "T" ⊥}.
 
@@ -110,8 +109,8 @@ Definition optionModT : ty := hoptionModT.
 
 (** Define the stamped map table we'll need. *)
 Definition hpBot : hstampTy := MkTy 1 [] ⊥ 0.
-Definition hpXA x : hstampTy := MkTy 2 [x] (hclose (hpv hx0 @; "A")) 1.
-Definition hpOptionTConcr : hstampTy := MkTy 3 [] (hclose hoptionTConcr) 0.
+Definition hpXA x : hstampTy := MkTy 2 [x] (hx0 @; "A") 1.
+Definition hpOptionTConcr : hstampTy := MkTy 3 [] hoptionTConcr 0.
 
 Definition primOptionG : stys := psAddStys ∅ [hpBot; hpXA hx0; hpOptionTConcr].
 
@@ -135,7 +134,6 @@ Definition hnoneV := ν: _, {@
   val "isEmpty" = true;
   val "pmatch" = λ: x none some, none
 }.
-Definition noneV := hclose hnoneV.
 
 Lemma boolSing g Γ (b : bool) : Γ v⊢ₜ[g] b : TSing b.
 Proof.
@@ -144,28 +142,26 @@ Proof.
 Qed.
 
 Example noneTypStronger Γ :
-  Γ v⊢ₜ[ primOptionG ] tv noneV : hclose hnoneConcrT.
+  Γ v⊢ₜ[ primOptionG ] hnoneV : hnoneConcrT.
 Proof.
   tcrush; [tMember | apply boolSing | var].
 Qed.
 
 Definition hmkSome : hvl := λ: x content, ν: self, {@
-  (* type "T" = hpv x @; "A"; *)
   type "T" =[ hpXA x ];
   val "isEmpty" = false;
   val "pmatch" = λ: x none some, some $: htskip (self @: "get");
   val "get" = content
 }.
-Definition mkSome := hclose hmkSome.
 
 Example mkSomeTypStronger Γ :
-  Γ v⊢ₜ[ primOptionG ] tv mkSome : hclose hmkSomeTSing.
+  Γ v⊢ₜ[ primOptionG ] hmkSome : hmkSomeTSing.
 Proof.
   tcrush; cbv.
   - tMember.
   - apply boolSing.
   - eapply iT_All_E; first var.
-    apply (iT_Sub (i := 1) (T1 := hclose (▶: (hp3 @; "T"))%HT)); tcrush.
+    apply (iT_Sub (i := 1) (T1 := (▶: (hx3 @; "T"))%HT)); tcrush.
     varsub; ltcrush.
   - varsub.
     ettrans; first (apply iSub_Add_Later; tcrush).
@@ -182,9 +178,9 @@ Definition hoptionModV := ν: self, {@
 
 (** Rather precise type for [hoptionModV]. *)
 Example optionModConcrTyp Γ :
-  Γ v⊢ₜ[ primOptionG ] hclose hoptionModV : hclose (μ: _, hoptionModTConcrBody).
+  Γ v⊢ₜ[ primOptionG ] hoptionModV : μ: _, hoptionModTConcrBody.
 Proof.
-  set U := hclose (▶: hoptionModTConcrBody).
+  set U := (▶: hoptionModTConcrBody)%ty : ty.
   have := noneTypStronger (U :: Γ).
   have := mkSomeTypStronger (U :: Γ) => /(iD_Val "mkSome") Hs Hn.
   ltcrush.
@@ -192,7 +188,7 @@ Proof.
 Qed.
 
 Example optionModInvTyp Γ :
-  Γ v⊢ₜ[ primOptionG ] hclose hoptionModV : hclose (μ: self, hoptionModTInvBody self).
+  Γ v⊢ₜ[ primOptionG ] hoptionModV : μ: self, hoptionModTInvBody self.
 Proof.
   eapply iT_Sub_nocoerce; first apply optionModConcrTyp.
   ltcrush; rewrite iterate_0.
@@ -203,11 +199,11 @@ Proof.
 Qed.
 
 Example optionModTypSub Γ :
-  Γ v⊢ₜ[ primOptionG ] hclose (μ: self, hoptionModTInvBody self), 0 <: hclose hoptionModT, 0.
+  Γ v⊢ₜ[ primOptionG ] μ: self, hoptionModTInvBody self, 0 <: hoptionModT, 0.
 Proof. ltcrush; eapply (iT_Sub (i := 0)), iT_Bool_I; tcrush. Qed.
 
 Example optionModTyp Γ :
-  Γ v⊢ₜ[ primOptionG ] hclose (htv hoptionModV) : hclose hoptionModT.
+  Γ v⊢ₜ[ primOptionG ] hoptionModV : hoptionModT.
 Proof. eapply iT_Sub_nocoerce, optionModTypSub; apply optionModInvTyp. Qed.
 
 End prim_boolean_option_mod.

--- a/theories/Dot/examples/scala_lib.v
+++ b/theories/Dot/examples/scala_lib.v
@@ -13,24 +13,24 @@ Import hoasNotation.
 (** * Infinite loops *)
 
 Definition hloopDefV : hvl := ν: self, {@
-  val "loop" = hpv (λ: w, self @: "loop" $: w)
+  val "loop" = λ: w, self @: "loop" $: w
   (* λ w, self.loop w. *)
 }.
 Definition hloopDefT : hty := val "loop" : ⊤ →: ⊥.
 Definition hloopDefTConcr : hty := μ: _, {@ hloopDefT }.
-Example loopDefTyp Γ : Γ u⊢ₜ hclose (htv hloopDefV) : hclose hloopDefT.
+Example loopDefTyp Γ : Γ u⊢ₜ hloopDefV : hloopDefT.
 Proof.
-  apply (iT_Sub_nocoerce (hclose hloopDefTConcr)); mltcrush; cbv.
+  apply (iT_Sub_nocoerce hloopDefTConcr); mltcrush; cbv.
   eapply iT_All_E; last var.
   tcrush; varsub; lookup.
 Qed.
 
-Definition hloopFunTm : htm := htv hloopDefV @: "loop".
-Example loopFunTyp Γ : Γ u⊢ₜ hclose hloopFunTm : hclose ⊤ →: ⊥.
+Definition hloopFunTm : htm := hloopDefV @: "loop".
+Example loopFunTyp Γ : Γ u⊢ₜ hloopFunTm : ⊤ →: ⊥.
 Proof. have ? := loopDefTyp Γ; tcrush. Qed.
 
-Definition hloopTm : htm := hloopFunTm $: htv (hvint 0).
-Example loopTyp Γ : Γ u⊢ₜ hclose hloopTm : ⊥.
+Definition hloopTm : htm := hloopFunTm $: hvint 0.
+Example loopTyp Γ : Γ u⊢ₜ hloopTm : ⊥.
 Proof.
   have ? := loopFunTyp Γ; apply (iT_All_E (T1 := ⊤)), (iT_Sub_nocoerce 𝐙);
     tcrush.
@@ -54,66 +54,64 @@ let bool = boolImplV : μ { Boolean: IFT..IFT; true : b.Boolean; false : b.Boole
  *)
 Module Export hBool.
 Import hoasNotation.
-Definition hIFTBody x : hty := hpv x @; "A" →: hpv x @; "A" →: hpv x @; "A".
-Definition IFTBody := hclose $ hIFTBody hx0.
+Definition hIFTBody x : hty := x @; "A" →: x @; "A" →: x @; "A".
+Definition IFTBody : ty := hIFTBody hx0.
 Definition hIFT : hty :=
   ∀: x : tparam "A", hIFTBody x.
-Definition IFT := hclose hIFT.
+Definition IFT : ty := hIFT.
 
-Definition hiftTrue : hvl := λ: x, λ:: t f, htv t.
-Definition hiftFalse : hvl := λ: x, λ:: t f, htv f.
-Definition iftTrue := hclose hiftTrue.
-Definition iftFalse := hclose hiftFalse.
+Definition hiftTrue : hvl := λ: x t f, t.
+Definition hiftFalse : hvl := λ: x t f, f.
 End hBool.
 
-Example iftTrueTyp Γ : Γ u⊢ₜ tv iftTrue : IFT.
+Example iftTrueTyp Γ : Γ u⊢ₜ hiftTrue : hIFT.
 Proof. tcrush. var. Qed.
-Example iftFalseTyp Γ : Γ u⊢ₜ tv iftFalse : IFT.
+Example iftFalseTyp Γ : Γ u⊢ₜ hiftFalse : hIFT.
 Proof. tcrush. var. Qed.
 
 Definition boolImplV :=
   ν {@
-    type "Boolean" = IFT;
-    val "true" = pv iftTrue;
-    val "false" = pv iftFalse
+    type "Boolean" = hIFT;
+    val "true" = hiftTrue;
+    val "false" = hiftFalse
   }.
 
 Definition boolImplTConcr : ty :=
   μ {@
-    typeEq "Boolean" IFT;
-    val "true" : IFT;
-    val "false" : IFT
+    typeEq "Boolean" hIFT;
+    val "true" : hIFT;
+    val "false" : hIFT
   }.
 
-Definition p0Bool := p0 @; "Boolean".
+Definition p0Bool := x0 @; "Boolean".
 
 (* This type makes "Boolean" nominal by abstracting it. *)
 Definition boolImplT : ty :=
   μ {@
-    type "Boolean" >: ⊥ <: IFT;
+    type "Boolean" >: ⊥ <: hIFT;
     val "true" : TLater p0Bool;
     val "false" : TLater p0Bool
   }.
 
 Example SubIFT_P0Bool Γ : {@
-    typeEq "Boolean" IFT;
-    val "true" : IFT;
-    val "false" : IFT
-  }%ty :: Γ u⊢ₜ IFT, 0 <: p0Bool, 0.
+    typeEq "Boolean" hIFT;
+    val "true" : hIFT;
+    val "false" : hIFT
+  }%ty :: Γ u⊢ₜ hIFT, 0 <: p0Bool, 0.
 Proof. eapply iSub_Sel''; tcrush. varsub; tcrush. Qed.
 
 Example SubIFT_LaterP0Bool' Γ : {@
-    typeEq "Boolean" IFT;
-    val "true" : IFT;
-    val "false" : IFT
-  }%ty :: Γ u⊢ₜ IFT, 0 <: ▶: p0Bool, 0.
+    typeEq "Boolean" hIFT;
+    val "true" : hIFT;
+    val "false" : hIFT
+  }%ty :: Γ u⊢ₜ hIFT, 0 <: ▶: p0Bool, 0.
 Proof. ettrans; first exact: SubIFT_P0Bool. tcrush. Qed.
 
 Example SubIFT_LaterP0Bool Γ : (▶: {@
-    typeEq "Boolean" IFT;
+    typeEq "Boolean" hIFT;
     val "true" : ▶: p0Bool;
     val "false" : ▶: p0Bool
-  })%ty :: Γ u⊢ₜ IFT, 0 <: ▶: p0Bool, 0.
+  })%ty :: Γ u⊢ₜ hIFT, 0 <: ▶: p0Bool, 0.
 Proof.
   asideLaters.
   ettrans; first (apply (iSub_AddI _ _ 1); tcrush).
@@ -122,11 +120,11 @@ Proof.
 Qed.
 
 Example boolImplTypConcr Γ :
-  Γ u⊢ₜ tv boolImplV : boolImplTConcr.
-Proof. tcrush; by [apply (iD_Typ_Abs IFT); tcrush | var]. Qed.
+  Γ u⊢ₜ boolImplV : boolImplTConcr.
+Proof. tcrush; by [apply (iD_Typ_Abs hIFT); tcrush | var]. Qed.
 
 Example boolImplTyp Γ :
-  Γ u⊢ₜ tv boolImplV : boolImplT.
+  Γ u⊢ₜ boolImplV : boolImplT.
 Proof.
   apply (iT_Sub_nocoerce boolImplTConcr); first by apply boolImplTypConcr.
   tcrush; rewrite iterate_0; ltcrush; apply SubIFT_LaterP0Bool'.
@@ -135,56 +133,56 @@ Qed.
 Module Export hBoolSing.
 Import hoasNotation.
 Definition hIFTGenT hres : hty :=
-  ∀: x : tparam "A", ∀: t : hpv x @; "A", ∀: f: hpv x @; "A", hres t f.
+  ∀: x : tparam "A", ∀: t : x @; "A", ∀: f: x @; "A", hres t f.
 
-Definition hIFTFalseT : hty := hIFTGenT (λ t f, hTSing (hpv f)).
-Definition hIFTTrueT : hty := hIFTGenT (λ t f, hTSing (hpv t)).
+Definition hIFTFalseT : hty := hIFTGenT (λ t f, hTSing f).
+Definition hIFTTrueT : hty := hIFTGenT (λ t f, hTSing t).
 
-Example iftTrueSingTyp Γ : Γ u⊢ₜ tv iftTrue : hclose hIFTTrueT.
+Example iftTrueSingTyp Γ : Γ u⊢ₜ hiftTrue : hIFTTrueT.
 Proof.
   tcrush; cbv.
   eapply (iT_Path (p := pv _)), iP_Sngl_Refl.
   typconstructor; var.
 Qed.
 
-Example iftFalseSingTyp Γ : Γ u⊢ₜ tv iftFalse : hclose hIFTFalseT.
+Example iftFalseSingTyp Γ : Γ u⊢ₜ hiftFalse : hIFTFalseT.
 Proof.
   tcrush; cbv.
   eapply (iT_Path (p := pv _)), iP_Sngl_Refl.
   typconstructor; var.
 Qed.
 
-Lemma hIFTTrueTSub Γ : Γ u⊢ₜ hclose hIFTTrueT, 0 <: hclose hIFT, 0.
+Lemma hIFTTrueTSub Γ : Γ u⊢ₜ hIFTTrueT, 0 <: hIFT, 0.
 Proof. tcrush; varsub; tcrush. Qed.
 
-Lemma hIFTFalseTSub Γ : Γ u⊢ₜ hclose hIFTFalseT, 0 <: hclose hIFT, 0.
+Lemma hIFTFalseTSub Γ : Γ u⊢ₜ hIFTFalseT, 0 <: hIFT, 0.
 Proof. tcrush; varsub; tcrush. Qed.
 
 Import DBNotation.
 
 Module AssertPlain.
 Definition assertBody e : tm :=
-  tskip (tyApp e "A" (⊤ →: ⊤) $: tv x1 $: tv x0).
+  tskip (tyApp e "A" (⊤ →: ⊤) $: x1 $: x0).
 
 Import hoasNotation.
 
 Definition hassertFun e :=
-  hlett: hsucc := htv (λ: x, htv x) in:
+  hlett: hsucc := λ: x, x in:
   hlett: hfail := hloopFunTm in:
   pureS (assertBody e).
 
 Definition hassert e :=
-  hassertFun e $: htv (hvint 0).
+  hassertFun e $: hvint 0.
 
 Lemma hassertBodyTyp Γ e T :
-  T :: Γ u⊢ₜ e : hclose hIFT →
-  T :: Γ u⊢ₜ tv x0 : ⊤ →: ⊤ →
-  T :: Γ u⊢ₜ tv x1 : ⊤ →: ⊤ →
+  T :: Γ u⊢ₜ e : hIFT →
+  T :: Γ u⊢ₜ x0 : ⊤ →: ⊤ →
+  T :: Γ u⊢ₜ x1 : ⊤ →: ⊤ →
   T :: Γ u⊢ₜ assertBody e : ⊤ →: ⊤.
 Proof.
   rewrite /assertBody => /= He Hx0 Hx1.
   have Hty: T :: Γ u⊢ₜ tyApp e "A" (⊤ →: ⊤) :
-    hclose (⊤ →: ⊤) →: (⊤ →: ⊤) →: ▶: (⊤ →: ⊤).
+    (⊤ →: ⊤) →: (⊤ →: ⊤) →: ▶: (⊤ →: ⊤).
   by eapply tyApp_typed; first apply He; intros; simpl; tcrush;
     [eapply iSub_Sel', (path_tp_delay (i := 0))..|
     eapply iSel_Sub, (path_tp_delay (i := 0))];
@@ -194,8 +192,8 @@ Proof.
 Qed.
 
 Lemma hassertFunTyp Γ e
-  (Hty : ((⊤ →: ⊤) :: (⊤ →: ⊤) :: Γ)%ty u⊢ₜ e : hclose hIFT) :
-  Γ u⊢ₜ hclose (hassertFun e) : ⊤ →: ⊤.
+  (Hty : ((⊤ →: ⊤) :: (⊤ →: ⊤) :: Γ)%ty u⊢ₜ e : hIFT) :
+  Γ u⊢ₜ hassertFun e : ⊤ →: ⊤.
 Proof.
   apply iT_Let with (T := (⊤ →: ⊤)%ty); tcrush; first var.
   apply iT_Let with (T := (⊤ →: ⊤)%ty); stcrush.
@@ -204,8 +202,8 @@ Proof.
 Qed.
 
 Lemma hassertTyp Γ e
-  (Ht : ((⊤ →: ⊤) :: (⊤ →: ⊤) :: Γ)%ty u⊢ₜ e : hclose hIFT):
-  Γ u⊢ₜ hclose (hassert e) : ⊤.
+  (Ht : ((⊤ →: ⊤) :: (⊤ →: ⊤) :: Γ)%ty u⊢ₜ e : hIFT):
+  Γ u⊢ₜ hassert e : ⊤.
 Proof.
   eapply iT_All_E, iT_Sub_nocoerce; first exact: hassertFunTyp; tcrush.
 Qed.
@@ -214,26 +212,26 @@ End AssertPlain.
 Module AssertSingletons.
 
 Definition assertBody e : tm :=
-  tyApp e "A" ⊤ $: tv x1 $: tv x0.
+  tyApp e "A" ⊤ $: x1 $: x0.
 
 Import hoasNotation.
 Definition hassertFun e :=
-  hlett: hsucc := htv (λ: x, htv x) in:
+  hlett: hsucc := λ: x, x in:
   hlett: hfail := hloopFunTm in:
   pureS (assertBody e).
 
 Definition hassert e :=
-  hassertFun e $: htv (hvint 0).
+  hassertFun e $: hvint 0.
 
 Lemma hassertBodyFalseTyp Γ e T :
-  T :: Γ u⊢ₜ e : hclose hIFTFalseT →
-  T :: Γ u⊢ₜ tv x0 : ⊤ →
-  T :: Γ u⊢ₜ tv x1 : ⊤ →
-  T :: Γ u⊢ₜ assertBody e : TSing (pv x0).
+  T :: Γ u⊢ₜ e : hIFTFalseT →
+  T :: Γ u⊢ₜ x0 : ⊤ →
+  T :: Γ u⊢ₜ x1 : ⊤ →
+  T :: Γ u⊢ₜ assertBody e : TSing x0.
 Proof.
   move => /= He Hx0 Hx1.
   have Hty: T :: Γ u⊢ₜ tyApp e "A" ⊤ :
-    hclose (∀: t : ⊤, ∀: f: ⊤, hTSing (hpv f)).
+    ∀: t : ⊤, ∀: f: ⊤, hTSing f.
   by eapply tyApp_typed; first apply He; intros; tcrush;
     eapply iSub_Sel', (path_tp_delay (i := 0));
     try (typconstructor; var); wtcrush.
@@ -243,14 +241,14 @@ Proof.
 Qed.
 
 Lemma hassertBodyTrueTyp Γ e T U :
-  T :: U :: Γ u⊢ₜ e : hclose hIFTTrueT →
-  T :: U :: Γ u⊢ₜ tv x1 : ⊤ →
-  T :: U :: Γ u⊢ₜ tv x0 : ⊤ →
-  T :: U :: Γ u⊢ₜ assertBody e : TSing (pv x1).
+  T :: U :: Γ u⊢ₜ e : hIFTTrueT →
+  T :: U :: Γ u⊢ₜ x1 : ⊤ →
+  T :: U :: Γ u⊢ₜ x0 : ⊤ →
+  T :: U :: Γ u⊢ₜ assertBody e : TSing x1.
 Proof.
   move => /= He Hx1 Hx0.
   have Hty: T :: U :: Γ u⊢ₜ tyApp e "A" ⊤ :
-    hclose (∀: t : ⊤, ∀: f: ⊤, hTSing (hpv t)).
+    ∀: t : ⊤, ∀: f: ⊤, hTSing t.
   by eapply tyApp_typed; first apply He; intros; tcrush;
     eapply iSub_Sel', (path_tp_delay (i := 0));
     try (typconstructor; var); wtcrush.
@@ -260,8 +258,8 @@ Proof.
 Qed.
 
 Lemma hassertFunTrueTyp Γ e :
-  (⊤ :: ⊤ :: Γ)%ty u⊢ₜ e : hclose hIFTTrueT →
-  Γ u⊢ₜ hclose (hassertFun e) : ⊤.
+  (⊤ :: ⊤ :: Γ)%ty u⊢ₜ e : hIFTTrueT →
+  Γ u⊢ₜ hassertFun e : ⊤.
 Proof.
   move => /hassertBodyTrueTyp He.
   apply iT_Let with (T := ⊤%ty); stcrush. {
@@ -274,8 +272,8 @@ Proof.
 Qed.
 
 Lemma hassertFunFalseTyp Γ e :
-  (⊤ :: ⊤ :: Γ)%ty u⊢ₜ e : hclose hIFTFalseT →
-  Γ u⊢ₜ hclose (hassertFun e) : ⊤.
+  (⊤ :: ⊤ :: Γ)%ty u⊢ₜ e : hIFTFalseT →
+  Γ u⊢ₜ hassertFun e : ⊤.
 Proof.
   move => /hassertBodyFalseTyp He.
   apply iT_Let with (T := ⊤%ty); stcrush. {
@@ -305,7 +303,7 @@ Module Export option.
 Import hoasNotation.
 
 (* ∀ x : {type U}, x.U → (self.T → x.U) → x.U *)
-Definition hpmatchT self := ∀: x : tparam "U", hpv x @; "U" →: (hpv self @; "T" →: hpv x @; "U") →: hpv x @; "U".
+Definition hpmatchT self := ∀: x : tparam "U", x @; "U" →: (self @; "T" →: x @; "U") →: x @; "U".
 Definition hoptionTGen (L U : hty) := μ: self, {@
   type "T" >: L <: U;
   val "isEmpty" : hIFT;
@@ -329,15 +327,14 @@ Definition hnoneSingT := μ: self, hnoneSingTBody self.
 
 Definition hnoneV := ν: _, {@
   type "T" = ⊥;
-  val "isEmpty" = hpv hiftTrue;
-  val "pmatch" = hpv (λ: x, λ:: none some, htv none)
+  val "isEmpty" = hiftTrue;
+  val "pmatch" = λ: x none some, none
 }.
-Definition noneV := hclose hnoneV.
 
 Example noneTypStronger Γ :
-  Γ u⊢ₜ tv noneV : hclose hnoneSingT.
+  Γ u⊢ₜ hnoneV : hnoneSingT.
 Proof.
-  have := iftTrueSingTyp (hclose (▶: hnoneSingTBody hx0) :: Γ) =>
+  have := iftTrueSingTyp ((▶: hnoneSingTBody hx0)%ty :: Γ) =>
     /(iD_Val "isEmpty") ?.
   (* apply iT_Obj_I; last stcrush.
   apply iD_Cons; [tcrush| |tcrush].
@@ -360,29 +357,28 @@ Definition hsomeSingT hL hU : hty := μ: self, {@
   type "T" >: hL <: hU;
   val "isEmpty" : hIFTFalseT;
   val "pmatch" : hpmatchT self;
-  val "get" : ▶: hpv self @; "T"
+  val "get" : ▶: self @; "T"
 }.
 
-Definition hmkSomeTGen res : hty := ∀: x: tparam "A", (hpv x @; "A" →: res (hpv x @; "A") (hpv x @; "A")).
+Definition hmkSomeTGen res : hty := ∀: x: tparam "A", x @; "A" →: res (x @; "A") (x @; "A").
 
 Definition hmkSomeTSing : hty := hmkSomeTGen hsomeSingT.
 
-Definition hmkSome : hvl := λ: x, λ:: content, htv $ ν: self, {@
-  type "T" = hpv x @; "A";
-  val "isEmpty" = hpv hiftFalse;
-  val "pmatch" = hpv (λ: x, λ:: none some, htv some $: htskip (htv self @: "get"));
-  val "get" = hpv content
+Definition hmkSome : hvl := λ: x content, ν: self, {@
+  type "T" = x @; "A";
+  val "isEmpty" = hiftFalse;
+  val "pmatch" = λ: x none some, some $: htskip (self @: "get");
+  val "get" = content
 }.
-Definition mkSome := hclose hmkSome.
 
 Example mkSomeTypStronger Γ :
-  Γ u⊢ₜ tv mkSome : hclose hmkSomeTSing.
+  Γ u⊢ₜ hmkSome : hmkSomeTSing.
 Proof.
   evar (Γ' : ctx).
   have := iftFalseSingTyp Γ' => /(iD_Val "isEmpty"); rewrite /Γ' => Hf.
   tcrush; cbv.
   - eapply iT_All_E; first var.
-    apply (iT_Sub (i := 1) (T1 := hclose (▶: (hp3 @; "T"))%HT)); tcrush.
+    apply (iT_Sub (i := 1) (T1 := ▶: hx3 @; "T")); tcrush.
     varsub; ltcrush.
   - varsub.
     ettrans; first (apply iSub_Add_Later; tcrush).
@@ -401,15 +397,15 @@ Definition hoptionModTConcrBody : hty := {@
 
 Definition hoptionModV := ν: self, {@
   type "Option" = hoptionTSing;
-  val "none" = hpv hnoneV;
-  val "mkSome" = hpv hmkSome
+  val "none" = hnoneV;
+  val "mkSome" = hmkSome
 }.
 
 (** Rather precise type for [hoptionModV]. *)
 Example optionModConcrTyp Γ :
-  Γ u⊢ₜ hclose (htv hoptionModV) : hclose (μ: _, hoptionModTConcrBody).
+  Γ u⊢ₜ hoptionModV : (μ: _, hoptionModTConcrBody).
 Proof.
-  set U := hclose (▶: hoptionModTConcrBody).
+  set U := (▶: hoptionModTConcrBody)%ty : ty.
   have := noneTypStronger (U :: Γ).
   have := mkSomeTypStronger (U :: Γ) => /(iD_Val "mkSome") Hs Hn.
   ltcrush.
@@ -418,13 +414,12 @@ Qed.
 (** Define interface for [hoptionModV]. To rewrite to have abstraction. *)
 
 Definition hoptionT := hoptionTGen ⊥ ⊤.
-Definition optionT := hclose hoptionT.
 
-Definition hnoneT self := hTAnd (hpv self @; "Option") {@ typeEq "T" ⊥}.
+Definition hnoneT self := hTAnd (self @; "Option") {@ typeEq "T" ⊥}.
 
 (** Behold here [(optionT & (μ self, val get: ▶: self @; "T")) & { type T = hT } ]. *)
 Definition hsomeT self hL hU : hty :=
-  hTAnd (hTAnd (hpv self @; "Option") (μ: self, val "get" : ▶: hpv self @; "T"))
+  hTAnd (hTAnd (self @; "Option") (μ: self, val "get" : ▶: self @; "T"))
     (type "T" >: hL <: hU).
 Definition hmkSomeT self : hty := hmkSomeTGen (hsomeT self).
 
@@ -435,7 +430,7 @@ Definition hoptionModTInvBody self : hty := {@
 }.
 
 Example optionModInvTyp Γ :
-  Γ u⊢ₜ hclose (htv hoptionModV) : hclose (μ: self, hoptionModTInvBody self).
+  Γ u⊢ₜ hoptionModV : μ: self, hoptionModTInvBody self.
 Proof.
   eapply iT_Sub_nocoerce; first apply optionModConcrTyp.
   ltcrush; rewrite iterate_0.
@@ -458,11 +453,11 @@ Ltac prepare_lemma L H :=
   evar (Γ' : ctx); have := L Γ'; rewrite {}/Γ' => H.
 
 Example optionModTypSub Γ :
-  Γ u⊢ₜ hclose (μ: self, hoptionModTInvBody self), 0 <: hclose hoptionModT, 0.
+  Γ u⊢ₜ μ: self, hoptionModTInvBody self, 0 <: hoptionModT, 0.
 Proof. ltcrush; varsub; tcrush. Qed.
 
 Example optionModTyp Γ :
-  Γ u⊢ₜ hclose (htv hoptionModV) : hclose hoptionModT.
+  Γ u⊢ₜ hoptionModV : hoptionModT.
 Proof. eapply iT_Sub_nocoerce, optionModTypSub; apply optionModInvTyp. Qed.
 
 End option.

--- a/theories/Dot/examples/small_sem_ex.v
+++ b/theories/Dot/examples/small_sem_ex.v
@@ -86,19 +86,19 @@ Section small_ex.
   *)
   Definition miniVT2Body : ty := {@
     type "A" >: ⊥ <: 𝐙;
-    val "n" : TLater (p0 @; "A")
+    val "n" : TLater (x0 @; "A")
   }.
   Definition miniVT2 := μ miniVT2Body.
 
   Definition sminiVT2Body : oltyO Σ 0 :=
     oAnd (cTMem "A" oBot (oPrim tint))
-      (oAnd (cVMem "n" (oLater (oSel p0 "A")))
+      (oAnd (cVMem "n" (oLater (oSel x0 "A")))
       oTop).
   Goal V⟦miniVT2Body⟧ = sminiVT2Body. done. Abort.
 
   Definition sminiVT2ConcrBody : cltyO Σ :=
     cAnd (cTMem "A" ipos ipos)
-      (cAnd (cVMem "n" (oLater (oSel p0 "A")))
+      (cAnd (cVMem "n" (oLater (oSel x0 "A")))
       cTop).
   Definition sminiVT2Concr := oMu sminiVT2ConcrBody.
 

--- a/theories/Dot/examples/storeless_typing_ex.v
+++ b/theories/Dot/examples/storeless_typing_ex.v
@@ -34,16 +34,16 @@ Proof.
 Qed.
 
 Example ex2 Γ T
-  (Hg: g !! s1 = Some (p0 @; "B")):
+  (Hg: g !! s1 = Some (x0 @; "B")):
   Γ v⊢ₜ[ g ] ν {@ type "A" = (idsσ 1 ; s1) } :
     TMu (TAnd (TTMem "A" TBot TTop) TTop).
 Proof.
-  have Hs: (p0 @; "B") ~[ 1 ] (g, (s1, idsσ 1)).
+  have Hs: (x0 @; "B") ~[ 1 ] (g, (s1, idsσ 1)).
   by_extcrush.
-  have Hst: is_stamped_ty (1 + length Γ) g (p0 @; "B").
+  have Hst: is_stamped_ty (1 + length Γ) g (x0 @; "B").
   by tcrush.
   apply iT_Obj_I; tcrush. (* Avoid trying iT_Mu_I, that's slow. *)
-  apply (iD_Typ_Abs (p0 @; "B")); cbn; by wtcrush.
+  apply (iD_Typ_Abs (x0 @; "B")); cbn; by wtcrush.
 Qed.
 
 (* Try out fixpoints. *)
@@ -51,16 +51,16 @@ Definition F3 T :=
   TMu (TAnd (TTMem "A" T T) TTop).
 
 Example ex3 Γ T
-  (Hg: g !! s1 = Some (F3 (p0 @; "A"))):
+  (Hg: g !! s1 = Some (F3 (x0 @; "A"))):
   Γ v⊢ₜ[ g ] ν {@ type "A" = (σ1 ; s1) } :
-    F3 (F3 (TSel p0 "A")).
+    F3 (F3 (TSel x0 "A")).
 Proof.
-  have Hs: F3 (p0 @; "A") ~[ 0 ] (g, (s1, σ1)).
+  have Hs: F3 (x0 @; "A") ~[ 0 ] (g, (s1, σ1)).
   by_extcrush.
-  have Hst: is_stamped_ty (1 + length Γ) g (F3 (p0 @; "A")).
+  have Hst: is_stamped_ty (1 + length Γ) g (F3 (x0 @; "A")).
   by stcrush.
   apply iT_Obj_I; tcrush. (* Avoid trying iT_Mu_I, that's slow. *)
-  apply (iD_Typ_Abs (F3 (p0 @; "A"))); by wtcrush.
+  apply (iD_Typ_Abs (F3 (x0 @; "A"))); by wtcrush.
 Qed.
 
 (********************)
@@ -87,11 +87,11 @@ Qed.
 (* This stands for type [String] in that example. *)
 Definition KeysT : ty := μ {@
   type "Key" >: ⊥ <: ⊤;
-  val "key": TAll HashableString (p1 @; "Key")
+  val "key": TAll HashableString (x1 @; "Key")
 }.
 Definition hashKeys : vl := ν {@
   type "Key" = (σ1; s1);
-  val "key" = pv (vabs (tapp (tproj (tv x0) "hashCode") tUnit))
+  val "key" = vabs (tapp (tproj x0 "hashCode") tUnit)
 }.
 Definition s1_is_tint :=
   TInt ~[ 0 ] (g, (s1, σ1)).
@@ -102,7 +102,7 @@ Proof. by_extcrush. Qed.
     and then widen it. *)
 Definition KeysT' := μ {@
   type "Key" >: TInt <: ⊤;
-  val "key": TAll HashableString (p1 @; "Key")
+  val "key": TAll HashableString (x1 @; "Key")
 }.
 (* IDEA for our work: use [(type "Key" >: TInt <: ⊤) ⩓ (type "Key" >: ⊥ <: ⊤)]. *)
 
@@ -198,7 +198,7 @@ In fact, that code doesn't typecheck as given, and we fix it by setting.
 
 IFT ≡ IFTFun
  *)
-Definition IFTBody := (TAll (p0 @; "A") (TAll (p1 @; "A") (p2 @; "A"))).
+Definition IFTBody := (TAll (x0 @; "A") (TAll (x1 @; "A") (x2 @; "A"))).
 Definition IFT : ty :=
   TAll (type "A" >: ⊥ <: ⊤) IFTBody.
 Lemma IFTStamped: is_stamped_ty 0 g IFT.
@@ -207,8 +207,8 @@ Hint Resolve IFTStamped : core.
 
 (* Definition IFT : ty := {@ val "if" : IFTFun }. *)
 
-Definition iftTrue := vabs (vabs' (vabs' x1)).
-Definition iftFalse := vabs (vabs' (vabs' x0)).
+Definition iftTrue := vabs (vabs (vabs x1)).
+Definition iftFalse := vabs (vabs (vabs x0)).
 
 Example iftTrueTyp Γ : Γ v⊢ₜ[ g ] iftTrue : IFT.
 Proof. tcrush. exact: iT_Var'. Qed.
@@ -223,7 +223,7 @@ Lemma get_s1_is_ift : s1_is_ift → s1_is_ift_ext.
 Proof. intros; red. by_extcrush. Qed.
 Hint Resolve get_s1_is_ift : core.
 
-Definition p0Bool := (p0 @; "Boolean").
+Definition p0Bool := x0 @; "Boolean".
 Lemma p0BoolStamped: is_stamped_ty 1 g p0Bool.
 Proof. tcrush. Qed.
 Hint Resolve p0BoolStamped : core.
@@ -340,13 +340,13 @@ Lemma packBooleanUB Γ (Hst : s1_is_ift) i :
   Γ v⊢ₜ[ g ] packBoolean @; "A", i <: ▶: IFT, i.
 Proof. apply /val_UB /packBooleanTyp0; wtcrush. Qed.
 
-Definition iftAnd false : vl := vabs (vabs' (
+Definition iftAnd false : vl := vabs (vabs (
   x1 $: packBoolean $: x0 $: false)).
 
 Example iftAndTyp Γ (Hst : s1_is_ift):
   Γ v⊢ₜ[ g ] iftAnd iftFalse : TAll IFT (TAll IFT (▶:IFT)).
 Proof.
-  unfold s1_is_ift in *; rewrite /iftAnd /vabs'.
+  unfold s1_is_ift in *; rewrite /iftAnd.
   tcrush.
   eapply iT_All_E; last exact: iftFalseTyp.
   eapply iT_All_E; last exact: iT_Var'.
@@ -369,7 +369,7 @@ Qed.
 (* Eta-expand to drop the later. *)
 
 Example iftAndTyp'1 Γ (Hst : s1_is_ift):
-  Γ v⊢ₜ[ g ] vabs' (vabs'
+  Γ v⊢ₜ[ g ] vabs (vabs
     (tskip (iftAnd iftFalse $: x1 $: x0))) :
     TAll IFT (TAll IFT IFT).
 Proof.
@@ -381,7 +381,7 @@ Proof.
 Qed.
 
 Definition iftCoerce t :=
-  lett t (vabs' (vabs' (tskip (x2 $: x1 $: x0)))).
+  lett t (vabs (vabs (tskip (x2 $: x1 $: x0)))).
 
 Lemma coerce_tAppIFT Γ t T :
   is_stamped_ty (length Γ) g T →
@@ -462,8 +462,8 @@ Proof. intros. apply tAppIFT_coerced_typed; eauto 3. Qed.
 Definition iftNot Γ t s :=
   tapp (tapp
       (iftCoerce (tApp Γ t s))
-    (tv iftFalse))
-  (tv iftTrue).
+    iftFalse)
+  iftTrue.
 
 Lemma iftNotTyp Γ T t s :
   g !! s = Some IFT →

--- a/theories/Dot/examples/storeless_typing_ex_utils.v
+++ b/theories/Dot/examples/storeless_typing_ex_utils.v
@@ -502,7 +502,7 @@ Lemma packTV_typed' s T n Γ :
   g !! s = Some T →
   is_stamped_ty n g T →
   n <= length Γ →
-  Γ v⊢ₜ[ g ] tv (packTV n s) : typeEq "A" T.
+  Γ v⊢ₜ[ g ] packTV n s : typeEq "A" T.
 Proof.
   move => Hlp HsT1 Hle; move: (Hle) (HsT1) => /le_n_S Hles /is_stamped_ren1_ty HsT2.
   move: (is_stamped_nclosed_ty HsT1) => Hcl.
@@ -517,17 +517,17 @@ Qed.
 Lemma packTV_typed s T Γ :
   g !! s = Some T →
   is_stamped_ty (length Γ) g T →
-  Γ v⊢ₜ[ g ] tv (packTV (length Γ) s) : typeEq "A" T.
+  Γ v⊢ₜ[ g ] packTV (length Γ) s : typeEq "A" T.
 Proof. intros; exact: packTV_typed'. Qed.
 
 Lemma val_LB L U Γ i v :
   is_stamped_ty (length Γ) g L →
   is_stamped_ty (length Γ) g U →
   is_stamped_vl (length Γ) g v →
-  Γ v⊢ₜ[ g ] tv v : type "A" >: L <: U →
-  Γ v⊢ₜ[ g ] ▶: L, i <: (pv v @; "A"), i.
+  Γ v⊢ₜ[ g ] v : type "A" >: L <: U →
+  Γ v⊢ₜ[ g ] ▶: L, i <: v @; "A", i.
 Proof.
-  intros ??? Hv; apply (iSub_Sel (p := pv _) (U := U)).
+  intros ??? Hv; apply (iSub_Sel (U := U)).
   apply (path_tp_delay (i := 0)); wtcrush.
 Qed.
 
@@ -551,7 +551,7 @@ Lemma packTV_LB s T n Γ i :
   g !! s = Some T →
   is_stamped_ty n g T →
   n <= length Γ →
-  Γ v⊢ₜ[ g ] ▶: T, i <: (pv (packTV n s) @; "A"), i.
+  Γ v⊢ₜ[ g ] ▶: T, i <: packTV n s @; "A", i.
 Proof.
   intros; apply /val_LB /packTV_typed'; wtcrush; cbn.
   eapply (is_stamped_sub_dm (dtysem _ _) (ren (+1))); trivial.
@@ -562,10 +562,10 @@ Lemma val_UB L U Γ i v :
   is_stamped_ty (length Γ) g L →
   is_stamped_ty (length Γ) g U →
   is_stamped_vl (length Γ) g v →
-  Γ v⊢ₜ[ g ] tv v : type "A" >: L <: U →
-  Γ v⊢ₜ[ g ] (pv v @; "A"), i <: ▶: U, i.
+  Γ v⊢ₜ[ g ] v : type "A" >: L <: U →
+  Γ v⊢ₜ[ g ] v @; "A", i <: ▶: U, i.
 Proof.
-  intros ??? Hv; apply (iSel_Sub (p := pv _) (L := L)).
+  intros ??? Hv; apply (iSel_Sub (L := L)).
   apply (path_tp_delay (i := 0)); wtcrush.
 Qed.
 
@@ -573,7 +573,7 @@ Lemma packTV_UB s T n Γ i :
   is_stamped_ty n g T →
   g !! s = Some T →
   n <= length Γ →
-  Γ v⊢ₜ[ g ] (pv (packTV n s) @; "A"), i <: ▶: T, i.
+  Γ v⊢ₜ[ g ] packTV n s @; "A", i <: ▶: T, i.
 Proof.
   intros; apply /val_UB /packTV_typed'; wtcrush.
   eapply (is_stamped_sub_dm (dtysem _ _) (ren (+1))); trivial.
@@ -581,7 +581,7 @@ Proof.
 Qed.
 
 Definition tApp Γ t s :=
-  lett t (lett (tv (packTV (S (length Γ)) s)) (tapp (tv x1) (tv x0))).
+  lett t (lett (packTV (S (length Γ)) s) (tapp x1 x0)).
 
 Lemma typeApp_typed s Γ T U V t :
   Γ v⊢ₜ[ g ] t : TAll (type "A" >: ⊥ <: ⊤) U →

--- a/theories/Dot/examples/storeless_typing_ex_utils.v
+++ b/theories/Dot/examples/storeless_typing_ex_utils.v
@@ -547,17 +547,6 @@ Proof.
   by apply Trav1.trav_dtysem with (T' := T) (ts' := (m, g)), is_stamped_idsσ.
 Qed.
 
-Lemma packTV_LB s T n Γ i :
-  g !! s = Some T →
-  is_stamped_ty n g T →
-  n <= length Γ →
-  Γ v⊢ₜ[ g ] ▶: T, i <: packTV n s @; "A", i.
-Proof.
-  intros; apply /val_LB /packTV_typed'; wtcrush; cbn.
-  eapply (is_stamped_sub_dm (dtysem _ _) (ren (+1))); trivial.
-  exact: is_stamped_dtysem.
-Qed.
-
 Lemma val_UB L U Γ i v :
   is_stamped_ty (length Γ) g L →
   is_stamped_ty (length Γ) g U →
@@ -567,17 +556,6 @@ Lemma val_UB L U Γ i v :
 Proof.
   intros ??? Hv; apply (iSel_Sub (L := L)).
   apply (path_tp_delay (i := 0)); wtcrush.
-Qed.
-
-Lemma packTV_UB s T n Γ i :
-  is_stamped_ty n g T →
-  g !! s = Some T →
-  n <= length Γ →
-  Γ v⊢ₜ[ g ] packTV n s @; "A", i <: ▶: T, i.
-Proof.
-  intros; apply /val_UB /packTV_typed'; wtcrush.
-  eapply (is_stamped_sub_dm (dtysem _ _) (ren (+1))); trivial.
-  exact: is_stamped_dtysem.
 Qed.
 
 Definition tApp Γ t s :=

--- a/theories/Dot/examples/unstamped_typing_ex.v
+++ b/theories/Dot/examples/unstamped_typing_ex.v
@@ -155,7 +155,7 @@ Proof. intros. apply iftCoerce_tyAppIFT_typed; tcrush. Qed.
 Definition iftNotBody t T true false :=
   iftCoerce (tyApp t "A" T) $: false $: true.
 
-(* XXX Beware that false and true are inlined here. *)
+(* Beware that false and true are inlined here. *)
 Lemma iftNotBodyTyp Γ t :
   Γ u⊢ₜ t : hIFT →
   Γ u⊢ₜ iftNotBody t hIFT hiftTrue hiftFalse : hIFT.

--- a/theories/Dot/typing/unstamped_typing_derived_rules.v
+++ b/theories/Dot/typing/unstamped_typing_derived_rules.v
@@ -229,19 +229,6 @@ Proof.
   apply (path_tp_delay (i := 0)); wtcrush.
 Qed.
 
-(* These rules from storeless typing must be encoded somehow via variables. *)
-(* Lemma packTV_LB T n Γ i :
-  is_unstamped_ty' n T →
-  n <= length Γ →
-  Γ u⊢ₜ ▶: T, i <: (pv (packTV T) @; "A"), i.
-Proof. intros; apply /val_LB /packTV_typed'. Qed. *)
-
-(* Lemma packTV_UB T n Γ i :
-  is_unstamped_ty' n T →
-  n <= length Γ →
-  Γ u⊢ₜ (pv (packTV T) @; "A"), i <: ▶: T, i.
-Proof. intros; by apply /val_UB /packTV_typed'. Qed. *)
-
 Lemma iD_Typ Γ T l:
   is_unstamped_ty' (length Γ) T →
   Γ u⊢{ l := dtysyn T } : TTMem l T T.


### PR DESCRIPTION
- Fix some notation issues, with scopes, output, etc.
- Stop using outdated notations (DBNotation is still used).
- Misc. cleanups.