### PR TITLE
Drop extraneous builtin laters in semantics for TTMem

### DIFF
--- a/theories/Dot/examples/ex_iris_utils.v
+++ b/theories/Dot/examples/ex_iris_utils.v
@@ -34,6 +34,9 @@ Import stamp_transfer.
 Section loop_sem.
   Context `{HdlangG: !dlangG Σ}.
   Context `{SwapPropI Σ}.
+
+  Definition cTMemL l L U := cTMem l (oLater L) (oLater U).
+
   Lemma loopSemT: ⊢ WP hloopTm {{ _, False }}.
   Proof using Type*.
     iDestruct (fundamental_typed (loopTyp []) with "[]") as "H".

--- a/theories/Dot/examples/ex_utils.v
+++ b/theories/Dot/examples/ex_utils.v
@@ -104,7 +104,7 @@ Notation "▶: T" := (TLater T) (at level 49, right associativity) : ty_scope.
 Notation "'∀:' T , U" := (TAll T U) (at level 48, T at level 98, U at level 98).
 
 Notation "'μ' Ts " := (TMu Ts) (at level 50, Ts at next level).
-Notation "'type' l >: L <: U" := (TTMem l L U) (at level 60, l at level 50, L, U at level 70) : ty_scope.
+Notation "'type' l >: L <: U" := (TTMemL l L U) (at level 60, l at level 50, L, U at level 70) : ty_scope.
 Notation "'val' l : T" :=
   (TVMem l T)
   (at level 60, l, T at level 50, format "'[' 'val'  l  :  T  ']' '/'") : ty_scope.

--- a/theories/Dot/examples/from_pdot_mutual_rec_sem.v
+++ b/theories/Dot/examples/from_pdot_mutual_rec_sem.v
@@ -211,7 +211,7 @@ Proof.
   - rewrite /hoptionTConcr/=; ettrans; first apply iDistr_And_Or_Sub;
     stcrush; apply iOr_Sub_split; ltcrush.
   - lThis. ettrans; last apply iLater_Sub; stcrush.
-    eapply (iSel_Sub (L := ⊥) (U := hoptionTConcr)); tcrush.
+    eapply (iSel_SubL (L := ⊥) (U := hoptionTConcr)); tcrush.
     varsub.
     ettrans; first apply iSub_Add_Later; stcrush.
     asideLaters; mltcrush.
@@ -394,7 +394,7 @@ Proof.
     varsub. asideLaters. lNext. ltcrush.
   }
   lThis.
-  apply (iSel_Sub (L := ⊥)); tcrush.
+  apply (iSel_SubL (L := ⊥)); tcrush.
   varsub. mltcrush. lThis.
 Qed.
 

--- a/theories/Dot/examples/hoas.v
+++ b/theories/Dot/examples/hoas.v
@@ -163,6 +163,7 @@ Definition hTAll : hty → (hvl → hty) → hty := λ T U i,
 Definition hTMu : (hvl → hty) → hty := liftBind TMu.
 Definition hTVMem : label → hty → hty := λ l, liftA1 (TVMem l).
 Definition hTTMem : label → hty → hty → hty := λ l, liftA2 (TTMem l).
+Definition hTTMemL : label → hty → hty → hty := λ l, liftA2 (TTMemL l).
 Definition hTSel : hpath → label → hty := Eval cbv in λ p l, liftA2 TSel p (pureS l).
 Definition hTPrim b : hty := liftA0 (TPrim b).
 Definition hTSing : hpath → hty := liftA1 TSing.
@@ -199,6 +200,7 @@ Arguments hTAll /.
 Arguments hTMu /.
 Arguments hTVMem /.
 Arguments hTTMem /.
+Arguments hTTMemL /.
 Arguments hTSel /.
 Arguments hTPrim /.
 Arguments hTSing /.
@@ -282,7 +284,7 @@ Notation "▶: T" := (hTLater T) (at level 49, right associativity) : hsyn_scope
 Notation "'∀:' x : T , U" := (hTAll T (λT x, U)) (at level 48, x, T at level 98, U at level 98).
 Notation "'μ' Ts" := (hTMu Ts) (at level 50, Ts at next level).
 Notation "'μ:' x , Ts" := (hTMu (λT x, Ts)) (at level 50, Ts at next level).
-Notation "'type' l >: L <: U" := (hTTMem l L U) (at level 60, l at level 50, L, U at level 70) : hsyn_scope.
+Notation "'type' l >: L <: U" := (hTTMemL l L U) (at level 60, l at level 50, L, U at level 70) : hsyn_scope.
 Notation "'val' l : T" := (hTVMem l T)
   (at level 60, l, T at level 50, format "'[' 'val'  l  :  T  ']' '/'") : hsyn_scope.
 

