### PR TITLE
Prepare for semantic unstamped typing

### DIFF
--- a/theories/DSub/lr/ty_interp_subst_lemmas.v
+++ b/theories/DSub/lr/ty_interp_subst_lemmas.v
@@ -53,7 +53,7 @@ Section logrel_binding_lemmas.
   Proof.
     rewrite interp_subst_compose_ind !(interp_subst_ids T) -hsubst_comp.
     (* *The* step requiring [HclT]. *)
-    by rewrite (subst_compose _ _ HclT).
+    by rewrite (subst_compose HclT).
   Qed.
 End logrel_binding_lemmas.
 End ty_interp_lemmas.

--- a/theories/DSub/stamping/type_extraction_syn.v
+++ b/theories/DSub/stamping/type_extraction_syn.v
@@ -138,7 +138,7 @@ Proof.
   exists T, T.|[ξ]; split_and!; eauto.
   move: (is_stamped_nclosed_ty HstT) => HclT.
   move: (is_stamped_nclosed_sub Hstξ) => Hclξ.
-  simplify_eq; rewrite (subst_compose _ _ HclT) //.
+  simplify_eq; rewrite (subst_compose HclT) //.
   rewrite !closed_subst_idsρ //. exact: nclosed_sub_app.
 Qed.
 

--- a/theories/Dot/examples/from_pdot_mutual_rec_sem.v
+++ b/theories/Dot/examples/from_pdot_mutual_rec_sem.v
@@ -89,20 +89,17 @@ Definition pSymbol : stampTy := MkTy 50 [x0; x1; x2] {@
 
 Definition pTypeRef : stampTy := MkTy 60 [x0; x1] (TAnd (x0 @; "Type") typeRefTBody) 2.
 
-(* Definition fromPDotG : stys := psAddStys primOptionG [pTop; pSymbol; pTypeRef]. *)
 (** The syntactic stamp map we use in our syntactic judgments. *)
-Definition fromPDotG : stys := psAddStys primOptionG [pTop; pSymbol].
-Definition fromPDotG' : stys := pAddStys pTypeRef fromPDotG.
-Definition fromPDotGφ := Vs⟦ fromPDotG' ⟧.
+Definition fromPDotG : stys := psAddStys primOptionG [pTypeRef; pTop; pSymbol].
+Definition fromPDotGφ := Vs⟦ fromPDotG ⟧.
 Arguments fromPDotG : simpl never.
-Arguments fromPDotG' : simpl never.
 
 Lemma pTopStamp : TyMemStamp fromPDotG pTop. Proof. split; stcrush. Qed.
 Lemma pTypeRefStamp : TyMemStamp fromPDotG pTypeRef. Proof. split; stcrush. Qed.
 Lemma pSymbolStamp : TyMemStamp fromPDotG pSymbol. Proof. split; stcrush. Qed.
 Lemma Htop : styConforms fromPDotG pTop. Proof. done. Qed.
 Lemma Hsymbol : styConforms fromPDotG pSymbol. Proof. done. Qed.
-Lemma HtypeRef : styConforms fromPDotG' pTypeRef. Proof. done. Qed.
+Lemma HtypeRef : styConforms fromPDotG pTypeRef. Proof. done. Qed.
 
 Definition assert cond :=
   tif cond 0 hloopTm.
@@ -341,7 +338,7 @@ Proof.
   iApply D_Cons; [done | iApply D_Val | iApply D_Nil].
   iApply (T_All_I_Strong (Γ' := Γ')). apply Hctx.
   iApply (fundamental_typed with "Hs").
-  have Hx: x1 @; "TypeRef" :: Γ' v⊢ₜ[ fromPDotG' ] x0 : ▶: shift typeRefTBody. {
+  have Hx: x1 @; "TypeRef" :: Γ' v⊢ₜ[ fromPDotG ] x0 : ▶: shift typeRefTBody. {
     varsub.
     eapply (iSub_Trans (T2 := ▶: TAnd (x1 @; "Type") (shift typeRefTBody))).
     + apply (iSel_Sub (L := ⊥)); tcrush. varsub. lThis; ltcrush.
@@ -441,21 +438,8 @@ Proof.
     + iApply (semFromPDotPaperTypesTyp with "Hs").
 
   - iApply D_Cons; [done| iApply D_Val | iApply D_Nil].
-  (* Fix mismatch between maps; one is an extension. *)
-    (* - Way 1, easier: weaken syntactic typing *)
     iApply (fundamental_typed with "Hs").
-    eapply storeless_typing_mono_mut.
-    + exact: fromPDotPaperSymbolsAbsTyp.
-    + by eapply map_union_subseteq_r, map_disjoint_singleton_l.
-  (* - Way 2, harder: weaken wellMapped. *)
-  (* iApply fundamental_typed.
-  exact: fromPDotPaperSymbolsAbsTyp.
-  iApply (wellMappedφ_extend with "Hs") => s.
-  destruct (fromPDotG !! s) as [T|] eqn:Heqs; rewrite !lookup_fmap Heqs/=;
-    last by case_match.
-  have Heq: fromPDotG' !! s = Some T. eapply lookup_union_Some_r, Heqs.
-  by apply map_disjoint_singleton_l.
-  by simpl_map by exact: Heq. *)
+    exact: fromPDotPaperSymbolsAbsTyp.
 Qed.
 
 Example pCoreSemTyped Γ : ⊢ Γ ⊨[fromPDotGφ]
@@ -466,7 +450,7 @@ Proof.
   iApply T_All_E; first last.
   iApply (fundamental_typed with "Hs").
   eapply storeless_typing_mono_mut; first exact: optionModInvTyp.
-  rewrite /fromPDotG' /fromPDotG/=.
+  rewrite /fromPDotG/=.
   by repeat (etrans; last apply map_union_subseteq_r; last solve_map_disjoint).
   iApply (T_All_I_Strong (Γ' := Γ)). ietp_weaken_ctx.
   iApply (T_Sub (i := 0)).

--- a/theories/Dot/fundamental.v
+++ b/theories/Dot/fundamental.v
@@ -73,7 +73,8 @@ Section fundamental.
       + iApply D_Val_New. by iApply H.
       + iApply D_Path_Sub; by [> iApply H|iApply H0].
 
-      + iApply unary_lr.sP_Var. by iApply H.
+      + (* XXX unclean, but temporary. *)
+        iApply sP_Val. by iApply H.
       + iApply sP_Val. by iApply H.
       + iApply P_Fld_E. by iApply H.
       + by iApply sP_Sub; [iApply H0|iApply H].

--- a/theories/Dot/hkdot/sem_kind.v
+++ b/theories/Dot/hkdot/sem_kind.v
@@ -614,11 +614,11 @@ Section proper_eq.
 
   Lemma cTMemK_eq {n} l (K : sf_kind Σ n) d ρ :
     cTMemK l K ρ [(l, d)] ⊣⊢ oDTMemK K ρ d.
-  Proof. by rewrite dty2clty_singleton. Qed.
+  Proof. by rewrite dlty2clty_singleton. Qed.
 
   Lemma cTMemAnyKind_eq l d ρ :
     cTMemAnyKind l ρ [(l, d)] ⊣⊢ oDTMemAnyKind ρ d.
-  Proof. by rewrite dty2clty_singleton. Qed.
+  Proof. by rewrite dlty2clty_singleton. Qed.
 
   Lemma cTMemK_subst {n} l (K : sf_kind Σ n) ρ :
     (clty_olty (cTMemK l K)).|[ρ] = cTMemK l K.|[ρ].

--- a/theories/Dot/lr/dot_lty.v
+++ b/theories/Dot/lr/dot_lty.v
@@ -157,7 +157,7 @@ Section DefsTypes.
   Global Instance dty2clty_proper l :
     Proper ((≡) ==> (≡)) (dty2clty l) := ne_proper _.
 
-  Lemma dty2clty_singleton l (TD : dlty Σ) ρ d :
+  Lemma dlty2clty_singleton l (TD : dlty Σ) ρ d :
     dty2clty l TD ρ [(l, d)] ≡ TD ρ d.
   Proof. by rewrite lift_dty_dms_singleton_eq. Qed.
 

--- a/theories/Dot/lr/dot_lty.v
+++ b/theories/Dot/lr/dot_lty.v
@@ -247,7 +247,7 @@ Section logrel_binding_lemmas.
   Proof.
     rewrite interp_subst_compose_ind !(interp_subst_ids T) -hsubst_comp.
     (* *The* step requiring [HclT]. *)
-    by rewrite (subst_compose _ _ HclT).
+    by rewrite (subst_compose HclT).
   Qed.
 
   (** Substitution on semantic types commutes with the semantics. *)

--- a/theories/Dot/lr/hkdot.v
+++ b/theories/Dot/lr/hkdot.v
@@ -545,9 +545,8 @@ Section dot_types.
     s ↝[ σ ] T -∗
     Γ s⊨ { l := dtysem σ s } : cTMemK l K.
   Proof.
-    rewrite sdtp_eq; iIntros "#HTK"; iDestruct 1 as (φ Hγφ) "#Hγ".
-    iIntros "!>" (ρ Hpid) "Hg"; rewrite cTMemK_eq.
-    iExists (hoEnvD_inst (σ.|[ρ]) φ); iSplit.
+    rewrite sdtp_eq'; iIntros "#HTK"; iDestruct 1 as (φ Hγφ) "#Hγ".
+    iIntros "!>" (ρ Hpid) "Hg"; iExists (hoEnvD_inst (σ.|[ρ]) φ); iSplit.
     by iApply (dm_to_type_intro with "Hγ").
     iApply (sf_kind_proper' with "(HTK Hg)") => args v /=.
     by rewrite -(Hγφ args ρ v) make_intuitionistically.

--- a/theories/Dot/lr/later_sub_sem.v
+++ b/theories/Dot/lr/later_sub_sem.v
@@ -34,15 +34,28 @@ Section TypeEquiv.
     Γ ⊨ e : T1 -∗ Γ ⊨ e : T2.
   Proof. by apply equiv_entails, setp_proper, fundamental_type_equiv_olty. Qed.
 
-  Lemma ietp_proper_teq Γ : Proper (type_equiv ==> (=) ==> (⊢)) (ietp Γ).
+  Lemma ietp_teq_proper Γ : Proper (type_equiv ==> (=) ==> (⊢)) (ietp Γ).
   Proof. repeat intro; subst. exact: ietp_respects_type_equiv. Qed.
 
-  Lemma istpd_proper_teq Γ i : Proper (type_equiv ==> type_equiv ==> (⊢)) (istpd Γ i).
+  (* XXX All these instances are local, because setoid rewriting doesn't work
+  for some reason, but I don't feel like debugging it. *)
+  Instance istpd_teq_proper Γ i :
+    Proper (type_equiv ==> type_equiv ==> (⊣⊢)) (istpd i Γ).
   Proof.
-    by repeat intro; apply equiv_entails, sstpd_proper; [|
+    by repeat intro; apply sstpd_proper; [|
       exact: fundamental_type_equiv_olty..].
   Qed.
 
+  Instance: Params (@istpd) 4 := {}.
+  Instance: Equivalence type_equiv := {}.
+  Instance: RewriteRelation type_equiv := {}.
+
+  Lemma Stp_Eq i T1 T2 Γ :
+    |- T1 == T2 → ⊢ Γ ⊨ T1 <:[i] T2.
+  Proof.
+    intros Heq.
+    iApply istpd_teq_proper; [eassumption|reflexivity|iApply sStp_Refl].
+  Qed.
 End TypeEquiv.
 
 (* This is specialized to [vnil] because contexts only contain proper types anyway. *)

--- a/theories/Dot/lr/sem_unstamped_typing.v
+++ b/theories/Dot/lr/sem_unstamped_typing.v
@@ -1,0 +1,97 @@
+(** * Unstamped semantic judgments, adequacy, and typing lemmas. *)
+From D Require Export iris_prelude swap_later_impl.
+From D.pure_program_logic Require Import weakestpre.
+From D Require Import iris_extra.det_reduction.
+From D.Dot Require Import skeleton path_repl typing_aux_defs.
+From D.Dot Require Import unary_lr.
+From D.Dot Require Import later_sub_sem binding_lr path_repl_lr defs_lr dsub_lr prims_lr.
+From stdpp Require Import relations.
+(* Fix scope. *)
+Import dlang_adequacy D.prelude stdpp.relations stdpp.tactics.
+
+Implicit Types (Σ : gFunctors)
+         (v w : vl) (e : tm) (d : dm) (ds : dms) (p : path)
+         (ρ : env) (l : label).
+
+(* XXX *)
+Arguments bupd {_}%type_scope {_} _%bi_scope.
+Notation "|==> Q" := (bupd Q) : bi_scope.
+
+Section unstamped_judgs.
+  Context `{!dlangG Σ}.
+
+  (* Semantic, Unstamped, Expression TyPing *)
+  Definition suetp e_u Γ T : iProp Σ :=
+    □ |==> ∃ e_s, ⌜ same_skel_tm e_u e_s⌝ ∧ Γ s⊨ e_s : T.
+
+  Definition sudstp ds_u Γ T : iProp Σ :=
+    □ |==> ∃ ds_s, ⌜ same_skel_dms ds_u ds_s⌝ ∧ Γ s⊨ds ds_s : T.
+
+  Definition sudtp l d_u Γ T : iProp Σ :=
+    □ |==> ∃ d_s, ⌜ same_skel_dm d_u d_s⌝ ∧ Γ s⊨ { l := d_s } : T.
+
+  Definition iudtp  Γ T l d     := sudtp l d  V⟦Γ⟧* C⟦T⟧.
+  Definition iudstp Γ T ds      := sudstp ds  V⟦Γ⟧* C⟦T⟧.
+  Definition iuetp  Γ T e       := suetp e    V⟦Γ⟧* V⟦T⟧.
+End unstamped_judgs.
+
+Global Instance: Params (@suetp) 3 := {}.
+Global Instance: Params (@sudstp) 3 := {}.
+Global Instance: Params (@sudtp) 4 := {}.
+
+Section unstamped_judgs_proper.
+  Context `{!dlangG Σ}.
+
+  Global Instance suetp_proper e : Proper ((≡) ==> (≡) ==> (≡)) (suetp e).
+  Proof. rewrite /suetp => ??????. by repeat f_equiv. Qed.
+  Global Instance suetp_flip_proper e :
+    Proper (flip (≡) ==> flip (≡) ==> flip (≡)) (suetp e).
+  Proof. apply: flip_proper_3. Qed.
+
+  Global Instance sudstp_proper ds : Proper ((≡) ==> (≡) ==> (≡)) (sudstp ds).
+  Proof. rewrite /sudstp => ??????; by repeat f_equiv. Qed.
+  Global Instance sudstp_flip_proper ds :
+    Proper (flip (≡) ==> flip (≡) ==> flip (≡)) (sudstp ds).
+  Proof. apply: flip_proper_3. Qed.
+
+  Global Instance sudtp_proper l d : Proper ((≡) ==> (≡) ==> (≡)) (sudtp l d).
+  Proof. rewrite /sudtp => ??????. by repeat f_equiv. Qed.
+  Global Instance sudtp_flip_proper l d :
+    Proper (flip (≡) ==> flip (≡) ==> flip (≡)) (sudtp l d).
+  Proof. apply: flip_proper_3. Qed.
+End unstamped_judgs_proper.
+
+Notation "Γ su⊨ e : T" := (suetp e Γ T) (at level 74, e, T at next level).
+Notation "Γ su⊨ {  l := d  } : T" := (sudtp l d Γ T) (at level 64, d, l, T at next level).
+Notation "Γ su⊨ds ds : T" := (sudstp ds Γ T) (at level 74, ds, T at next level).
+
+Notation "Γ u⊨ {  l := d  } : T" := (iudtp Γ T l d) (at level 74, d, l, T at next level).
+Notation "Γ u⊨ds ds : T" := (iudstp Γ T ds) (at level 74, ds, T at next level).
+Notation "Γ u⊨ e : T" := (iuetp Γ T e) (at level 74, e, T at next level).
+
+(* Adequacy *)
+Theorem unstamped_s_safety_dot_sem Σ `{HdlangG: !dlangPreG Σ} `{!SwapPropI Σ}
+  {e_u}
+  (τ : ∀ `{!dlangG Σ}, olty Σ 0)
+  (Hwp : ∀ `{!dlangG Σ} `(!SwapPropI Σ), ⊢ [] su⊨ e_u : τ):
+  safe e_u.
+Proof.
+  intros e_u' [n Hsteps]%rtc_nsteps.
+  eapply same_skel_safe_n_impl, Hsteps.
+  apply (soundness (M := iResUR Σ) _ n).
+  apply (bupd_plain_soundness _).
+  (* XXX [hG] is needed, till I fix everything and drop the second map. *)
+  iMod (gen_iheap_init (L := stamp) ∅) as (hG) "_".
+  set (DLangΣ := DLangG Σ).
+  iDestruct (Hwp DLangΣ SwapPropI0) as "#>Hwp".
+  iDestruct "Hwp" as (e_s Hsim) "#Hwp /=".
+  iSpecialize ("Hwp" $! ids with "[//]").
+  rewrite hsubst_id (wptp_safe_n n).
+  iIntros "!>!>"; iDestruct ("Hwp") as %Hsafe; naive_solver.
+Qed.
+
+Corollary unstamped_safety_dot_sem Σ `{HdlangG: !dlangPreG Σ} `{!SwapPropI Σ}
+  {e T}
+  (Hlog : ∀ `(!dlangG Σ) `(!SwapPropI Σ), ⊢ [] u⊨ e : T):
+  safe e.
+Proof. exact: (unstamped_s_safety_dot_sem Σ (λ _, V⟦T⟧)). Qed.

--- a/theories/Dot/lr/unary_lr.v
+++ b/theories/Dot/lr/unary_lr.v
@@ -276,16 +276,18 @@ Section sem_types.
   (* Avoid auto-dropping box (and unfolding) when introducing judgments persistently. *)
   Local Notation IntoPersistent' P := (IntoPersistent false P P).
 
-  Global Instance idtp_persistent Γ T l d: IntoPersistent' (idtp Γ T l d) | 0 := _.
+  (* Instances for [[is]dtp must come after, to take priority over [[is]dstp]
+  since they overlap. *)
   Global Instance idstp_persistent Γ T ds: IntoPersistent' (idstp Γ T ds) | 0 := _.
+  Global Instance idtp_persistent Γ T l d: IntoPersistent' (idtp Γ T l d) | 0 := _.
   Global Instance ietp_persistent Γ T e : IntoPersistent' (ietp Γ T e) | 0 := _.
   Global Instance istpi_persistent Γ T1 T2 i j : IntoPersistent' (istpi Γ T1 T2 i j) | 0 := _.
   Global Instance iptp_persistent Γ T p i : IntoPersistent' (iptp Γ T p i) | 0 := _.
 
   Implicit Types (T : olty Σ 0) (Td : clty Σ) (Tds : dslty Σ).
 
-  Global Instance sdtp_persistent : IntoPersistent' (sdtp l d   Γ Td) | 0 := _.
   Global Instance sdstp_persistent : IntoPersistent' (sdstp ds  Γ Tds) | 0 := _.
+  Global Instance sdtp_persistent : IntoPersistent' (sdtp l d   Γ Td) | 0 := _.
   Global Instance setp_persistent : IntoPersistent' (setp e     Γ T) | 0 := _.
   Global Instance sstpi_persistent : IntoPersistent' (sstpi i j Γ T1 T2) | 0 := _.
   Global Instance sptp_persistent : IntoPersistent' (sptp p i   Γ T) | 0 := _.

--- a/theories/Dot/lr/unary_lr.v
+++ b/theories/Dot/lr/unary_lr.v
@@ -204,10 +204,6 @@ Section sem_types.
     cVMem l T ρ [(l, d)] ⊣⊢ oDVMem T ρ d.
   Proof. by rewrite dlty2clty_singleton. Qed.
 
-  Lemma cVMem_dpt_eq l T p ρ :
-    cVMem l T ρ [(l, dpt p)] ⊣⊢ path_wp p (oClose T ρ).
-  Proof. by rewrite cVMem_eq oDVMem_eq. Qed.
-
   Lemma oSel_pv {n} w l args ρ v :
     oSelN n (pv w) l args ρ v ⊣⊢
       ∃ d ψ, ⌜w.[ρ] @ l ↘ d⌝ ∧ d ↗n[ n ] ψ ∧ ▷ □ ψ args v.
@@ -437,6 +433,11 @@ Section misc_lemmas.
   Proof.
     rewrite /= pure_True ?(left_id True%I bi_and); by [> | exact: NoDup_singleton].
   Qed.
+
+  Lemma sdtp_eq' (Γ : sCtx Σ) (T : dlty Σ) l d:
+    Γ s⊨ { l := d } : dty2clty l T ⊣⊢
+      (□∀ ρ, ⌜path_includes (pv (ids 0)) ρ [(l, d)]⌝ → sG⟦Γ⟧* ρ → T ρ d.|[ρ]).
+  Proof. by rewrite sdtp_eq; properness; last apply dlty2clty_singleton. Qed.
 
   Lemma sP_Val {Γ} v T:
     Γ s⊨ tv v : T -∗

--- a/theories/Dot/lr/unary_lr.v
+++ b/theories/Dot/lr/unary_lr.v
@@ -193,7 +193,7 @@ Section sem_types.
 
   Lemma cTMem_eq l T1 T2 d ρ :
     cTMem l T1 T2 ρ [(l, d)] ⊣⊢ oDTMem T1 T2 ρ d.
-  Proof. by rewrite dty2clty_singleton. Qed.
+  Proof. by rewrite dlty2clty_singleton. Qed.
 
   (** [ Ds⟦ { l : τ } ⟧] and [ V⟦ { l : τ } ⟧ ]. *)
   Definition cVMem l τ : clty Σ := dty2clty l (oDVMem τ).
@@ -202,7 +202,7 @@ Section sem_types.
 
   Lemma cVMem_eq l T d ρ :
     cVMem l T ρ [(l, d)] ⊣⊢ oDVMem T ρ d.
-  Proof. by rewrite dty2clty_singleton. Qed.
+  Proof. by rewrite dlty2clty_singleton. Qed.
 
   Lemma cVMem_dpt_eq l T p ρ :
     cVMem l T ρ [(l, dpt p)] ⊣⊢ path_wp p (oClose T ρ).

--- a/theories/Dot/lr/unary_lr.v
+++ b/theories/Dot/lr/unary_lr.v
@@ -447,10 +447,6 @@ Section misc_lemmas.
     iApply ("Hp" with "Hg").
   Qed.
 
-  Lemma sP_Var {Γ} x T :
-    Γ s⊨ tv (var_vl x) : T -∗ Γ s⊨p pv (var_vl x) : T, 0.
-  Proof. apply sP_Val. Qed.
-
   Lemma sSub_Refl {Γ} T i : ⊢ Γ s⊨ T, i <: T, i.
   Proof. by iIntros "!> **". Qed.
 

--- a/theories/Dot/semtyp_lemmas/binding_lr.v
+++ b/theories/Dot/semtyp_lemmas/binding_lr.v
@@ -98,6 +98,17 @@ Section Sec.
     by rewrite s_interp_env_lookup // id_subst.
   Qed.
 
+  Lemma sT_Path {Γ τ p} :
+    Γ s⊨p p : τ, 0 -∗ Γ s⊨ path2tm p : τ.
+  Proof.
+    iIntros "#Hep !> %ρ #Hg /="; rewrite path2tm_subst.
+    by iApply (path_wp_to_wp with "(Hep Hg)").
+  Qed.
+
+  Lemma T_Path {Γ T p} :
+    Γ ⊨p p : T, 0 -∗ Γ ⊨ path2tm p : T.
+  Proof. apply sT_Path. Qed.
+
   Lemma T_Var {Γ x τ}
     (Hx : Γ !! x = Some τ):
     (*──────────────────────*)

--- a/theories/Dot/semtyp_lemmas/binding_lr.v
+++ b/theories/Dot/semtyp_lemmas/binding_lr.v
@@ -80,15 +80,6 @@ Section Sec.
     exact: sSub_Skolem_P.
   Qed.
 
-  Lemma sT_Var {Γ x τ}
-    (Hx : Γ !! x = Some τ):
-    (*──────────────────────*)
-    ⊢ Γ s⊨ of_val (ids x) : shiftN x τ.
-  Proof.
-    iIntros "/= !> %ρ #Hg"; rewrite -wp_value'.
-    by rewrite s_interp_env_lookup // id_subst.
-  Qed.
-
   Lemma sP_Var {Γ x τ}
     (Hx : Γ !! x = Some τ):
     (*──────────────────────*)
@@ -96,6 +87,15 @@ Section Sec.
   Proof.
     iIntros "/= !> %ρ #Hg"; rewrite path_wp_pv_eq.
     by rewrite s_interp_env_lookup // id_subst.
+  Qed.
+
+  Lemma P_Var {Γ x τ}
+    (Hx : Γ !! x = Some τ):
+    (*──────────────────────*)
+    ⊢ Γ ⊨p pv (ids x) : shiftN x τ, 0.
+  Proof.
+    rewrite /iptp (interp_subst_commute τ (ren (+x))). apply sP_Var.
+    by rewrite list_lookup_fmap Hx.
   Qed.
 
   Lemma sT_Path {Γ τ p} :
@@ -113,10 +113,7 @@ Section Sec.
     (Hx : Γ !! x = Some τ):
     (*──────────────────────*)
     ⊢ Γ ⊨ of_val (ids x) : shiftN x τ.
-  Proof.
-    rewrite /ietp (interp_subst_commute τ (ren (+x))). apply sT_Var.
-    by rewrite list_lookup_fmap Hx.
-  Qed.
+  Proof. by iApply (T_Path (p := pv _)); iApply P_Var. Qed.
 
   Lemma sT_And_I Γ v T1 T2:
     Γ s⊨ tv v : T1 -∗

--- a/theories/Dot/semtyp_lemmas/defs_lr.v
+++ b/theories/Dot/semtyp_lemmas/defs_lr.v
@@ -15,8 +15,8 @@ Section Sec.
     Γ s⊨p p : T, 0 -∗
     Γ s⊨ { l := dpt p } : cVMem l T.
   Proof.
-    rewrite sdtp_eq; iIntros "#Hv !>" (ρ Hpid) "#Hg".
-    rewrite cVMem_dpt_eq; iApply ("Hv" with "Hg").
+    rewrite sdtp_eq'; iIntros "#Hv !>" (ρ Hpid) "#Hg".
+    rewrite oDVMem_eq; iApply ("Hv" with "Hg").
   Qed.
 
 
@@ -38,9 +38,9 @@ Section Sec.
     oAnd (oLater T) (oSing (pself (pv (ids 1)) l)) :: Γ s⊨ds ds : T -∗
     Γ s⊨ { l := dpt (pv (vobj ds)) } : cVMem l (oMu (clty_olty T)).
   Proof.
-    rewrite sdtp_eq; iDestruct 1 as (Hwf) "#Hds";
+    rewrite sdtp_eq'; iDestruct 1 as (Hwf) "#Hds";
       iIntros "!>" (ρ Hpid%path_includes_field_aliases) "#Hg".
-    rewrite cVMem_dpt_eq path_wp_pv_eq /=. iLöb as "IH".
+    rewrite oDVMem_eq path_wp_pv_eq /=. iLöb as "IH".
     iApply clty_commute. rewrite norm_selfSubst.
     iApply ("Hds" $! (vobj _ .: ρ) with "[%] [$IH $Hg //]").
     exact: path_includes_self.
@@ -56,8 +56,8 @@ Section Sec.
     Γ s⊨ { l := dpt p } : cVMem l T1 -∗
     Γ s⊨ { l := dpt p } : cVMem l T2.
   Proof.
-    rewrite !sdtp_eq; iIntros "#Hsub #Hv !>" (ρ Hpid) "#Hg".
-    iSpecialize ("Hv" $! ρ Hpid with "Hg"); rewrite !cVMem_dpt_eq.
+    rewrite !sdtp_eq'; iIntros "#Hsub #Hv !>" (ρ Hpid) "#Hg".
+    iSpecialize ("Hv" $! ρ Hpid with "Hg"); rewrite !oDVMem_eq.
     iApply (path_wp_wand with "Hv"); iIntros "**".
     by iApply ("Hsub" with "Hg").
   Qed.
@@ -75,8 +75,8 @@ Section Sec.
     Γ s⊨ { l := dtysem σ s } : cTMem l L1 U1 -∗
     Γ s⊨ { l := dtysem σ s } : cTMem l L2 U2.
   Proof.
-    rewrite !sdtp_eq; iIntros "#HL #HU #Hd !>" (ρ Hpid) "#Hg".
-    iSpecialize ("Hd" $! ρ Hpid with "Hg"); rewrite !cTMem_eq.
+    rewrite !sdtp_eq'; iIntros "#HL #HU #Hd !>" (ρ Hpid) "#Hg".
+    iSpecialize ("Hd" $! ρ Hpid with "Hg").
     iDestruct "Hd" as (ψ) "(Hφ & HLψ & HψU)".
     iExists ψ. iFrame "Hφ".
     iModIntro; repeat iSplit; iIntros (v) "#H".
@@ -88,8 +88,8 @@ Section Sec.
     s ↝[ σ ] T -∗
     Γ s⊨ { l := dtysem σ s } : cTMem l (oLater T) (oLater T).
   Proof.
-    rewrite !sdtp_eq; iDestruct 1 as (φ Hγφ) "#Hγ"; iIntros "!>" (ρ Hpid) "#Hg".
-    rewrite cTMem_eq. iExists (hoEnvD_inst (σ.|[ρ]) φ); iSplit.
+    rewrite !sdtp_eq'; iDestruct 1 as (φ Hγφ) "#Hγ".
+    iIntros "!>" (ρ Hpid) "#Hg"; iExists (hoEnvD_inst (σ.|[ρ]) φ); iSplit.
     by iApply (dm_to_type_intro with "Hγ").
     by iModIntro; repeat iSplit; iIntros (v) "#H"; iNext; rewrite /= (Hγφ _ _).
   Qed.

--- a/theories/Dot/semtyp_lemmas/defs_lr.v
+++ b/theories/Dot/semtyp_lemmas/defs_lr.v
@@ -41,7 +41,7 @@ Section Sec.
     rewrite sdtp_eq'; iDestruct 1 as (Hwf) "#Hds";
       iIntros "!>" (ρ Hpid%path_includes_field_aliases) "#Hg".
     rewrite oDVMem_eq path_wp_pv_eq /=. iLöb as "IH".
-    iApply clty_commute. rewrite norm_selfSubst.
+    iEval rewrite -clty_commute norm_selfSubst.
     iApply ("Hds" $! (vobj _ .: ρ) with "[%] [$IH $Hg //]").
     exact: path_includes_self.
   Qed.
@@ -58,8 +58,8 @@ Section Sec.
   Proof.
     rewrite !sdtp_eq'; iIntros "#Hsub #Hv !>" (ρ Hpid) "#Hg".
     iSpecialize ("Hv" $! ρ Hpid with "Hg"); rewrite !oDVMem_eq.
-    iApply (path_wp_wand with "Hv"); iIntros "**".
-    by iApply ("Hsub" with "Hg").
+    iApply (path_wp_wand with "Hv"); iIntros "{Hv} %v #Hv".
+    iApply ("Hsub" with "Hg Hv").
   Qed.
 
   Lemma D_Path_Sub {Γ T1 T2 p l}:
@@ -78,7 +78,7 @@ Section Sec.
     rewrite !sdtp_eq'; iIntros "#HL #HU #Hd !>" (ρ Hpid) "#Hg".
     iSpecialize ("Hd" $! ρ Hpid with "Hg").
     iDestruct "Hd" as (ψ) "(Hφ & HLψ & HψU)".
-    iExists ψ. iFrame "Hφ".
+    iExists ψ. iFrame "Hφ"; iClear "Hφ".
     iModIntro; repeat iSplit; iIntros (v) "#H".
     - iApply ("HLψ" with "(HL Hg H)").
     - iApply ("HU" with "Hg (HψU H)").

--- a/theories/Dot/semtyp_lemmas/dsub_lr.v
+++ b/theories/Dot/semtyp_lemmas/dsub_lr.v
@@ -366,8 +366,8 @@ Section DStpLemmas.
     Γ s⊨ { l := dpt p } : cVMem l T1 -∗
     Γ s⊨ { l := dpt p } : cVMem l T2.
   Proof.
-    rewrite !sdtp_eq; iIntros "#Hsub #Hd !>" (ρ Hpid) "#Hg".
-    iSpecialize ("Hd" $! ρ Hpid with "Hg"); rewrite !cVMem_eq.
+    rewrite !sdtp_eq'; iIntros "#Hsub #Hd !>" (ρ Hpid) "#Hg".
+    iSpecialize ("Hd" $! ρ Hpid with "Hg").
     iApply (oDVMem_respects_sub with "(Hsub Hg) Hd").
   Qed.
 
@@ -377,8 +377,8 @@ Section DStpLemmas.
     Γ s⊨ { l := dtysem σ s } : cTMem l L1 U1 -∗
     Γ s⊨ { l := dtysem σ s } : cTMem l L2 U2.
   Proof.
-    rewrite !sdtp_eq; iIntros "#HL #HU #Hd !>" (ρ Hpid) "#Hg".
-    iSpecialize ("Hd" $! ρ Hpid with "Hg"); rewrite !cTMem_eq.
+    rewrite !sdtp_eq'; iIntros "#HL #HU #Hd !>" (ρ Hpid) "#Hg".
+    iSpecialize ("Hd" $! ρ Hpid with "Hg").
     iApply (oDTMem_respects_sub with "(HL Hg) (HU Hg) Hd").
   Qed.
 

--- a/theories/Dot/semtyp_lemmas/dsub_lr.v
+++ b/theories/Dot/semtyp_lemmas/dsub_lr.v
@@ -195,13 +195,35 @@ Section DStpLemmas.
     iApply ("Hstp" $! (v .: ρ) v with "[$Hg $HT1] [$HT1]").
   Qed.
 
+  Lemma Mu_Stp_Mu {Γ} T1 T2 i `{!SwapPropI Σ}:
+    iterate TLater i T1 :: Γ ⊨ T1 <:[i] T2 -∗
+    Γ ⊨ TMu T1 <:[i] TMu T2.
+  Proof.
+    rewrite /istpd -sMu_Stp_Mu.
+    by rewrite fmap_cons (iterate_TLater_oLater i T1).
+  Qed.
+
   (** Novel subtyping rules. [Sub_Bind_1] and [Sub_Bind_2] become
   derivable. *)
   Lemma sMu_Stp {Γ T i} : ⊢ Γ s⊨ oMu (shift T) <:[i] T.
   Proof. rewrite oMu_shift. apply sStp_Refl. Qed.
 
+  Lemma Mu_Stp {Γ} T i: ⊢ Γ ⊨ TMu (shift T) <:[i] T.
+  Proof.
+    rewrite /istpd; cbn -[sstpd].
+    rewrite (interp_subst_commute T (ren (+1))).
+    apply sMu_Stp.
+  Qed.
+
   Lemma sStp_Mu {Γ T i} : ⊢ Γ s⊨ T <:[i] oMu (shift T).
   Proof. rewrite oMu_shift. apply sStp_Refl. Qed.
+
+  Lemma Stp_Mu {Γ} T i: ⊢ Γ ⊨ T <:[i] TMu (shift T).
+  Proof.
+    rewrite /istpd; cbn -[sstpd].
+    rewrite (interp_subst_commute T (ren (+1))).
+    apply sStp_Mu.
+  Qed.
 
   Lemma sFld_Stp_Fld {Γ T1 T2 i l}:
     Γ s⊨ T1 <:[i] T2 -∗
@@ -238,6 +260,72 @@ Section DStpLemmas.
     iNext (i.+1); iModIntro. iApply (wp_wand with "(HT1 (HsubT HwT2))").
     iIntros (u) "#HuU1". iApply ("HsubU" with "HuU1").
   Qed.
+
+  (* An inverse of subsumption: subtyping is *equivalent* to convertibility
+  for values. *)
+  Lemma sStp_Skolem_P {Γ T1 T2 i} `{!SwapPropI Σ} :
+    oLaterN i (shift T1) :: Γ s⊨p pv (ids 0) : shift T2, i -∗
+    (*───────────────────────────────*)
+    Γ s⊨ T1 <:[i] T2.
+  Proof.
+    rewrite -sstpd_delay_oLaterN; iIntros "#Htyp !> %ρ Hg %v HvT1".
+    iEval rewrite /= -path_wp_pv_eq.
+    iApply ("Htyp" $! (v .: ρ) with "[$Hg $HvT1]").
+  Qed.
+
+  Lemma Stp_Skolem_P {Γ T1 T2 i} `{!SwapPropI Σ} :
+    iterate TLater i (shift T1) :: Γ ⊨p pv (ids 0) : shift T2, i -∗
+    (*───────────────────────────────*)
+    Γ ⊨ T1 <:[i] T2.
+  Proof.
+    rewrite /iptp fmap_cons iterate_TLater_oLater !interp_subst_commute.
+    exact: sStp_Skolem_P.
+  Qed.
+
+  (* Is it true that for covariant F, F[A ∧ B] = F[A] ∧ F[B]?
+    Dotty assumes that, tho DOT didn't capture it.
+    F[A ∧ B] <: F[A] ∧ F[B] is provable by covariance.
+    Let's prove F[A] ∧ F[B] <: F[A ∧ B] in the model.
+    *)
+  Lemma sAnd_All_Stp_Distr Γ T U1 U2 i:
+    ⊢ Γ s⊨ oAnd (oAll T U1) (oAll T U2) <:[i] oAll T (oAnd U1 U2).
+  Proof.
+    iIntros "/= !> %ρ #Hg !> %v [#H1 #H2]".
+    iDestruct "H1" as (t ?) "#H1"; iDestruct "H2" as (t' ->) "#H2"; simplify_eq.
+    iExists _; iSplit => //.
+    iIntros "!>" (w) "#HT".
+    iSpecialize ("H1" with "HT").
+    iSpecialize ("H2" with "HT").
+    iNext. iModIntro.
+    (* Oh. Dreaded conjunction rule. Tho could we use a version
+    for separating conjunction? *)
+    iApply wp_and. by iApply "H1". by iApply "H2".
+  Qed.
+
+  Lemma sAnd_Fld_Stp_Distr Γ l T1 T2 i:
+    ⊢ Γ s⊨ oAnd (cVMem l T1) (cVMem l T2) <:[i] cVMem l (oAnd T1 T2).
+  Proof.
+    iIntros "/= !> %ρ #Hg !> %v [#H1 H2]".
+    iDestruct "H1" as (d? pmem?) "#H1"; iDestruct "H2" as (d'? pmem'?) "#H2". objLookupDet.
+    repeat (iExists _; repeat iSplit => //).
+    by iApply (path_wp_and' with "H1 H2").
+  Qed.
+
+  Lemma sAnd_Typ_Stp_Distr Γ l L U1 U2 i:
+    ⊢ Γ s⊨ oAnd (cTMem l L U1) (cTMem l L U2) <:[i] cTMem l L (oAnd U1 U2).
+  Proof.
+    iIntros "/= !> %ρ #Hg !> %v [#H1 H2]".
+    iDestruct "H1" as (d? φ) "#[Hsφ1 [#HLφ1 #HφU1]]"; iDestruct "H2" as (d'? φ') "#[Hsφ2 [_ #HφU2]]".
+    objLookupDet.
+    iExists d; repeat iSplit => //.
+    iExists φ; repeat iSplit => //.
+    iModIntro; iSplit; iIntros (w) "Hw".
+    - by iApply "HLφ1".
+    - iDestruct (dm_to_type_agree vnil w with "Hsφ1 Hsφ2") as "#Hag {Hsφ1 Hsφ2 HLφ1}".
+      iSplit; [iApply "HφU1" | iApply "HφU2"] => //.
+      iNext. by iRewrite -"Hag".
+  Qed.
+
 
   Lemma sSngl_Stp_Self Γ p T i :
     Γ s⊨p p : T, i -∗

--- a/theories/Dot/semtyp_lemmas/examples_lr.v
+++ b/theories/Dot/semtyp_lemmas/examples_lr.v
@@ -6,7 +6,7 @@ From iris.program_logic Require Import language.
 
 From D Require Import iris_prelude succ_notation swap_later_impl proper.
 From D.Dot Require Import rules path_repl.
-From D.Dot Require Import unary_lr later_sub_sem sub_lr fundamental.
+From D.Dot Require Export fundamental dsub_lr.
 
 Implicit Types (Σ : gFunctors).
 Implicit Types (v: vl) (e: tm) (d: dm) (ds: dms) (ρ : env) (l : label).
@@ -186,14 +186,6 @@ Section Lemmas.
     elim: j T => [|j IHj] T; rewrite 1?oLaterN_0 1?oLaterN_Sr ?plusSn.
     apply sSub_Refl.
     iApply sSub_Trans; [iApply IHj|iApply sLater_Sub].
-  Qed.
-
-  Lemma sP_Later {Γ} p T i :
-    Γ s⊨p p : oLater T, i -∗
-    Γ s⊨p p : T, S i.
-  Proof.
-    rewrite (sP_Sub (j := 1) (T1 := oLater T) (T2 := T)) !(plus_comm i 1).
-    iIntros "Hsub"; iApply "Hsub"; iApply sLater_Sub.
   Qed.
 
   Lemma sP_LaterN {Γ i j} p T :

--- a/theories/Dot/semtyp_lemmas/examples_lr.v
+++ b/theories/Dot/semtyp_lemmas/examples_lr.v
@@ -196,6 +196,10 @@ Section Lemmas.
     by rewrite -(IHj (S i)) -sP_Later.
   Qed.
 
+  Lemma sT_Var {Γ x τ} (Hx : Γ !! x = Some τ):
+    ⊢ Γ s⊨ of_val (ids x) : shiftN x τ.
+  Proof. by iApply (sT_Path (p := pv _)); iApply sP_Var. Qed.
+
   Lemma sT_Var0 {Γ T}
     (Hx : Γ !! 0 = Some T):
     (*──────────────────────*)

--- a/theories/Dot/semtyp_lemmas/path_repl_lr.v
+++ b/theories/Dot/semtyp_lemmas/path_repl_lr.v
@@ -158,17 +158,6 @@ Section semantic_lemmas.
     iApply (sem_psubst_one_eq Hrepl Hal with "Hv").
   Qed.
 
-  Lemma sT_Path Γ τ p :
-    Γ s⊨p p : τ, 0 -∗ Γ s⊨ path2tm p : τ.
-  Proof.
-    iIntros "#Hep !> %ρ #Hg /="; rewrite path2tm_subst.
-    by iApply (path_wp_to_wp with "(Hep Hg)").
-  Qed.
-
-  Lemma T_Path Γ T p :
-    Γ ⊨p p : T, 0 -∗ Γ ⊨ path2tm p : T.
-  Proof. apply sT_Path. Qed.
-
   (* From pDOT *)
   Lemma sP_Fld_I Γ p T l i:
     Γ s⊨p pself p l : T, i -∗

--- a/theories/Dot/stamping/skeleton.v
+++ b/theories/Dot/stamping/skeleton.v
@@ -406,6 +406,26 @@ Proof.
   split; [econstructor; eauto | exact: same_skel_fill_item].
 Qed.
 
+Definition same_skel_tm_refl_def : Prop := ∀ e, same_skel_tm e e.
+Definition same_skel_vl_refl_def : Prop := ∀ v, same_skel_vl v v.
+Definition same_skel_dm_refl_def : Prop := ∀ d, same_skel_dm d d.
+Definition same_skel_path_refl_def : Prop := ∀ p, same_skel_path p p.
+Definition same_skel_ty_refl_def : Prop := ∀ T, same_skel_ty T T.
+
+Lemma same_skel_refl :
+  same_skel_tm_refl_def ∧ same_skel_vl_refl_def ∧
+  same_skel_dm_refl_def ∧ same_skel_path_refl_def ∧
+  same_skel_ty_refl_def.
+Proof.
+  apply syntax_mut_ind; try by cbn; intuition.
+  elim => [//|[l d] ds IHds]; rewrite Forall_cons; naive_solver.
+Qed.
+
+Lemma same_skel_refl_tm e : same_skel_tm e e.
+Proof. apply same_skel_refl. Qed.
+Lemma same_skel_refl_dm d : same_skel_dm d d.
+Proof. apply same_skel_refl. Qed.
+
 Definition same_skel_tm_symm_def e1 : Prop := ∀ e2,
   same_skel_tm e1 e2 → same_skel_tm e2 e1.
 Definition same_skel_vl_symm_def v1 : Prop := ∀ v2,

--- a/theories/Dot/stamping/skeleton.v
+++ b/theories/Dot/stamping/skeleton.v
@@ -450,6 +450,49 @@ Qed.
 Lemma same_skel_symm_tm e1 e2: same_skel_tm e1 e2 → same_skel_tm e2 e1.
 Proof. apply same_skel_symm. Qed.
 
+Lemma same_skel_symm_dm d1 d2: same_skel_dm d1 d2 → same_skel_dm d2 d1.
+Proof. apply same_skel_symm. Qed.
+
+Definition same_skel_tm_trans_def e1 : Prop := ∀ e2 e3,
+  same_skel_tm e1 e2 → same_skel_tm e2 e3 → same_skel_tm e1 e3.
+Definition same_skel_vl_trans_def v1 : Prop := ∀ v2 v3,
+  same_skel_vl v1 v2 → same_skel_vl v2 v3 → same_skel_vl v1 v3.
+Definition same_skel_dm_trans_def d1 : Prop := ∀ d2 d3,
+  same_skel_dm d1 d2 → same_skel_dm d2 d3 → same_skel_dm d1 d3.
+Definition same_skel_path_trans_def p1 : Prop := ∀ p2 p3,
+  same_skel_path p1 p2 → same_skel_path p2 p3 → same_skel_path p1 p3.
+Definition same_skel_ty_trans_def T1 : Prop := ∀ T2 T3,
+  same_skel_ty T1 T2 → same_skel_ty T2 T3 → same_skel_ty T1 T3.
+
+Local Lemma same_skel_trans_dms ds1 ds2 ds3 :
+  Forall same_skel_dm_trans_def (map snd ds1) →
+  same_skel_dms ds1 ds2 →
+  same_skel_dms ds2 ds3 →
+  same_skel_dms ds1 ds3.
+Proof.
+  elim: ds1 ds2 ds3 => [|[l1 d1] ds1 IHds1] [|[l2 d2] ds2] [|[l3 d3] ds3] //.
+  rewrite Forall_cons; naive_solver.
+Qed.
+
+Section same_skel_trans.
+  Local Hint Immediate same_skel_trans_dms : core.
+  Local Ltac prepare :=
+    try first [assumption | contradiction | hnf in *]; intuition idtac; subst.
+
+  Lemma same_skel_trans :
+    (∀ t, same_skel_tm_trans_def t) ∧ (∀ v, same_skel_vl_trans_def v) ∧
+    (∀ d, same_skel_dm_trans_def d) ∧ (∀ p, same_skel_path_trans_def p) ∧
+    (∀ T, same_skel_ty_trans_def T).
+  Proof.
+    apply syntax_mut_ind; intros ** E2 E3 **; hnf in *; fold same_skel_dms in *.
+    all: destruct E2, E3; prepare; eauto 2.
+  Qed.
+
+  Lemma same_skel_trans_dm d1 d2 d3 :
+    same_skel_dm d1 d2 → same_skel_dm d2 d3 → same_skel_dm d1 d3.
+  Proof. apply same_skel_trans. Qed.
+End same_skel_trans.
+
 Ltac prim_step_inversion H :=
   destruct (prim_step_inversion H); ev; simplify_eq/=.
 

--- a/theories/Dot/stamping/type_extraction_syn.v
+++ b/theories/Dot/stamping/type_extraction_syn.v
@@ -138,7 +138,7 @@ Proof.
   exists T, T.|[ξ]; split_and!; eauto.
   move: (is_stamped_nclosed_ty HstT) => HclT.
   move: (is_stamped_nclosed_sub Hstξ) => Hclξ.
-  simplify_eq; rewrite (subst_compose _ _ HclT) //.
+  simplify_eq; rewrite (subst_compose HclT) //.
   rewrite !closed_subst_idsρ //. exact: nclosed_sub_app.
 Qed.
 

--- a/theories/Dot/typing/typing.v
+++ b/theories/Dot/typing/typing.v
@@ -1,0 +1,378 @@
+(** * Judgments defining gDOT unstamped typing.
+
+We show that unstamped typing derivations from here can
+be converted to stamped derivations of this typing judgment, in lemma
+[stamp_typing_mut].
+
+This judgment allowing only variables in paths, and not arbitrary values.
+*)
+From D Require Import tactics.
+From D.Dot Require Export syn path_repl lr_syn_aux.
+From D.Dot.typing Require Export typing_aux_defs type_eq.
+From D.Dot.stamping Require Export core_stamping_defs.
+
+Set Implicit Arguments.
+Unset Strict Implicit.
+
+Implicit Types (L T U : ty) (v : vl) (e : tm) (d : dm) (p: path) (ds : dms) (Γ : list ty).
+
+Reserved Notation "Γ t⊢ₜ e : T" (at level 74, e, T at next level).
+Reserved Notation "Γ t⊢ₚ p : T , i" (at level 74, p, T, i at next level).
+Reserved Notation "Γ t⊢{ l := d  } : T" (at level 74, l, d, T at next level).
+Reserved Notation "Γ t⊢ds ds : T" (at level 74, ds, T at next level).
+Reserved Notation "Γ t⊢ₜ T1 <:[ i  ] T2" (at level 74, T1, T2 at next level).
+
+(** ** Judgments for typing, subtyping, path and definition typing. *)
+Inductive typed Γ : tm → ty → Prop :=
+(** First, elimination forms *)
+(** Dependent application; only allowed if the argument is a path. *)
+| iT_All_Ex_p p2 e1 T1 T2:
+    is_unstamped_ty' (S (length Γ)) T2 →
+    Γ t⊢ₜ e1: TAll T1 T2 →
+    Γ t⊢ₚ p2 : T1, 0 →
+    (*────────────────────────────────────────────────────────────*)
+    Γ t⊢ₜ tapp e1 (path2tm p2) : T2 .Tp[ p2 /]
+(** Non-dependent application; allowed for any argument. *)
+| iT_All_E e1 e2 T1 T2:
+    Γ t⊢ₜ e1: TAll T1 (shift T2) →      Γ t⊢ₜ e2 : T1 →
+    (*────────────────────────────────────────────────────────────*)
+    Γ t⊢ₜ tapp e1 e2 : T2
+| iT_Obj_E e T l:
+    Γ t⊢ₜ e : TVMem l T →
+    (*─────────────────────────*)
+    Γ t⊢ₜ tproj e l : T
+(** Introduction forms *)
+| iT_All_I_Strong e T1 T2 Γ':
+    ⊢G Γ >>▷* Γ' →
+    is_unstamped_ty' (length Γ) T1 →
+    (* T1 :: Γ' t⊢ₜ e : T2 → (* Would work, but allows the argument to occur in its own type. *) *)
+    shift T1 :: Γ' t⊢ₜ e : T2 →
+    (*─────────────────────────*)
+    Γ t⊢ₜ tv (vabs e) : TAll T1 T2
+| iT_Obj_I ds T:
+    Γ |L T t⊢ds ds: T →
+    is_unstamped_ty' (S (length Γ)) T →
+    (*──────────────────────*)
+    Γ t⊢ₜ tv (vobj ds): TMu T
+
+(** "General" rules *)
+| iT_Sub e T1 T2 :
+    Γ t⊢ₜ T1 <:[ 0 ] T2 → Γ t⊢ₜ e : T1 →
+    (*───────────────────────────────*)
+    Γ t⊢ₜ e : T2
+| iT_Skip e T :
+    Γ t⊢ₜ e : TLater T →
+    (*───────────────────────────────*)
+    Γ t⊢ₜ tskip e : T
+| iT_Path p T :
+    Γ t⊢ₚ p : T, 0 →
+    (*───────────────────────────────*)
+    Γ t⊢ₜ path2tm p : T
+
+(** Primitives. *)
+| iT_Nat_I n:
+    Γ t⊢ₜ tv (vint n): TInt
+| iT_Bool_I b:
+    Γ t⊢ₜ tv (vbool b): TBool
+| iT_Un u e1 B1 Br (Hu : un_op_syntype u B1 Br) :
+    Γ t⊢ₜ e1 : TPrim B1 →
+    Γ t⊢ₜ tun u e1 : TPrim Br
+| iT_Bin b e1 e2 B1 B2 Br (Hu : bin_op_syntype b B1 B2 Br) :
+    Γ t⊢ₜ e1 : TPrim B1 →
+    Γ t⊢ₜ e2 : TPrim B2 →
+    Γ t⊢ₜ tbin b e1 e2 : TPrim Br
+| iT_If e e1 e2 T :
+    Γ t⊢ₜ e: TBool →
+    Γ t⊢ₜ e1 : T →
+    Γ t⊢ₜ e2 : T →
+    Γ t⊢ₜ tif e e1 e2 : T
+where "Γ t⊢ₜ e : T " := (typed Γ e T)
+with dms_typed Γ : dms → ty → Prop :=
+| iD_Nil : Γ t⊢ds [] : TTop
+(* This demands definitions and members to be defined in aligned lists. *)
+| iD_Cons l d ds T1 T2:
+    Γ t⊢{ l := d } : T1 →
+    Γ t⊢ds ds : T2 →
+    dms_hasnt ds l →
+    (*──────────────────────*)
+    Γ t⊢ds (l, d) :: ds : TAnd T1 T2
+where "Γ t⊢ds ds : T" := (dms_typed Γ ds T)
+with dm_typed Γ : label → dm → ty → Prop :=
+| iD_Typ_Abs T l L U:
+    (* To drop *)
+    is_unstamped_ty' (length Γ) T →
+    (* To keep *)
+    nclosed T (length Γ) →
+    Γ t⊢ₜ L <:[0] TLater T →
+    Γ t⊢ₜ TLater T <:[0] U →
+    Γ t⊢{ l := dtysyn T } : TTMem l L U
+| iD_Val l v T:
+    Γ t⊢ₜ tv v : T →
+    Γ t⊢{ l := dpt (pv v) } : TVMem l T
+| iD_Path l p T:
+    Γ t⊢ₚ p : T, 0 →
+    Γ t⊢{ l := dpt p } : TVMem l T
+| iD_Val_New l T ds:
+    TAnd (TLater T) (TSing (pself (pv (ids 1)) l)) :: Γ t⊢ds ds : T →
+    is_unstamped_ty' (S (length Γ)) T →
+    Γ t⊢{ l := dpt (pv (vobj ds)) } : TVMem l (TMu T)
+| iD_Path_Sub T1 T2 p l:
+    Γ t⊢ₜ T1 <:[0] T2 →
+    Γ t⊢{ l := dpt p } : TVMem l T1 →
+    Γ t⊢{ l := dpt p } : TVMem l T2
+where "Γ t⊢{ l := d  } : T" := (dm_typed Γ l d T)
+with path_typed Γ : path → ty → nat → Prop :=
+| iP_Var x T:
+    Γ !! x = Some T →
+    (* After looking up in Γ, we must weaken T for the variables on top of x. *)
+    Γ t⊢ₚ pv (var_vl x) : shiftN x T, 0
+(* Mnemonic: Path from SELecting a Field *)
+| iP_Fld_E p T i l:
+    Γ t⊢ₚ p : TVMem l T, i →
+    Γ t⊢ₚ pself p l : T, i
+| iP_Sub p T1 T2 i :
+    Γ t⊢ₜ T1 <:[i] T2 →
+    Γ t⊢ₚ p : T1, i →
+    (*───────────────────────────────*)
+    Γ t⊢ₚ p : T2, i
+| iP_Later p T i :
+    Γ t⊢ₚ p : TLater T, i →
+    (*───────────────────────────────*)
+    Γ t⊢ₚ p : T, S i
+| iP_Mu_I p T {i} :
+    is_unstamped_ty' (S (length Γ)) T →
+    Γ t⊢ₚ p : T .Tp[ p /], i →
+    Γ t⊢ₚ p : TMu T, i
+| iP_Mu_E p T {i} :
+    is_unstamped_ty' (S (length Γ)) T →
+    Γ t⊢ₚ p : TMu T, i →
+    Γ t⊢ₚ p : T .Tp[ p /], i
+| iP_Fld_I p T i l:
+    Γ t⊢ₚ pself p l : T, i →
+    (*─────────────────────────*)
+    Γ t⊢ₚ p : TVMem l T, i
+| iP_Sngl_Refl T p i :
+    Γ t⊢ₚ p : T, i →
+    Γ t⊢ₚ p : TSing p, i
+| iP_Sngl_Inv p q i:
+    Γ t⊢ₚ p : TSing q, i →
+    is_unstamped_path' (length Γ) q →
+    Γ t⊢ₚ q : TTop, i
+| iP_Sngl_Trans p q T i:
+    Γ t⊢ₚ p : TSing q, i →
+    Γ t⊢ₚ q : T, i →
+    Γ t⊢ₚ p : T, i
+| iP_Sngl_E T p q l i:
+    Γ t⊢ₚ p : TSing q, i →
+    Γ t⊢ₚ pself q l : T, i →
+    Γ t⊢ₚ pself p l : TSing (pself q l), i
+where "Γ t⊢ₚ p : T , i" := (path_typed Γ p T i)
+with subtype Γ : nat → ty → ty → Prop :=
+| iStp_Refl i T :
+    is_unstamped_ty' (length Γ) T →
+    Γ t⊢ₜ T <:[i] T
+| iStp_Trans T2 {i T1 T3}:
+    Γ t⊢ₜ T1 <:[i] T2 →
+    Γ t⊢ₜ T2 <:[i] T3 →
+    Γ t⊢ₜ T1 <:[i] T3
+| iLater_Idx_Stp i T1 T2: (* XXX name *)
+    Γ t⊢ₜ T1 <:[S i] T2 →
+    Γ t⊢ₜ TLater T1 <:[i] TLater T2
+| iIdx_Later_Stp i T1 T2: (* XXX name*)
+    Γ t⊢ₜ TLater T1 <:[i] TLater T2 →
+    Γ t⊢ₜ T1 <:[S i] T2
+
+(* "Structural" rule about indexes *)
+| iStp_Add_Later T i:
+    is_unstamped_ty' (length Γ) T →
+    Γ t⊢ₜ T <:[i] TLater T
+
+(* "Logical" connectives *)
+| iStp_Top i T :
+    is_unstamped_ty' (length Γ) T →
+    Γ t⊢ₜ T <:[i] TTop
+| iBot_Stp i T :
+    is_unstamped_ty' (length Γ) T →
+    Γ t⊢ₜ TBot <:[i] T
+| iAnd1_Stp T1 T2 i:
+    is_unstamped_ty' (length Γ) T1 →
+    is_unstamped_ty' (length Γ) T2 →
+    Γ t⊢ₜ TAnd T1 T2 <:[i] T1
+| iAnd2_Stp T1 T2 i:
+    is_unstamped_ty' (length Γ) T1 →
+    is_unstamped_ty' (length Γ) T2 →
+    Γ t⊢ₜ TAnd T1 T2 <:[i] T2
+| iStp_And T U1 U2 i:
+    Γ t⊢ₜ T <:[i] U1 →
+    Γ t⊢ₜ T <:[i] U2 →
+    Γ t⊢ₜ T <:[i] TAnd U1 U2
+| iStp_Or1 T1 T2 i:
+    is_unstamped_ty' (length Γ) T1 →
+    is_unstamped_ty' (length Γ) T2 →
+    Γ t⊢ₜ T1 <:[i] TOr T1 T2
+| iStp_Or2 T1 T2 i:
+    is_unstamped_ty' (length Γ) T1 →
+    is_unstamped_ty' (length Γ) T2 →
+    Γ t⊢ₜ T2 <:[i] TOr T1 T2
+| iOr_Stp T1 T2 U i:
+    Γ t⊢ₜ T1 <:[i] U →
+    Γ t⊢ₜ T2 <:[i] U →
+    Γ t⊢ₜ TOr T1 T2 <:[i] U
+
+(* Type selections *)
+| iSel_Stp p L {l U i}:
+    Γ t⊢ₚ p : TTMem l L U, i →
+    Γ t⊢ₜ TSel p l <:[i] U
+| iStp_Sel p U {l L i}:
+    Γ t⊢ₚ p : TTMem l L U, i →
+    Γ t⊢ₜ L <:[i] TSel p l
+
+| iSngl_pq_Stp p q {i T1 T2}:
+    T1 ~Tp[ p := q ]* T2 →
+    is_unstamped_ty' (length Γ) T1 →
+    is_unstamped_ty' (length Γ) T2 →
+    Γ t⊢ₚ p : TSing q, i →
+    Γ t⊢ₜ T1 <:[i] T2
+| iSngl_Stp_Sym T {p q i}:
+    Γ t⊢ₚ p : T, i →
+    Γ t⊢ₜ TSing p <:[i] TSing q →
+    Γ t⊢ₜ TSing q <:[i] TSing p
+| iSngl_Stp_Self {p T i} :
+    Γ t⊢ₚ p : T, i →
+    Γ t⊢ₜ TSing p <:[i] T
+
+(* Subtyping for recursive types. Congruence, and opening in both directions. *)
+| iMu_Stp_Mu T1 T2 i:
+    (iterate TLater i T1 :: Γ) t⊢ₜ T1 <:[i] T2 →
+    is_unstamped_ty' (S (length Γ)) T1 →
+    Γ t⊢ₜ TMu T1 <:[i] TMu T2
+| iMu_Stp T i:
+    is_unstamped_ty' (length Γ) T →
+    Γ t⊢ₜ TMu (shift T) <:[i] T
+| iStp_Mu T i:
+    is_unstamped_ty' (length Γ) T →
+    Γ t⊢ₜ T <:[i] TMu (shift T)
+
+(* "Congruence" or "variance" rules for subtyping. Unneeded for "logical" types. *)
+| iAll_Stp_All T1 T2 U1 U2 i:
+    Γ t⊢ₜ TLater T2 <:[i] TLater T1 →
+    iterate TLater (S i) (shift T2) :: Γ t⊢ₜ TLater U1 <:[i] TLater U2 →
+    is_unstamped_ty' (length Γ) T2 →
+    Γ t⊢ₜ TAll T1 U1 <:[i] TAll T2 U2
+| iFld_Stp_Fld T1 T2 i l:
+    Γ t⊢ₜ T1 <:[i] T2 →
+    Γ t⊢ₜ TVMem l T1 <:[i] TVMem l T2
+| iTyp_Stp_Typ L1 L2 U1 U2 i l:
+    Γ t⊢ₜ L2 <:[i] L1 →
+    Γ t⊢ₜ U1 <:[i] U2 →
+    Γ t⊢ₜ TTMem l L1 U1 <:[i] TTMem l L2 U2
+  (* Is it true that for covariant F, F[A ∧ B] = F[A] ∧ F[B]?
+    Dotty assumes that, tho DOT didn't capture it.
+    F[A ∧ B] <:[i] F[A] ∧ F[B] is provable by covariance.
+    Let's prove F[A] ∧ F[B] <:[i] F[A ∧ B] in the model.
+    *)
+| iAnd_All_Stp_Distr T U1 U2 i:
+    is_unstamped_ty' (length Γ) T →
+    is_unstamped_ty' (S (length Γ)) U1 →
+    is_unstamped_ty' (S (length Γ)) U2 →
+    Γ t⊢ₜ TAnd (TAll T U1) (TAll T U2) <:[i] TAll T (TAnd U1 U2)
+| iAnd_Fld_Stp_Distr l T1 T2 i:
+    is_unstamped_ty' (length Γ) T1 →
+    is_unstamped_ty' (length Γ) T2 →
+    Γ t⊢ₜ TAnd (TVMem l T1) (TVMem l T2) <:[i] TVMem l (TAnd T1 T2)
+| iAnd_Typ_Stp_Distr l L U1 U2 i:
+    is_unstamped_ty' (length Γ) L →
+    is_unstamped_ty' (length Γ) U1 →
+    is_unstamped_ty' (length Γ) U2 →
+    Γ t⊢ₜ TAnd (TTMem l L U1) (TTMem l L U2) <:[i] TTMem l L (TAnd U1 U2)
+| iDistr_And_Or_Stp {S T U i}:
+    is_unstamped_ty' (length Γ) S →
+    is_unstamped_ty' (length Γ) T →
+    is_unstamped_ty' (length Γ) U →
+    Γ t⊢ₜ TAnd (TOr S T) U  <:[i] TOr (TAnd S U) (TAnd T U)
+| iStp_Eq i T1 T2 :
+    |- T1 == T2 →
+    Γ t⊢ₜ T1 <:[i] T2
+
+where "Γ t⊢ₜ T1 <:[ i  ] T2"  := (subtype Γ i T1 T2).
+
+(* Make [T] first argument: Hide Γ for e.g. typing examples. *)
+Global Arguments iD_Typ_Abs {Γ} T _ _ _ _ _ _ _ : assert.
+
+Scheme typed_mut_ind := Induction for typed Sort Prop
+with   dms_typed_mut_ind := Induction for dms_typed Sort Prop
+with   dm_typed_mut_ind := Induction for dm_typed Sort Prop
+with   path_typed_mut_ind := Induction for path_typed Sort Prop
+with   subtype_mut_ind := Induction for subtype Sort Prop.
+
+Combined Scheme typing_mut_ind from typed_mut_ind, dms_typed_mut_ind, dm_typed_mut_ind,
+  path_typed_mut_ind, subtype_mut_ind.
+
+Scheme exp_typed_mut_ind := Induction for typed Sort Prop
+with   exp_dms_typed_mut_ind := Induction for dms_typed Sort Prop
+with   exp_dm_typed_mut_ind := Induction for dm_typed Sort Prop
+with   exp_path_typed_mut_ind := Induction for path_typed Sort Prop.
+
+Combined Scheme exp_typing_mut_ind from exp_typed_mut_ind, exp_dms_typed_mut_ind,
+  exp_dm_typed_mut_ind, exp_path_typed_mut_ind.
+
+Lemma unstamped_path_root_is_var Γ p T i:
+  Γ t⊢ₚ p : T, i → ∃ x, path_root p = var_vl x.
+Proof. by elim; intros; cbn; eauto 2 using is_unstamped_path_root. Qed.
+
+Lemma dtysem_not_utyped Γ l d T :
+  Γ t⊢{ l := d } : T → ∀ σ s, d ≠ dtysem σ s.
+Proof. by case. Qed.
+
+(** ** A few derived rules, and some automation to use them in examples. *)
+
+Hint Constructors typed dms_typed dm_typed path_typed subtype : core.
+
+(** Ensure [eauto]'s proof search does not diverge due to transitivity. *)
+Remove Hints iStp_Trans : core.
+Hint Extern 10 => try_once iStp_Trans : core.
+
+Lemma iT_Var Γ x T
+  (Hl : Γ !! x = Some T) :
+  Γ t⊢ₜ tv (var_vl x) : shiftN x T.
+Proof. intros. apply (iT_Path (p := pv _)), iP_Var, Hl. Qed.
+
+Lemma iT_All_I Γ e T1 T2:
+  is_unstamped_ty' (length Γ) T1 →
+  shift T1 :: Γ t⊢ₜ e : T2 →
+  (*─────────────────────────*)
+  Γ t⊢ₜ tv (vabs e) : TAll T1 T2.
+Proof. apply iT_All_I_Strong. ietp_weaken_ctx. Qed.
+
+Lemma iT_All_I_strip1 Γ e V T1 T2:
+  is_unstamped_ty' (S (length Γ)) T1 →
+  shift T1 :: V :: Γ t⊢ₜ e : T2 →
+  (*─────────────────────────*)
+  Γ |L V t⊢ₜ tv (vabs e) : TAll T1 T2.
+Proof.
+  intros. apply iT_All_I_Strong with (Γ' := (V :: Γ)) => //.
+  rewrite /defCtxCons/=; ietp_weaken_ctx.
+Qed.
+
+Lemma iD_All Γ V T1 T2 e l:
+  is_unstamped_ty' (S (length Γ)) T1 →
+  shift T1 :: V :: Γ t⊢ₜ e : T2 →
+  Γ |L V t⊢{ l := dpt (pv (vabs e)) } : TVMem l (TAll T1 T2).
+Proof. by intros; apply iD_Val, iT_All_I_strip1. Qed.
+
+Ltac ettrans := eapply iStp_Trans.
+
+(* Old names: *)
+Definition Sub_later_shift := iLater_Idx_Stp.
+Definition Sub_later_shift_inv := iIdx_Later_Stp.
+
+Ltac typconstructor :=
+  match goal with
+  | |- typed _ _ _ =>
+    first [apply iT_Var | apply iT_All_I_strip1 | apply iT_All_I | constructor]
+  | |- dms_typed _ _ _ => constructor
+  | |- dm_typed _ _ _ _ => first [apply iD_All | constructor]
+  | |- path_typed _ _ _ _ => first [apply iP_Later | constructor]
+  | |- subtype _ _ _ _ _ =>
+    first [apply Sub_later_shift | constructor ]
+  end.

--- a/theories/asubst_base.v
+++ b/theories/asubst_base.v
@@ -65,7 +65,6 @@ Definition nclosed `{HSubst vl X} (x : X) n :=
   ∀ ρ1 ρ2, eq_n_s ρ1 ρ2 n → x.|[ρ1] = x.|[ρ2].
 
 Notation nclosed_σ σ n := (Forall (λ v, nclosed_vl v n) σ).
-Notation cl_ρ σ := (nclosed_σ σ 0).
 
 (** Infrastructure to prove "direct" lemmas on [nclosed{,_vl}]: deduce that an expression is closed
     by knowing that its subexpression are closed. *)
@@ -326,8 +325,6 @@ Qed.
 
 Lemma lookup_ids_fv {X} {Γ : list X} {i} {T: X}: Γ !! i = Some T → nclosed_vl (ids i) (length Γ).
 Proof. move => ????; rewrite /= !id_subst. eauto using lookup_lt_Some. Qed.
-
-Definition cl_ρ_fv: ∀ σ, cl_ρ σ → nclosed σ 0 := @Forall_to_closed_vls 0.
 
 Lemma to_subst_compose σ ρ:
   eq_n_s (∞ σ.|[ρ]) (∞ σ >> ρ) (length σ).

--- a/theories/asubst_base.v
+++ b/theories/asubst_base.v
@@ -36,9 +36,6 @@ Implicit Types (v w : vl) (vs σ : vls) (i j k n : nat)
 
 Definition subst_sigma σ vs := σ.|[∞ vs].
 
-Definition eq_n_s ρ1 ρ2 n := ∀ x, x < n → ρ1 x = ρ2 x.
-Global Arguments eq_n_s /.
-
 Lemma eq_n_s_symm ρ1 ρ2 n : eq_n_s ρ1 ρ2 n → eq_n_s ρ2 ρ1 n.
 Proof. move => Heqs x ?. symmetry. exact: Heqs. Qed.
 
@@ -54,15 +51,6 @@ Fixpoint idsσ n : vls :=
   | 0 => []
   | S n => push_var (idsσ n)
   end.
-
-(** [n]-closedness defines when some AST has at most [n] free variables (from [0] to [n - 1]). *)
-(** Here and elsewhere, we give one definition for values, using [subst], and
-    another for other ASTs, using [hsubst]. *)
-Definition nclosed_vl (v : vl) n :=
-  ∀ ρ1 ρ2, eq_n_s ρ1 ρ2 n → v.[ρ1] = v.[ρ2].
-
-Definition nclosed `{HSubst vl X} (x : X) n :=
-  ∀ ρ1 ρ2, eq_n_s ρ1 ρ2 n → x.|[ρ1] = x.|[ρ2].
 
 Notation nclosed_σ σ n := (Forall (λ v, nclosed_vl v n) σ).
 
@@ -326,13 +314,6 @@ Qed.
 Lemma lookup_ids_fv {X} {Γ : list X} {i} {T: X}: Γ !! i = Some T → nclosed_vl (ids i) (length Γ).
 Proof. move => ????; rewrite /= !id_subst. eauto using lookup_lt_Some. Qed.
 
-Lemma to_subst_compose σ ρ:
-  eq_n_s (∞ σ.|[ρ]) (∞ σ >> ρ) (length σ).
-Proof.
-  elim: σ => /= [|v σ IHσ] i Hin; first lia; asimpl.
-  case: i Hin => [//|i] /lt_S_n Hin /=. exact: IHσ.
-Qed.
-
 Lemma fv_cons_inv_v v vs n : nclosed (v :: vs) n → nclosed_vl v n /\ nclosed vs n.
 Proof. intros Hcl; split; solve_inv_fv_congruence_h Hcl. Qed.
 
@@ -452,11 +433,6 @@ Proof. elim: xs => /= [//|x xs IHxs] /fv_cons_inv [Hclx Hclxs]. auto. Qed.
 
 Lemma nclosed_xs_eq_nclosed n xs: nclosed_xs xs n ↔ nclosed xs n.
 Proof. split; eauto using Forall_to_closed_xs, closed_xs_to_Forall. Qed.
-
-Lemma subst_compose x σ ξ n :
-  nclosed x n → length σ = n →
-  x.|[∞ σ.|[ξ]] = x.|[∞ σ].|[ξ].
-Proof. intros Hclx <-; asimpl. apply Hclx, to_subst_compose. Qed.
 
 Lemma nclosed_mono x n m:
   nclosed x n → n <= m → nclosed x m.

--- a/theories/asubst_intf.v
+++ b/theories/asubst_intf.v
@@ -46,88 +46,6 @@ Module Type ValuesSig.
   Parameter hsubst_of_val : ∀ (v : vl) s, (of_val v).|[s] = of_val (v.[s]).
 End ValuesSig.
 
-(** ** This module type contains minimal infrastructure for D*-languages.
-It is a "mixin module": that is, it is [Include]d (indirectly) in each language
-implementing [ValuesSig], yet functors can abstract over implementing modules.
-Mixin module [Sorts] in [asubst_base] defines additional infrastructure.
-*)
-Module Type SortsSig (Import V : ValuesSig).
-  Definition vls := list vl.
-  Definition env := var → vl.
-
-  Implicit Types (v : vl) (vs σ : vls) (ρ : env).
-
-  Fixpoint to_subst σ : var → vl :=
-    match σ with
-    | [] => ids
-    | v :: σ => v .: to_subst σ
-    end.
-  (* Tighter precedence than [>>], which has level 56. *)
-  Notation "∞ σ" := (to_subst σ) (at level 50).
-
-  Definition to_subst_nil : ∞ [] = ids := reflexivity _.
-
-  Definition to_subst_cons v σ : ∞ (v :: σ) = v .: ∞ σ :=
-    reflexivity _.
-
-  Definition stail ρ := (+1) >>> ρ.
-  Definition shead ρ := ρ 0.
-
-  Lemma shead_eq v ρ: shead (v .: ρ) = v. Proof. done. Qed.
-  Lemma stail_eq v ρ: stail (v .: ρ) = ρ. Proof. done. Qed.
-
-  (* This class describes a syntactic sort that supports substituting values. *)
-  Class Sort (s : Type)
-    {inh_s : Inhabited s}
-    {ids_s : Ids s} {ren_s : Rename s} {hsubst_vl_s : HSubst vl s}
-    {hsubst_lemmas_vl_s : HSubstLemmas vl s} := {}.
-
-  (** Some hand-written rewriting lemmas, designed to replace
-      certain common and slow uses of [autosubst]. *)
-  Lemma scons_up_swap a sb1 sb2 : a .: sb1 >> sb2 = up sb1 >> a .: sb2.
-  Proof.
-    (* Reverse-engineered from autosubst output. *)
-    rewrite upX /ren /scomp scons_comp;
-      fsimpl; rewrite subst_compX; by fsimpl; rewrite id_scompX id_subst.
-  Qed.
-  (* Rewrite lemmas to be faster than asimpl: *)
-  Lemma renS_comp n : ren (+S n) = ren (+n) >> ren (+1).
-  Proof. rewrite /ren/scomp. fsimpl. by rewrite (id_scompX ((+1) >>> ids)). Qed.
-
-  Lemma subst_swap_base v ρ : v.[ρ] .: ρ = (v .: ids) >> ρ.
-  Proof.
-    rewrite /scomp scons_comp. (* Actual swap *)
-    by rewrite id_scompX. (* Cleanup result of manipulation *)
-  Qed.
-
-  Lemma shift_sub_vl v w: (shiftV v).[w/] = v.
-  Proof.
-    rewrite subst_comp -{2}(subst_id v) /ren /scomp; fsimpl; by rewrite id_scompX.
-  Qed.
-
-  Section sort_lemmas.
-    Context `{_HsX: Sort X}.
-    Implicit Types (x : X).
-
-    Lemma hrenS `{Sort X} (x : X) n : shiftN (S n) x = shift (shiftN n x).
-    Proof. rewrite hsubst_comp renS_comp. by []. Qed.
-
-    Lemma shift_sub `{Sort X} {x : X} v: (shift x).|[v/] = x.
-    Proof.
-      by rewrite hsubst_comp -{2}(hsubst_id x) /ren /scomp; fsimpl;
-        rewrite id_scompX.
-    Qed.
-  End sort_lemmas.
-End SortsSig.
-
-(** [VlSortsSig] mixes in [ValuesSig] and [SortsSig], and most infrastructure
-is defined in functors abstracting over [VlSortsSig].
-Module [VlSortsFullSig] in [asubst_base] defines additional infrastructure, but
-to minimize compile-time dependencies, most such functors should abstract over
-[VlSortsSig] and not [VlSortsFullSig].
-*)
-Module Type VlSortsSig := ValuesSig <+ SortsSig.
-
 (** Autosubst extensions, and utilities useful when defining languages and implementing
 [ValuesSig]. *)
 Module ASubstLangDefUtils.
@@ -231,3 +149,85 @@ Hint Mode HSubst - + : typeclass_instances.
 (* Fail Goal ∀ s x, x.|[s] = x. *)
 (* Goal ∀ s (x : ty), x.|[s] = x. Abort. *)
 End ASubstLangDefUtils.
+
+(** ** This module type contains minimal infrastructure for D*-languages.
+It is a "mixin module": that is, it is [Include]d (indirectly) in each language
+implementing [ValuesSig], yet functors can abstract over implementing modules.
+Mixin module [Sorts] in [asubst_base] defines additional infrastructure.
+*)
+Module Type SortsSig (Import V : ValuesSig).
+  Definition vls := list vl.
+  Definition env := var → vl.
+
+  Implicit Types (v : vl) (vs σ : vls) (ρ : env).
+
+  Fixpoint to_subst σ : var → vl :=
+    match σ with
+    | [] => ids
+    | v :: σ => v .: to_subst σ
+    end.
+  (* Tighter precedence than [>>], which has level 56. *)
+  Notation "∞ σ" := (to_subst σ) (at level 50).
+
+  Definition to_subst_nil : ∞ [] = ids := reflexivity _.
+
+  Definition to_subst_cons v σ : ∞ (v :: σ) = v .: ∞ σ :=
+    reflexivity _.
+
+  Definition stail ρ := (+1) >>> ρ.
+  Definition shead ρ := ρ 0.
+
+  Lemma shead_eq v ρ: shead (v .: ρ) = v. Proof. done. Qed.
+  Lemma stail_eq v ρ: stail (v .: ρ) = ρ. Proof. done. Qed.
+
+  (* This class describes a syntactic sort that supports substituting values. *)
+  Class Sort (s : Type)
+    {inh_s : Inhabited s}
+    {ids_s : Ids s} {ren_s : Rename s} {hsubst_vl_s : HSubst vl s}
+    {hsubst_lemmas_vl_s : HSubstLemmas vl s} := {}.
+
+  (** Some hand-written rewriting lemmas, designed to replace
+      certain common and slow uses of [autosubst]. *)
+  Lemma scons_up_swap a sb1 sb2 : a .: sb1 >> sb2 = up sb1 >> a .: sb2.
+  Proof.
+    (* Reverse-engineered from autosubst output. *)
+    rewrite upX /ren /scomp scons_comp;
+      fsimpl; rewrite subst_compX; by fsimpl; rewrite id_scompX id_subst.
+  Qed.
+  (* Rewrite lemmas to be faster than asimpl: *)
+  Lemma renS_comp n : ren (+S n) = ren (+n) >> ren (+1).
+  Proof. rewrite /ren/scomp. fsimpl. by rewrite (id_scompX ((+1) >>> ids)). Qed.
+
+  Lemma subst_swap_base v ρ : v.[ρ] .: ρ = (v .: ids) >> ρ.
+  Proof.
+    rewrite /scomp scons_comp. (* Actual swap *)
+    by rewrite id_scompX. (* Cleanup result of manipulation *)
+  Qed.
+
+  Lemma shift_sub_vl v w: (shiftV v).[w/] = v.
+  Proof.
+    rewrite subst_comp -{2}(subst_id v) /ren /scomp; fsimpl; by rewrite id_scompX.
+  Qed.
+
+  Section sort_lemmas.
+    Context `{_HsX: Sort X}.
+    Implicit Types (x : X).
+
+    Lemma hrenS `{Sort X} (x : X) n : shiftN (S n) x = shift (shiftN n x).
+    Proof. rewrite hsubst_comp renS_comp. by []. Qed.
+
+    Lemma shift_sub `{Sort X} {x : X} v: (shift x).|[v/] = x.
+    Proof.
+      by rewrite hsubst_comp -{2}(hsubst_id x) /ren /scomp; fsimpl;
+        rewrite id_scompX.
+    Qed.
+  End sort_lemmas.
+End SortsSig.
+
+(** [VlSortsSig] mixes in [ValuesSig] and [SortsSig], and most infrastructure
+is defined in functors abstracting over [VlSortsSig].
+Module [VlSortsFullSig] in [asubst_base] defines additional infrastructure, but
+to minimize compile-time dependencies, most such functors should abstract over
+[VlSortsSig] and not [VlSortsFullSig].
+*)
+Module Type VlSortsSig := ValuesSig <+ SortsSig.

--- a/theories/asubst_intf.v
+++ b/theories/asubst_intf.v
@@ -177,6 +177,25 @@ Module Type SortsSig (Import V : ValuesSig).
   Definition stail ρ := (+1) >>> ρ.
   Definition shead ρ := ρ 0.
 
+  Definition eq_n_s ρ1 ρ2 n := ∀ x, x < n → ρ1 x = ρ2 x.
+  Global Arguments eq_n_s /.
+
+  Lemma to_subst_compose σ ρ:
+    eq_n_s (∞ σ.|[ρ]) (∞ σ >> ρ) (length σ).
+  Proof.
+    elim: σ => /= [|v σ IHσ] i Hin; first lia; asimpl.
+    case: i Hin => [//|i] /lt_S_n Hin /=. exact: IHσ.
+  Qed.
+
+  (** [n]-closedness defines when some AST has at most [n] free variables (from [0] to [n - 1]). *)
+  (** Here and elsewhere, we give one definition for values, using [subst], and
+      another for other ASTs, using [hsubst]. *)
+  Definition nclosed_vl (v : vl) n :=
+    ∀ ρ1 ρ2, eq_n_s ρ1 ρ2 n → v.[ρ1] = v.[ρ2].
+
+  Definition nclosed `{HSubst vl X} (x : X) n :=
+    ∀ ρ1 ρ2, eq_n_s ρ1 ρ2 n → x.|[ρ1] = x.|[ρ2].
+
   Lemma shead_eq v ρ: shead (v .: ρ) = v. Proof. done. Qed.
   Lemma stail_eq v ρ: stail (v .: ρ) = ρ. Proof. done. Qed.
 
@@ -221,6 +240,11 @@ Module Type SortsSig (Import V : ValuesSig).
       by rewrite hsubst_comp -{2}(hsubst_id x) /ren /scomp; fsimpl;
         rewrite id_scompX.
     Qed.
+
+    Lemma subst_compose {x σ ξ n} :
+      nclosed x n → length σ = n →
+      x.|[∞ σ.|[ξ]] = x.|[∞ σ].|[ξ].
+    Proof. intros Hclx <-; asimpl. apply Hclx, to_subst_compose. Qed.
   End sort_lemmas.
 End SortsSig.
 

--- a/theories/iris_extra/det_reduction.v
+++ b/theories/iris_extra/det_reduction.v
@@ -73,6 +73,9 @@ Definition safe_gen {Λ} (e : L.expr Λ) :=
 Definition safe `{LangDet Λ} (e : L.expr Λ) :=
   ∀ e', rtc pure_step e e' → not_stuck e'.
 
+Definition safe_n `{InhabitedState Λ} n e1 :=
+  ∀ e2, nsteps pure_step n e1 e2 → not_stuck e2.
+
 Hint Constructors rtc : core.
 
 Section LangDet.

--- a/theories/iris_extra/lty.v
+++ b/theories/iris_extra/lty.v
@@ -234,6 +234,20 @@ Section olty_subst.
     φ.|[v/] args ρ ≡ φ args (v.[ρ] .: ρ).
   Proof. apply hoEnvD_subst_compose. autosubst. Qed.
 
+  (* XXX these alternative statements infer (@ids vl ρ] [*)
+  (* Lemma hoEnvD_subst_ids φ ρ {args} : φ args ρ ≡ φ.|[ρ] args ids. *)
+  (* Program Lemma hoEnvD_subst_ids φ ρ {args} : φ args ρ ≡ φ.|[ρ] args ids. *)
+  Lemma hoEnvD_subst_ids φ ρ {args} : φ args ρ ≡ φ.|[ρ] args (@ids vl ids_vl).
+  Proof. symmetry. apply hoEnvD_subst_compose. autosubst. Qed.
+
+  Lemma hoEnvD_finsubst_commute_cl φ σ ρ v (HclT : nclosed φ (length σ)) args :
+    φ.|[∞ σ] args ρ v ≡ φ args (∞ σ.|[ρ]) v.
+  Proof.
+    rewrite hoEnvD_subst_compose_ind !(hoEnvD_subst_ids φ) -hsubst_comp.
+    (* *The* step requiring [HclT]. *)
+    by rewrite (subst_compose HclT).
+  Qed.
+
   Definition Olty (olty_car : vec vl i → (var → vl) → vl → iProp Σ)
    `{∀ args ρ v, Persistent (olty_car args ρ v)}: oltyO Σ i :=
     λ args ρ, Lty (olty_car args ρ).
@@ -259,8 +273,6 @@ Section olty_subst.
   Global Instance hsubst_olty_proper ρ :
     Proper ((≡) ==> (≡)) (hsubst (outer := oltyO Σ i) ρ) := ne_proper _.
 
-  (* Currently unused; currently, we simplify and use the [hoEnvD_] lemmas.*)
-(*
   Lemma olty_subst_compose_ind τ args ρ1 ρ2 v: τ.|[ρ1] args ρ2 v ⊣⊢ τ args (ρ1 >> ρ2) v.
   Proof. apply hoEnvD_subst_compose_ind. Qed.
 
@@ -274,7 +286,18 @@ Section olty_subst.
 
   Lemma olty_subst_one τ v w args ρ:
     τ.|[v/] args ρ w ≡ τ args (v.[ρ] .: ρ) w.
-  Proof. apply hoEnvD_subst_one. Qed. *)
+  Proof. apply hoEnvD_subst_one. Qed.
+
+  Lemma olty_subst_ids τ ρ {args} : τ args ρ ≡ τ.|[ρ] args ids.
+  Proof. symmetry. apply olty_subst_compose. autosubst. Qed.
+
+  Lemma olty_finsubst_commute_cl τ σ ρ v (HclT : nclosed τ (length σ)) args :
+    τ.|[∞ σ] args ρ v ≡ τ args (∞ σ.|[ρ]) v.
+  Proof.
+    rewrite olty_subst_compose_ind !(olty_subst_ids τ) -hsubst_comp.
+    (* *The* step requiring [HclT]. *)
+    by rewrite (subst_compose HclT).
+  Qed.
 
   (** Shift a type; [oShift T] and [shift T] have different reduction
   behavior. *)

--- a/theories/pure_program_logic/adequacy.v
+++ b/theories/pure_program_logic/adequacy.v
@@ -68,6 +68,10 @@ Proof.
   iNext.
   iApply (wp_safe with "H").
 Qed.
+
+Lemma wptp_safe_n n e1 Φ :
+  WP e1 {{ Φ }} -∗ ▷^n ⌜safe_n n e1⌝.
+Proof. iIntros "Hwp" (e2 Hsteps); by iApply wptp_safe. Qed.
 End adequacy.
 
 Theorem wp_adequacy {Σ Λ} e φ `{LangDet Λ} :


### PR DESCRIPTION
Refactorings needed for #258.
This even includes adequacy of the new unstamped semantic typing judgments in 228e73db3f0544d02ad59a87c25dbb66e390d495.