### PR TITLE
WIP on projections out of equal bounds

### DIFF
--- a/theories/Dot/lr/sem_unstamped_typing.v
+++ b/theories/Dot/lr/sem_unstamped_typing.v
@@ -119,6 +119,14 @@ Section coveringσ_intro_lemmas.
     move=> args ρ v.
     by rewrite -olty_finsubst_commute_cl ?length_idsσ // closed_subst_idsρ.
   Qed.
+
+  Lemma coveringσ_shift {i} σ (T : olty Σ i) :
+    coveringσ σ T → coveringσ (push_var σ) (shift T).
+  Proof.
+    move => + args ρ => /(_ args (stail ρ)) HclT; cbn.
+    rewrite /= !olty_weaken_one hsubst_comp stail_eq.
+    apply HclT.
+  Qed.
 End coveringσ_intro_lemmas.
 
 Section tmem_unstamped_lemmas.
@@ -130,6 +138,11 @@ Section tmem_unstamped_lemmas.
     iMod (saved_ho_sem_type_alloc _ T) as (s) "#Hs"; iIntros "!>".
     iExists s, T; iFrame "Hs"; iIntros "!%". apply Hcl.
   Qed.
+
+  Lemma leadsto_envD_equiv_alloc_shift {σ} {T : olty Σ 0} :
+    coveringσ σ T →
+    ⊢ |==> ∃ s, s ↝[ push_var σ ] shift T.
+  Proof. intros Hcl; apply leadsto_envD_equiv_alloc, coveringσ_shift, Hcl. Qed.
 
   Lemma suD_Typ_Gen {l Γ fakeT s σ} {T : olty Σ 0} :
     s ↝[ σ ] T -∗ Γ su⊨ { l := dtysyn fakeT } : cTMem l (oLater T) (oLater T).

--- a/theories/Dot/lr/sem_unstamped_typing.v
+++ b/theories/Dot/lr/sem_unstamped_typing.v
@@ -13,10 +13,6 @@ Implicit Types (Σ : gFunctors)
          (v w : vl) (e : tm) (d : dm) (ds : dms) (p : path)
          (ρ : env) (l : label).
 
-(* XXX fix notation scopes for Iris basic updates. To drop when we update Iris. *)
-Arguments bupd {_}%type_scope {_} _%bi_scope.
-Notation "|==> Q" := (bupd Q) : bi_scope.
-
 Section unstamped_judgs.
   Context `{!dlangG Σ}.
 

--- a/theories/Dot/lr/sem_unstamped_typing.v
+++ b/theories/Dot/lr/sem_unstamped_typing.v
@@ -173,11 +173,11 @@ Section coveringσ_lemmas.
     Γ ⊨ L <:[0] TLater T -∗
     Γ ⊨ TLater T <:[0] U -∗
     Γ u⊨ { l := dtysyn fakeT } : TTMem l L U.
-  Proof. have := nclosed_syn_coveringσ HclT; apply suD_Typ_Abs. Qed.
+  Proof. have := !!nclosed_syn_coveringσ HclT; apply suD_Typ_Abs. Qed.
 
   Lemma uD_Typ {l n Γ T} fakeT (HclT : nclosed T n):
     ⊢ Γ u⊨ { l := dtysyn fakeT } : TTMem l (TLater T) (TLater T).
-  Proof. have := !!(nclosed_syn_coveringσ HclT). apply suD_Typ. Qed.
+  Proof. have := !!nclosed_syn_coveringσ HclT; apply suD_Typ. Qed.
 
   (* Maybe hard to use in general; [nclosed] requires equality on the nose? *)
   Lemma nclosed_sem_coveringσ {n} {T : olty Σ 0} (Hcl : nclosed T n) :

--- a/theories/Dot/lr/sem_unstamped_typing.v
+++ b/theories/Dot/lr/sem_unstamped_typing.v
@@ -102,6 +102,25 @@ Local Hint Resolve same_skel_dms_hasnt : core.
 Definition coveringσ `{!dlangG Σ} {i} σ (T : olty Σ i) : Prop :=
   ∀ args ρ, T args ρ ≡ T args (∞ σ.|[ρ]).
 