--- a/theories/Dot/examples/list.v
+++ b/theories/Dot/examples/list.v
@@ -288,7 +288,7 @@ Proof.
       eapply (iT_Mu_E' (T1 := (val "head" : ⊤ →: hx0 @; "A")%HS));
       [ | done | tcrush ..].
       - varsub; asideLaters; lThis; ltcrush.
-      - by apply (iSel_Sub (L := ⊥)), (path_tp_delay (i := 0)); wtcrush; varsub; ltcrush.
+      - by apply (iSel_SubL (L := ⊥)), (path_tp_delay (i := 0)); wtcrush; varsub; ltcrush.
   }
   eapply (iT_Sub (i := 1) (T1 := hTAnd (hx0 @; "List") U)).
   (******)

--- a/theories/Dot/examples/no_russell_paradox.v
+++ b/theories/Dot/examples/no_russell_paradox.v
@@ -40,7 +40,7 @@ Section Russell.
     iIntros "#Hs".
     iExists _; iSplit. by iExists _; iSplit.
     iExists _; iSplit. by iApply dm_to_type_intro.
-    by iModIntro; repeat iSplit; iIntros "% ** !>".
+    by iModIntro; repeat iSplit; iIntros "% **".
   Qed.
 
   Lemma later_not_UAU: Hs ⊢ uAu v -∗ ▷ False.

--- a/theories/Dot/examples/positive_div.v
+++ b/theories/Dot/examples/positive_div.v
@@ -147,38 +147,38 @@ Section div_example.
   Lemma Sub_later_ipos_nat Γ : ⊢ Γ s⊨ oLater ipos, 0 <: oLater V⟦ 𝐙 ⟧, 0.
   Proof. rewrite -sSub_Later_Sub -sSub_Index_Incr. apply Sub_ipos_nat. Qed.
 
-  Lemma posTMem_widen Γ l : ⊢ Γ s⊨ cTMem l ipos ipos, 0 <: cTMem l ⊥ oInt, 0.
+  Lemma posTMem_widen Γ l : ⊢ Γ s⊨ cTMemL l ipos ipos, 0 <: cTMemL l ⊥ oInt, 0.
   Proof using Type*.
     iApply sTyp_Sub_Typ; [iApply sBot_Sub | iApply Sub_later_ipos_nat].
   Qed.
 
 
-  Lemma sD_posDm_ipos l Γ : Hs -∗ Γ s⊨ { l := posDm } : cTMem l ipos ipos.
+  Lemma sD_posDm_ipos l Γ : Hs -∗ Γ s⊨ { l := posDm } : cTMemL l ipos ipos.
   Proof.
     iIntros "Hs".
     iApply (sD_Typ_Abs ipos); [iApply sSub_Refl..|by iExists _; iFrame "Hs"].
   Qed.
 
-  Lemma sD_posDm_abs l Γ : Hs -∗ Γ s⊨ { l := posDm } : cTMem l ⊥ oInt.
+  Lemma sD_posDm_abs l Γ : Hs -∗ Γ s⊨ { l := posDm } : cTMemL l ⊥ oInt.
   Proof.
-    iIntros "Hs"; iApply sD_Typ_Sub;
+    iIntros "Hs"; iApply (sD_Typ_Sub (oLater ipos));
       [iApply sBot_Sub|iApply Sub_later_ipos_nat|iApply (sD_posDm_ipos with "Hs")].
   Qed.
 
   Lemma sInTestVl l ρ : path_includes (pv x0) (testVl l .: ρ) [(l, posDm)].
   Proof. constructor; naive_solver. Qed.
 
-  Lemma s_posDm l : Hs -∗ cTMem l ipos ipos ids [(l, posDm)].
+  Lemma s_posDm l : Hs -∗ cTMemL l ipos ipos ids [(l, posDm)].
   Proof.
     rewrite (sD_posDm_ipos l []) sdtp_eq; iIntros "H".
     iApply ("H" $! (testVl l .: ids) with "[] [//]"); auto using sInTestVl.
   Qed.
 
   Lemma posModVHasA ρ :
-    Hs -∗ clty_olty (cTMem "Pos" ipos ipos) vnil ρ posModV.[ρ].
+    Hs -∗ clty_olty (cTMemL "Pos" ipos ipos) vnil ρ posModV.[ρ].
   Proof. by rewrite (s_posDm "Pos") -clty_commute. Qed.
 
-  Lemma posModVHasATy: Hs -∗ [] s⊨ posModV : cTMem "Pos" ipos ipos.
+  Lemma posModVHasATy: Hs -∗ [] s⊨ posModV : cTMemL "Pos" ipos ipos.
   Proof.
     rewrite -setp_value_eq; iIntros "#Hs %ρ"; iApply (posModVHasA ρ with "Hs").
   Qed.

--- a/theories/Dot/examples/small_sem_ex.v
+++ b/theories/Dot/examples/small_sem_ex.v
@@ -90,13 +90,13 @@ Section small_ex.
   Definition miniVT2 := μ miniVT2Body.
 
   Definition sminiVT2Body : oltyO Σ 0 :=
-    oAnd (cTMem "A" oBot (oPrim tint))
+    oAnd (cTMemL "A" oBot (oPrim tint))
       (oAnd (cVMem "n" (oLater (oSel x0 "A")))
       oTop).
   Goal V⟦miniVT2Body⟧ = sminiVT2Body. done. Abort.
 
   Definition sminiVT2ConcrBody : cltyO Σ :=
-    cAnd (cTMem "A" ipos ipos)
+    cAnd (cTMemL "A" ipos ipos)
       (cAnd (cVMem "n" (oLater (oSel x0 "A")))
       cTop).
   Definition sminiVT2Concr := oMu sminiVT2ConcrBody.

--- a/theories/Dot/examples/storeless_typing_ex.v
+++ b/theories/Dot/examples/storeless_typing_ex.v
@@ -48,7 +48,7 @@ Qed.
 
 (* Try out fixpoints. *)
 Definition F3 T :=
-  TMu (TAnd (TTMem "A" T T) TTop).
+  TMu (TAnd (TTMemL "A" T T) TTop).
 
 Example ex3 Γ T
   (Hg: g !! s1 = Some (F3 (x0 @; "A"))):

--- a/theories/Dot/examples/storeless_typing_ex_utils.v
+++ b/theories/Dot/examples/storeless_typing_ex_utils.v
@@ -311,16 +311,26 @@ Lemma iT_Var0_Sub Γ T1 T2 :
   Γ v⊢ₜ[ g ] tv (var_vl 0) : T2.
 Proof. intros. by eapply iT_Var_Sub; [| rewrite ?hsubst_id]. Qed.
 
+Lemma iSub_SelL {Γ p U l L i}:
+  Γ v⊢ₚ[ g ] p : TTMemL l L U, i →
+  Γ v⊢ₜ[ g ] TLater L, i <: TSel p l, i.
+Proof. intros; exact: iSub_Sel. Qed.
+
+Lemma iSel_SubL {Γ p L l U i}:
+  Γ v⊢ₚ[ g ] p : TTMemL l L U, i →
+  Γ v⊢ₜ[ g ] TSel p l, i <: TLater U, i.
+Proof. intros; exact: iSel_Sub. Qed.
+
 Lemma iSub_Sel' U {Γ p l L i}:
   is_stamped_ty (length Γ) g L →