+Section coveringσ_intro_lemmas.
+  Context `{!dlangG Σ}.
+
+  Lemma nclosed_syn_coveringσ {n} {T : ty} (Hcl : nclosed T n) :
+    coveringσ (idsσ n) V⟦T⟧.
+  Proof.
+    move=> args ρ v /=.
+    by rewrite -interp_finsubst_commute_cl ?length_idsσ // closed_subst_idsρ.
+  Qed.
+
+  (* Maybe hard to use in general; [nclosed] requires equality on the nose? *)
+  Lemma nclosed_sem_coveringσ {n} {T : olty Σ 0} (Hcl : nclosed T n) :
+    coveringσ (idsσ n) T.
+  Proof.
+    move=> args ρ v.
+    by rewrite -olty_finsubst_commute_cl ?length_idsσ // closed_subst_idsρ.
+  Qed.
+End coveringσ_intro_lemmas.
+
 Section tmem_unstamped_lemmas.
   Context `{!dlangG Σ}.
 
@@ -157,17 +176,6 @@ Section tmem_unstamped_lemmas.
   Proof.
     by iIntros "H1 H2"; iApply (suD_Typ_Stp with "H1 H2"); iApply suD_Typ.
   Qed.
-End tmem_unstamped_lemmas.
-
-Section coveringσ_lemmas.
-  Context `{!dlangG Σ}.
-
-  Lemma nclosed_syn_coveringσ {n} {T : ty} (Hcl : nclosed T n) :
-    coveringσ (idsσ n) V⟦T⟧.
-  Proof.
-    move=> args ρ v /=.
-    by rewrite -interp_finsubst_commute_cl ?length_idsσ // closed_subst_idsρ.
-  Qed.
 
   Lemma uD_Typ_Abs {l n Γ L T U} fakeT (HclT : nclosed T n):
     Γ ⊨ L <:[0] TLater T -∗
@@ -178,15 +186,7 @@ Section coveringσ_lemmas.
   Lemma uD_Typ {l n Γ T} fakeT (HclT : nclosed T n):
     ⊢ Γ u⊨ { l := dtysyn fakeT } : TTMem l (TLater T) (TLater T).
   Proof. have := !!nclosed_syn_coveringσ HclT; apply suD_Typ. Qed.
-
-  (* Maybe hard to use in general; [nclosed] requires equality on the nose? *)
-  Lemma nclosed_sem_coveringσ {n} {T : olty Σ 0} (Hcl : nclosed T n) :
-    coveringσ (idsσ n) T.
-  Proof.
-    move=> args ρ v.
-    by rewrite -olty_finsubst_commute_cl ?length_idsσ // closed_subst_idsρ.
-  Qed.
-End coveringσ_lemmas.
+End tmem_unstamped_lemmas.
 
 Section unstamped_lemmas.
   Context `{!dlangG Σ}.

--- a/theories/Dot/semtyp_lemmas/tproj_lr.v
+++ b/theories/Dot/semtyp_lemmas/tproj_lr.v
@@ -319,20 +319,17 @@ Section type_proj.
     points to [shift T] *)
     move=> /coveringσ_shift; set σ' := vvar 0 :: shift σ => HclT.
     iIntros "HT"; rewrite oProjN_eq.
-    iMod (leadsto_envD_equiv_alloc HclT) as (s) "Hs"; iModIntro.
+    iMod (leadsto_envD_equiv_alloc HclT) as (s) "#Hs"; iModIntro.
     set d := dtysem σ' s; set w := (vobj [(A, d)]).[ρ]. iExists w.
-
-    iAssert (oTMem A (oLater T) (oLater T) vnil ρ w)%I
-      with "[-HT]" as "#Hw"; first last. {
+    set lT := oLater T.
+    iAssert (oTMem A lT lT vnil ρ w)%I with "[-HT]" as "#Hw"; first last. {
       iFrame "Hw". iApply (vl_sel_lb with "HT Hw").
     }
-    iDestruct (sD_Typ (Γ := []) A with "Hs") as (Hwf) "Hd".
-    iSpecialize ("Hd" $! (w .: ρ) with "[%] [//]").
-    by apply path_includes_self, Hwf.
-    rewrite cTMem_eq.
-    iExists d.|[w .: ρ]; iSplit; first iIntros "!%".
-    eexists; split; first done.
-    rewrite norm_selfSubst. apply dms_lookup_head.
-    iApply "Hd".
+    iAssert ([] s⊨p pv (vobj [(A, d)]) :
+      oMu (oTMem A (shift lT) (shift lT)), 0) as "Hw".
+    by iApply sP_Obj_I; iApply sD_Sing'; iApply (sD_Typ with "Hs").
+    iSpecialize ("Hw" $! ρ); rewrite laterN_0 (path_wp_pv_eq w).
+    iEval (rewrite oMu_eq oTMem_shift olty_weaken_one stail_eq) in "Hw".
+    by iApply "Hw".
   Qed.
 End type_proj.

--- a/theories/Dot/semtyp_lemmas/tproj_lr.v
+++ b/theories/Dot/semtyp_lemmas/tproj_lr.v
@@ -325,11 +325,9 @@ Section type_proj.
     iAssert (oTMem A lT lT vnil ρ w)%I with "[-HT]" as "#Hw"; first last. {
       iFrame "Hw". iApply (vl_sel_lb with "HT Hw").
     }
+    rewrite -(path_wp_pv_eq w).
     iAssert ([] s⊨p pv (vobj [(A, d)]) :
-      oMu (oTMem A (shift lT) (shift lT)), 0) as "Hw".
+      oMu (oTMem A (shift lT) (shift lT)), 0) as "Hw"; last by iApply "Hw".
     by iApply sP_Obj_I; iApply sD_Sing'; iApply (sD_Typ with "Hs").
-    iSpecialize ("Hw" $! ρ); rewrite laterN_0 (path_wp_pv_eq w).
-    iEval (rewrite oMu_eq oTMem_shift olty_weaken_one stail_eq) in "Hw".
-    by iApply "Hw".
   Qed.
 End type_proj.

--- a/theories/Dot/semtyp_lemmas/tproj_lr.v
+++ b/theories/Dot/semtyp_lemmas/tproj_lr.v
@@ -32,7 +32,7 @@ Definition oExists `{!dlangG Σ} {n} (T : oltyO Σ 0) (U : oltyO Σ n) : oltyO �
   (* v ∈ w.A *)
   U args (w .: ρ) v).
 
-(**
+(** **
 Semantic proofs of typing lemmas for existentials.
 
 I adapted the rules from https://dl.acm.org/doi/pdf/10.1145/3290322 (see
@@ -69,7 +69,7 @@ Section existentials.
 
 End existentials.
 
-(**
+(** ** Semantics of type projections.
   This semantic type models upper-bound-only type projections using
   (model-level) existentials and normal DOT type members:
     [V[[T#A]](ρ) = { v | ∃ w ∈ V[[T]](ρ). v ∈ V[[w.A]](ρ) }].
@@ -83,7 +83,7 @@ Definition oProjN `{!dlangG Σ} n A (T : oltyO Σ 0) : oltyO Σ n :=
   oSelN n (pv (ids 0)) A args (w .: ρ) v).
 Notation oProj A T := (oProjN 0 A T).
 
-(** Technical infrastructure for setoid rewriting. *)
+(** *** Technical infrastructure for setoid rewriting. *)
 Instance: Params (@oProjN) 4 := {}.
 
 Section type_proj_setoid_equality.
@@ -110,7 +110,7 @@ Section type_proj_setoid_equality.
   Qed.
 End type_proj_setoid_equality.
 
-(** Semantic proofs of typing lemmas for projections. *)
+(** ** Semantic proofs of typing lemmas for projections. *)
 Section type_proj.
   Context `{!dlangG Σ}.
 

--- a/theories/iris_extra/iris_prelude.v
+++ b/theories/iris_extra/iris_prelude.v
@@ -13,6 +13,10 @@ From iris.program_logic Require Import ectx_language.
 From D.pure_program_logic Require Export weakestpre.
 From D Require Export prelude proofmode_extra.
 
+(* XXX fix notation scopes for Iris basic updates. To drop when we update Iris. *)
+Arguments bupd {_}%type_scope {_} _%bi_scope.
+Notation "|==> Q" := (bupd Q) : bi_scope.
+
 (** * Notation for functions in the Iris scope. *)
 Notation "'λI' x .. y , t" := (fun x => .. (fun y => t%I) ..)
   (at level 200, x binder, y binder, right associativity,


### PR DESCRIPTION
Before merging this, we should probably add a top-level update modality to the path typing and subtyping judgments, to avoid the problem described in one of the comments.