-  Γ v⊢ₚ[ g ] p : TTMem l L U, i →
+  Γ v⊢ₚ[ g ] p : TTMemL l L U, i →
   Γ v⊢ₜ[ g ] L, i <: TSel p l, i.
 Proof. intros; ettrans; last exact: (iSub_Sel (p := p)); tcrush. Qed.
 
 (** Specialization of [iSub_Sel'] for convenience. *)
 Lemma iSub_Sel'' Γ {p l L i}:
   is_stamped_ty (length Γ) g L →
-  Γ v⊢ₚ[ g ] p : TTMem l L L, i → Γ v⊢ₜ[ g ] L, i <: TSel p l, i.
+  Γ v⊢ₚ[ g ] p : TTMemL l L L, i → Γ v⊢ₜ[ g ] L, i <: TSel p l, i.
 Proof. apply iSub_Sel'. Qed.
 
 Lemma iSub_AddIJ' {Γ T i j} (Hst: is_stamped_ty (length Γ) g T) (Hle : i <= j):
@@ -495,7 +505,7 @@ Lemma iD_Typ T {Γ l s σ}:
   T ~[ length Γ ] (g, (s, σ)) →
   is_stamped_σ (length Γ) g σ →
   is_stamped_ty (length Γ) g T →
-  Γ v⊢[ g ]{ l := dtysem σ s } : TTMem l T T.
+  Γ v⊢[ g ]{ l := dtysem σ s } : TTMemL l T T.
 Proof. intros. apply (iD_Typ_Abs T); auto 3. Qed.
 
 Lemma packTV_typed' s T n Γ :
@@ -527,7 +537,7 @@ Lemma val_LB L U Γ i v :
   Γ v⊢ₜ[ g ] v : type "A" >: L <: U →
   Γ v⊢ₜ[ g ] ▶: L, i <: v @; "A", i.
 Proof.
-  intros ??? Hv; apply (iSub_Sel (U := U)).
+  intros ??? Hv; apply (iSub_SelL (U := U)).
   apply (path_tp_delay (i := 0)); wtcrush.
 Qed.
 
@@ -554,7 +564,7 @@ Lemma val_UB L U Γ i v :
   Γ v⊢ₜ[ g ] v : type "A" >: L <: U →
   Γ v⊢ₜ[ g ] v @; "A", i <: ▶: U, i.
 Proof.
-  intros ??? Hv; apply (iSel_Sub (L := L)).
+  intros ??? Hv; apply (iSel_SubL (L := L)).
   apply (path_tp_delay (i := 0)); wtcrush.
 Qed.
 

--- a/theories/Dot/examples/unstamped_typing_ex.v
+++ b/theories/Dot/examples/unstamped_typing_ex.v
@@ -30,7 +30,7 @@ Proof. apply iT_Obj_I; tcrush. Qed.
 
 (* Try out fixpoints. *)
 Definition F3 T :=
-  TMu (TAnd (TTMem "A" T T) TTop).
+  TMu (TAnd (TTMemL "A" T T) TTop).
 
 Example ex3 Γ T:
   Γ u⊢ₜ ν {@ type "A" = F3 (x0 @; "A") } : F3 (F3 (TSel x0 "A")).

--- a/theories/Dot/lr/unary_lr.v
+++ b/theories/Dot/lr/unary_lr.v
@@ -163,8 +163,8 @@ Section sem_types.
   (** [ D⟦ { A :: τ1 .. τ2 } ⟧ ]. *)
   Definition oDTMem τ1 τ2 : dltyO Σ := Dlty (λI ρ d,
     ∃ ψ, d ↗n[ 0 ] ψ ∧
-       □ (oLater τ1 vnil ρ ⊆ packHoLtyO ψ vnil ∧
-          packHoLtyO ψ vnil ⊆ oLater τ2 vnil ρ)).
+       □ (τ1 vnil ρ ⊆ packHoLtyO ψ vnil ∧
+          packHoLtyO ψ vnil ⊆ τ2 vnil ρ)).
   Global Instance Proper_oDTMem : Proper ((≡) ==> (≡) ==> (≡)) oDTMem.
   Proof.
     rewrite /oDTMem => ??? ??? ??/=; properness; try reflexivity;
@@ -359,7 +359,7 @@ Section misc_lemmas.
   Lemma vl_sel_ub w l L U ρ v :
     vl_sel w l vnil v -∗
     clty_olty (cTMem l L U) vnil ρ w -∗
-    oLater U vnil ρ v.
+    U vnil ρ v.
   Proof.
     iIntros "Hφ"; iDestruct 1 as (d1 Hl1 φ1) "(Hdφ1 & _ & HφU)".
     iApply "HφU".
@@ -369,7 +369,7 @@ Section misc_lemmas.
   Qed.
 
   Lemma vl_sel_lb w l L U ρ v :
-    oLater L vnil ρ v -∗
+    L vnil ρ v -∗
     clty_olty (cTMem l L U) vnil ρ w -∗
     vl_sel w l vnil v.
   Proof.
@@ -391,8 +391,8 @@ Section misc_lemmas.
   Proof. apply (lift_sub_dty2cltyN 0). Qed.
 
   Lemma oDTMem_respects_sub L1 L2 U1 U2 ρ d :
-    □(oLater L2 vnil ρ ⊆ oLater L1 vnil ρ) -∗
-    □(oLater U1 vnil ρ ⊆ oLater U2 vnil ρ) -∗
+    □(L2 vnil ρ ⊆ L1 vnil ρ) -∗
+    □(U1 vnil ρ ⊆ U2 vnil ρ) -∗
     oDTMem L1 U1 ρ d -∗ oDTMem L2 U2 ρ d.
   Proof.
     iIntros "#HsubL #HsubU"; iDestruct 1 as (φ) "#(Hφl & #HLφ & #HφU)".
@@ -402,8 +402,8 @@ Section misc_lemmas.
   Qed.
 
   Lemma cTMem_respects_sub L1 L2 U1 U2 ρ l :
-    □(oLater L2 vnil ρ ⊆ oLater L1 vnil ρ) -∗
-    □(oLater U1 vnil ρ ⊆ oLater U2 vnil ρ) -∗
+    □(L2 vnil ρ ⊆ L1 vnil ρ) -∗
+    □(U1 vnil ρ ⊆ U2 vnil ρ) -∗
     clty_olty (cTMem l L1 U1) vnil ρ ⊆ clty_olty (cTMem l L2 U2) vnil ρ.
   Proof.
     rewrite -lift_sub_dty2clty; iIntros "#HsubL #HsubU %d".

--- a/theories/Dot/semtyp_lemmas/defs_lr.v
+++ b/theories/Dot/semtyp_lemmas/defs_lr.v
@@ -70,8 +70,8 @@ Section Sec.
 
   (** ** Type member introduction. *)
   Lemma sD_Typ_Sub {Γ} L1 L2 U1 U2 s σ l:
-    Γ s⊨ oLater L2, 0 <: oLater L1, 0 -∗
-    Γ s⊨ oLater U1, 0 <: oLater U2, 0 -∗
+    Γ s⊨ L2, 0 <: L1, 0 -∗
+    Γ s⊨ U1, 0 <: U2, 0 -∗
     Γ s⊨ { l := dtysem σ s } : cTMem l L1 U1 -∗
     Γ s⊨ { l := dtysem σ s } : cTMem l L2 U2.
   Proof.
@@ -86,7 +86,7 @@ Section Sec.
 
   Lemma sD_Typ {Γ s σ} {T : oltyO Σ 0} l:
     s ↝[ σ ] T -∗
-    Γ s⊨ { l := dtysem σ s } : cTMem l T T.
+    Γ s⊨ { l := dtysem σ s } : cTMem l (oLater T) (oLater T).
   Proof.
     rewrite !sdtp_eq; iDestruct 1 as (φ Hγφ) "#Hγ"; iIntros "!>" (ρ Hpid) "#Hg".
     rewrite cTMem_eq. iExists (hoEnvD_inst (σ.|[ρ]) φ); iSplit.
@@ -96,19 +96,19 @@ Section Sec.
 
   Lemma D_Typ {Γ} T s σ l:
     s ↝[ σ ] V⟦ T ⟧ -∗
-    Γ ⊨ { l := dtysem σ s } : TTMem l T T.
+    Γ ⊨ { l := dtysem σ s } : TTMem l (TLater T) (TLater T).
   Proof. apply sD_Typ. Qed.
 
   Lemma sD_Typ_Abs {Γ} T L U s σ l:
-    Γ s⊨ oLater L, 0 <: oLater T, 0 -∗
-    Γ s⊨ oLater T, 0 <: oLater U, 0 -∗
+    Γ s⊨ L, 0 <: oLater T, 0 -∗
+    Γ s⊨ oLater T, 0 <: U, 0 -∗
     s ↝[ σ ] T -∗
     Γ s⊨ { l := dtysem σ s } : cTMem l L U.
   Proof. rewrite (sD_Typ l). apply sD_Typ_Sub. Qed.
 
   Lemma D_Typ_Abs {Γ} T L U s σ l:
-    Γ ⊨ TLater L, 0 <: TLater T, 0 -∗
-    Γ ⊨ TLater T, 0 <: TLater U, 0 -∗
+    Γ ⊨ L, 0 <: TLater T, 0 -∗
+    Γ ⊨ TLater T, 0 <: U, 0 -∗
     s ↝[ σ ] V⟦ T ⟧ -∗
     Γ ⊨ { l := dtysem σ s } : TTMem l L U.
   Proof. apply sD_Typ_Abs. Qed.

--- a/theories/Dot/semtyp_lemmas/dsub_lr.v
+++ b/theories/Dot/semtyp_lemmas/dsub_lr.v
@@ -168,7 +168,7 @@ Section DStpLemmas.
 
   Lemma sStp_Sel {Γ L U p l i}:
     Γ s⊨p p : cTMem l L U, i -∗
-    Γ s⊨ oLater L <:[i] oSel p l.
+    Γ s⊨ L <:[i] oSel p l.
   Proof.
     rewrite sstpd_eq'; iIntros "#Hp !> %ρ %v Hg".
     iSpecialize ("Hp" with "Hg"); iNext i; iIntros "#HL".
@@ -178,7 +178,7 @@ Section DStpLemmas.
 
   Lemma sSel_Stp {Γ L U p l i}:
     Γ s⊨p p : cTMem l L U, i -∗
-    Γ s⊨ oSel p l <:[i] oLater U.
+    Γ s⊨ oSel p l <:[i] U.
   Proof.
     rewrite sstpd_eq'; iIntros "#Hp !> %ρ %v Hg".
     iSpecialize ("Hp" with "Hg"); iNext i; iIntros "Hφ".
@@ -212,8 +212,8 @@ Section DStpLemmas.
   Qed.
 
   Lemma sTyp_Stp_Typ Γ L1 L2 U1 U2 i l :
-    Γ s⊨ oLater L2 <:[i] oLater L1 -∗
-    Γ s⊨ oLater U1 <:[i] oLater U2 -∗
+    Γ s⊨ L2 <:[i] L1 -∗
+    Γ s⊨ U1 <:[i] U2 -∗
     Γ s⊨ cTMem l L1 U1 <:[i] cTMem l L2 U2.
   Proof.
     iIntros "#HsubL #HsubU !> %ρ #Hg".
@@ -284,19 +284,19 @@ Section DStpLemmas.
   Qed.
 
   Lemma sD_Typ_Stp {Γ} L1 L2 U1 U2 s σ l:
-    Γ s⊨ oLater U1 <:[0] oLater U2 -∗
-    Γ s⊨ oLater L2 <:[0] oLater L1 -∗
+    Γ s⊨ L2 <:[0] L1 -∗
+    Γ s⊨ U1 <:[0] U2 -∗
     Γ s⊨ { l := dtysem σ s } : cTMem l L1 U1 -∗
     Γ s⊨ { l := dtysem σ s } : cTMem l L2 U2.
   Proof.
-    rewrite !sdtp_eq; iIntros "#HU #HL #Hd !>" (ρ Hpid) "#Hg".
+    rewrite !sdtp_eq; iIntros "#HL #HU #Hd !>" (ρ Hpid) "#Hg".
     iSpecialize ("Hd" $! ρ Hpid with "Hg"); rewrite !cTMem_eq.
     iApply (oDTMem_respects_sub with "(HL Hg) (HU Hg) Hd").
   Qed.
 
   Lemma sD_Typ_Abs_D {Γ} T L U s σ l:
-    Γ s⊨ oLater T <:[0] oLater U -∗
-    Γ s⊨ oLater L <:[0] oLater T -∗
+    Γ s⊨ L <:[0] oLater T -∗
+    Γ s⊨ oLater T <:[0] U -∗
     s ↝[ σ ] T -∗
     Γ s⊨ { l := dtysem σ s } : cTMem l L U.
   Proof. rewrite (sD_Typ l). apply sD_Typ_Stp. Qed.

--- a/theories/Dot/semtyp_lemmas/sub_lr.v
+++ b/theories/Dot/semtyp_lemmas/sub_lr.v
@@ -61,7 +61,7 @@ Section StpLemmas.
   (** ** Subtyping for type selections. *)
   Lemma sSub_Sel {Γ L U p l i}:
     Γ s⊨p p : cTMem l L U, i -∗
-    Γ s⊨ oLater L, i <: oSel p l, i.
+    Γ s⊨ L, i <: oSel p l, i.
   Proof.
     iIntros "/= #Hp !> %ρ %v Hg #HL"; iSpecialize ("Hp" with "Hg"); iNext i.
     iApply (path_wp_wand with "Hp"); iIntros (w).
@@ -70,7 +70,7 @@ Section StpLemmas.
 
   Lemma sSel_Sub {Γ L U p l i}:
     Γ s⊨p p : cTMem l L U, i -∗
-    Γ s⊨ oSel p l, i <: oLater U, i.
+    Γ s⊨ oSel p l, i <: U, i.
   Proof.
     iIntros "#Hp !> %ρ %v Hg Hφ"; iSpecialize ("Hp" with "Hg"); iNext i.
     iDestruct (path_wp_agree with "Hp Hφ") as (w Hw) "[Hp Hφ]".
@@ -157,14 +157,14 @@ Section StpLemmas.
 
   (** ** Type members: variance of [cTMem], that is [{A :: L .. U}]. *)
   Lemma sTyp_Sub_Typ {Γ L1 L2 U1 U2 i l} `{!SwapPropI Σ} :
-    Γ s⊨ oLater L2, i <: oLater L1, i -∗
-    Γ s⊨ oLater U1, i <: oLater U2, i -∗
+    Γ s⊨ L2, i <: L1, i -∗
+    Γ s⊨ U1, i <: U2, i -∗
     Γ s⊨ cTMem l L1 U1, i <: cTMem l L2 U2, i.
   Proof. rewrite -!sstpd_to_sstpi. apply sTyp_Stp_Typ. Qed.
 
   Lemma Typ_Sub_Typ {Γ L1 L2 U1 U2 i l} `{!SwapPropI Σ} :
-    Γ ⊨ TLater L2, i <: TLater L1, i -∗
-    Γ ⊨ TLater U1, i <: TLater U2, i -∗
+    Γ ⊨ L2, i <: L1, i -∗
+    Γ ⊨ U1, i <: U2, i -∗
     Γ ⊨ TTMem l L1 U1, i <: TTMem l L2 U2, i.
   Proof. apply sTyp_Sub_Typ. Qed.
 End StpLemmas.

--- a/theories/Dot/syn/syn.v
+++ b/theories/Dot/syn/syn.v
@@ -79,6 +79,8 @@ Notation TInt := (TPrim tint).
 Notation TBool := (TPrim tbool).
 Notation vint n := (vlit $ lint n).
 Notation vbool b := (vlit $ lbool b).
+(* Adapter over TTMem. [L] stands for Later. *)
+Definition TTMemL l L U := TTMem l (TLater L) (TLater U).
 
 (** Definition lists [\overbar{d}]. *)
 Definition dms := list (label * dm).

--- a/theories/Dot/typing/stamped_typing.v
+++ b/theories/Dot/typing/stamped_typing.v
@@ -104,8 +104,8 @@ with dm_typed Γ g : label → dm → ty → Prop :=
 | iD_Typ_Abs T l L U s σ:
     T ~[ length Γ ] (g, (s, σ)) →
     is_stamped_σ (length Γ) g σ →
-    Γ s⊢ₜ[ g ] TLater L, 0 <: TLater T, 0 →
-    Γ s⊢ₜ[ g ] TLater T, 0 <: TLater U, 0 →
+    Γ s⊢ₜ[ g ] L, 0 <: TLater T, 0 →
+    Γ s⊢ₜ[ g ] TLater T, 0 <: U, 0 →
     Γ s⊢[ g ]{ l := dtysem σ s } : TTMem l L U
 | iD_Val l v T:
     Γ s⊢ₜ[ g ] tv v : T →
@@ -221,10 +221,10 @@ with subtype Γ g : ty → nat → ty → nat → Prop :=
 (* Type selections *)
 | iSel_Sub p L {l U i}:
     Γ s⊢ₚ[ g ] p : TTMem l L U, i →
-    Γ s⊢ₜ[ g ] TSel p l, i <: TLater U, i
+    Γ s⊢ₜ[ g ] TSel p l, i <: U, i
 | iSub_Sel p U {l L i}:
     Γ s⊢ₚ[ g ] p : TTMem l L U, i →
-    Γ s⊢ₜ[ g ] TLater L, i <: TSel p l, i
+    Γ s⊢ₜ[ g ] L, i <: TSel p l, i
 
 | iSngl_pq_Sub p q {i T1 T2}:
     T1 ~Tp[ p := q ]* T2 →
@@ -262,8 +262,8 @@ with subtype Γ g : ty → nat → ty → nat → Prop :=
     Γ s⊢ₜ[ g ] T1, i <: T2, i →
     Γ s⊢ₜ[ g ] TVMem l T1, i <: TVMem l T2, i
 | iTyp_Sub_Typ L1 L2 U1 U2 i l:
-    Γ s⊢ₜ[ g ] TLater L2, i <: TLater L1, i →
-    Γ s⊢ₜ[ g ] TLater U1, i <: TLater U2, i →
+    Γ s⊢ₜ[ g ] L2, i <: L1, i →
+    Γ s⊢ₜ[ g ] U1, i <: U2, i →
     Γ s⊢ₜ[ g ] TTMem l L1 U1, i <: TTMem l L2 U2, i
   (* Is it true that for covariant F, F[A ∧ B] = F[A] ∧ F[B]?
     Dotty assumes that, tho DOT didn't capture it.

--- a/theories/Dot/typing/storeless_typing.v
+++ b/theories/Dot/typing/storeless_typing.v
@@ -120,8 +120,8 @@ with dm_typed Γ g : label → dm → ty → Prop :=
 | iD_Typ_Abs T l L U s σ:
     T ~[ length Γ ] (g, (s, σ)) →
     is_stamped_σ (length Γ) g σ →
-    Γ v⊢ₜ[ g ] TLater L, 0 <: TLater T, 0 →
-    Γ v⊢ₜ[ g ] TLater T, 0 <: TLater U, 0 →
+    Γ v⊢ₜ[ g ] L, 0 <: TLater T, 0 →
+    Γ v⊢ₜ[ g ] TLater T, 0 <: U, 0 →
     Γ v⊢[ g ]{ l := dtysem σ s } : TTMem l L U
 | iD_Val l v T:
     Γ v⊢ₜ[ g ] tv v : T →
@@ -237,10 +237,10 @@ with subtype Γ g : ty → nat → ty → nat → Prop :=
 (* Type selections *)
 | iSel_Sub p L {l U i}:
     Γ v⊢ₚ[ g ] p : TTMem l L U, i →
-    Γ v⊢ₜ[ g ] TSel p l, i <: TLater U, i
+    Γ v⊢ₜ[ g ] TSel p l, i <: U, i
 | iSub_Sel p U {l L i}:
     Γ v⊢ₚ[ g ] p : TTMem l L U, i →
-    Γ v⊢ₜ[ g ] TLater L, i <: TSel p l, i
+    Γ v⊢ₜ[ g ] L, i <: TSel p l, i
 
 | iSngl_pq_Sub p q {i T1 T2}:
     T1 ~Tp[ p := q ]* T2 →
@@ -278,8 +278,8 @@ with subtype Γ g : ty → nat → ty → nat → Prop :=
     Γ v⊢ₜ[ g ] T1, i <: T2, i →
     Γ v⊢ₜ[ g ] TVMem l T1, i <: TVMem l T2, i
 | iTyp_Sub_Typ L1 L2 U1 U2 i l:
-    Γ v⊢ₜ[ g ] TLater L2, i <: TLater L1, i →
-    Γ v⊢ₜ[ g ] TLater U1, i <: TLater U2, i →
+    Γ v⊢ₜ[ g ] L2, i <: L1, i →
+    Γ v⊢ₜ[ g ] U1, i <: U2, i →
     Γ v⊢ₜ[ g ] TTMem l L1 U1, i <: TTMem l L2 U2, i
   (* Is it true that for covariant F, F[A ∧ B] = F[A] ∧ F[B]?
     Dotty assumes that, tho DOT didn't capture it.

--- a/theories/Dot/typing/unstamped_typing.v
+++ b/theories/Dot/typing/unstamped_typing.v
@@ -103,8 +103,8 @@ where "Γ u⊢ds ds : T" := (dms_typed Γ ds T)
 with dm_typed Γ : label → dm → ty → Prop :=
 | iD_Typ_Abs T l L U:
     is_unstamped_ty' (length Γ) T →
-    Γ u⊢ₜ TLater L, 0 <: TLater T, 0 →
-    Γ u⊢ₜ TLater T, 0 <: TLater U, 0 →
+    Γ u⊢ₜ L, 0 <: TLater T, 0 →
+    Γ u⊢ₜ TLater T, 0 <: U, 0 →
     Γ u⊢{ l := dtysyn T } : TTMem l L U
 | iD_Val l v T:
     Γ u⊢ₜ tv v : T →
@@ -218,10 +218,10 @@ with subtype Γ : ty → nat → ty → nat → Prop :=
 (* Type selections *)
 | iSel_Sub p L {l U i}:
     Γ u⊢ₚ p : TTMem l L U, i →
-    Γ u⊢ₜ TSel p l, i <: TLater U, i
+    Γ u⊢ₜ TSel p l, i <: U, i
 | iSub_Sel p U {l L i}:
     Γ u⊢ₚ p : TTMem l L U, i →
-    Γ u⊢ₜ TLater L, i <: TSel p l, i
+    Γ u⊢ₜ L, i <: TSel p l, i
 
 | iSngl_pq_Sub p q {i T1 T2}:
     T1 ~Tp[ p := q ]* T2 →
@@ -259,8 +259,8 @@ with subtype Γ : ty → nat → ty → nat → Prop :=
     Γ u⊢ₜ T1, i <: T2, i →
     Γ u⊢ₜ TVMem l T1, i <: TVMem l T2, i
 | iTyp_Sub_Typ L1 L2 U1 U2 i l:
-    Γ u⊢ₜ TLater L2, i <: TLater L1, i →
-    Γ u⊢ₜ TLater U1, i <: TLater U2, i →
+    Γ u⊢ₜ L2, i <: L1, i →
+    Γ u⊢ₜ U1, i <: U2, i →
     Γ u⊢ₜ TTMem l L1 U1, i <: TTMem l L2 U2, i
   (* Is it true that for covariant F, F[A ∧ B] = F[A] ∧ F[B]?
     Dotty assumes that, tho DOT didn't capture it.

--- a/theories/Dot/typing/unstamped_typing_derived_rules.v
+++ b/theories/Dot/typing/unstamped_typing_derived_rules.v
@@ -159,16 +159,26 @@ Lemma iT_Mu_E' {Γ x T1 T2}:
   Γ u⊢ₜ tv (ids x): T2.
 Proof. intros; subst; tcrush. Qed.
 
+Lemma iSub_SelL {Γ p U l L i}:
+  Γ u⊢ₚ p : TTMemL l L U, i →
+  Γ u⊢ₜ TLater L, i <: TSel p l, i.
+Proof. intros; exact: iSub_Sel. Qed.
+
+Lemma iSel_SubL {Γ p L l U i}:
+  Γ u⊢ₚ p : TTMemL l L U, i →
+  Γ u⊢ₜ TSel p l, i <: TLater U, i.
+Proof. intros; exact: iSel_Sub. Qed.
+
 Lemma iSub_Sel' U {Γ p l L i}:
   is_unstamped_ty' (length Γ) L →
-  Γ u⊢ₚ p : TTMem l L U, i →
+  Γ u⊢ₚ p : TTMemL l L U, i →
   Γ u⊢ₜ L, i <: TSel p l, i.
 Proof. intros; ettrans; last exact: (iSub_Sel (p := p)); tcrush. Qed.
 
 (** Specialization of [iSub_Sel'] for convenience. *)
 Lemma iSub_Sel'' Γ {p l L i}:
   is_unstamped_ty' (length Γ) L →
-  Γ u⊢ₚ p : TTMem l L L, i → Γ u⊢ₜ L, i <: TSel p l, i.
+  Γ u⊢ₚ p : TTMemL l L L, i → Γ u⊢ₜ L, i <: TSel p l, i.
 Proof. apply iSub_Sel'. Qed.
 
 (** * Manipulating laters, basics. *)
@@ -214,7 +224,7 @@ Lemma val_LB L U Γ i x l :
   Γ u⊢ₜ tv (ids x) : type l >: L <: U →
   Γ u⊢ₜ ▶: L, i <: pv (ids x) @; l, i.
 Proof.
-  intros ??? Hv; apply (iSub_Sel (p := pv _) (U := U)).
+  intros ??? Hv; apply (iSub_SelL (p := pv _) (U := U)).
   apply (path_tp_delay (i := 0)); wtcrush.
 Qed.
 
@@ -225,13 +235,13 @@ Lemma val_UB L U Γ i x l :
   Γ u⊢ₜ tv (ids x) : type l >: L <: U →
   Γ u⊢ₜ pv (ids x) @; l, i <: ▶: U, i.
 Proof.
-  intros ??? Hv; apply (iSel_Sub (p := pv _) (L := L)).
+  intros ??? Hv; apply (iSel_SubL (p := pv _) (L := L)).
   apply (path_tp_delay (i := 0)); wtcrush.
 Qed.
 
 Lemma iD_Typ Γ T l:
   is_unstamped_ty' (length Γ) T →
-  Γ u⊢{ l := dtysyn T } : TTMem l T T.
+  Γ u⊢{ l := dtysyn T } : TTMemL l T T.
 Proof. intros. tcrush. Qed.
 
 (* We can derive rules iSub_Bind_1 and iSub_Bind_2 (the latter only conjectured) from


### PR DESCRIPTION
Turns out adapting examples was easy.