### PR TITLE
Separate subtyping and path typing from expression typing

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -72,6 +72,7 @@ theories/Dot/typing/typing_aux_defs.v
 theories/Dot/typing/typing_stamping.v
 theories/Dot/typing/typing_stamping_regularity.v
 theories/Dot/typing/old_subtyping.v
+theories/Dot/typing/old_subtyping_derived_rules.v
 theories/Dot/typing/old_unstamped_typing.v
 theories/Dot/typing/old_unstamped_typing_derived_rules.v
 

--- a/_CoqProject
+++ b/_CoqProject
@@ -71,6 +71,7 @@ theories/Dot/typing/storeless_typing.v
 theories/Dot/typing/typing_aux_defs.v
 theories/Dot/typing/typing_stamping.v
 theories/Dot/typing/typing_stamping_regularity.v
+theories/Dot/typing/old_subtyping.v
 theories/Dot/typing/old_unstamped_typing.v
 theories/Dot/typing/old_unstamped_typing_derived_rules.v
 

--- a/theories/DSub/typing/ds_obj_ident_typing.v
+++ b/theories/DSub/typing/ds_obj_ident_typing.v
@@ -17,7 +17,7 @@ Inductive typed Γ : tm → ty → Prop :=
 | iT_All_Ex e1 x2 T1 T2:
     Γ u⊢ₜ e1: TAll T1 T2 →                        Γ u⊢ₜ tv (var_vl x2) : T1 →
     (*────────────────────────────────────────────────────────────*)
-    Γ u⊢ₜ tapp e1 (tv (var_vl x2)) : T2.|[(var_vl x2)/]
+    Γ u⊢ₜ tapp e1 (tv (var_vl x2)) : T2.|[var_vl x2/]
 (** Non-dependent application; allowed for any argument. *)
 | iT_All_E e1 e2 T1 T2:
     Γ u⊢ₜ e1: TAll T1 (shift T2) →      Γ u⊢ₜ e2 : T1 →

--- a/theories/Dot/examples/from_pdot_mutual_rec_sem.v
+++ b/theories/Dot/examples/from_pdot_mutual_rec_sem.v
@@ -191,7 +191,7 @@ Proof.
   eapply (iSel_Sub (L := ⊥)).
   (* Necessary: Pick this over [iP_Later]. *)
   apply iP_Fld_E.
-  tcrush; varsub.
+  varsub.
   ltcrush; mltcrush.
 Qed.
 
@@ -366,7 +366,7 @@ Proof.
         (▶: val "tpe" : hsomeConcrT ⊥ ⊤))). {
     apply iSub_And_split, iSub_Refl; stcrush.
     apply (iSel_Sub (L := ⊥)), iP_Fld_E.
-    tcrush; varsub.
+    varsub.
     mltcrush.
     by mltcrush.
   }
@@ -494,7 +494,7 @@ Proof.
   by eapply iP_Fld_E, iP_Sub', iP_Mu_E; last var; [tcrush|stcrush].
   have HpxSubst: Γ' v⊢ₚ[fromPDotG] x0 @ "types" : fromPDotPaperAbsTypesTBodySubst, 0.
   by eapply (iP_Mu_E (T := fromPDotPaperAbsTypesTBody)
-    (p := x0 @ "types")), Hpx; tcrush.
+    (p := x0 @ "types")), Hpx; stcrush.
   eapply iT_Path', iP_Fld_I, (iP_Sub (i := 0)), HpxSubst.
   repeat lNext.
 Qed.
@@ -502,7 +502,7 @@ Qed.
 Example getAnyTypeTyp0 Γ :
   μ (fromPDotPaperAbsTBody x2) :: optionModTInv :: Γ v⊢ₜ[fromPDotG]
     tapp getAnyType x0 : x0 @ "types" @; "Type".
-Proof. eapply iT_All_Ex'; [exact: getAnyTypeFunTyp|var|tcrush..]. Qed.
+Proof. by eapply iT_All_Ex'; [exact: getAnyTypeFunTyp|var|]. Qed.
 
 End semExample.
 

--- a/theories/Dot/examples/from_pdot_mutual_rec_sem.v
+++ b/theories/Dot/examples/from_pdot_mutual_rec_sem.v
@@ -353,7 +353,7 @@ Proof.
   (A) on the one hand, show what x.T is.
   (B) on the other hand, thanks to hsomeConcr, we have a get method.
   *)
-  eapply (iT_Sub (i := 2)); first apply (iLaterN_Sub (j := 2)); tcrush.
+  eapply (iT_Sub (i := 2)); first apply (iLaterN_Sub _ 2); tcrush.
 
   apply (iT_Sub (i := 1) (T1 := TAnd (x2 @ "symbols" @; "Symbol")
     (▶: val "tpe" : hsomeConcrT ⊥ ⊤))); first last. {
@@ -379,7 +379,7 @@ Proof.
     (iSngl_pq_Sub_inv (q := x1) (p := x2 @ "types"));
     stcrush; [|exact: psubst_ty_rtc_sufficient|]; first last. {
     tcrush; varsub; asideLaters. lNext.
-    by ettrans; first apply (iSub_AddIJ' (j := 1)); wtcrush.
+    by ettrans; first apply (iSub_AddIJ' _ 1); wtcrush.
   }
   ettrans; first apply assoc_and; tcrush.
   lNext.

--- a/theories/Dot/examples/from_pdot_mutual_rec_sem.v
+++ b/theories/Dot/examples/from_pdot_mutual_rec_sem.v
@@ -417,7 +417,7 @@ Proof.
   - repeat first [var | typconstructor | tcrush].
   - ettrans; first last.
     eapply iSub_Sel'; first last.
-    + constructor; varsub; tcrush.
+    + varsub; tcrush.
     + tcrush.
     + mltcrush.
 Qed.
@@ -490,9 +490,8 @@ Proof.
   eapply (iT_Sub (T1 := TLater (x0 @ "types" @; "Type")) (i := 1)); tcrush.
   set Γ' := shift (μ (fromPDotPaperAbsTBody x2)) ::
     μ (fromPDotPaperAbsTBody x2) :: optionModTInv :: Γ.
-  have Hpx: Γ' v⊢ₚ[fromPDotG] x0 @ "types" : μ fromPDotPaperAbsTypesTBody, 0
-    by tcrush; eapply iT_Sub_nocoerce;
-      [ by eapply iT_Mu_E; first var; stcrush | tcrush].
+  have Hpx: Γ' v⊢ₚ[fromPDotG] x0 @ "types" : μ fromPDotPaperAbsTypesTBody, 0.
+  by eapply iP_Fld_E, iP_Sub', iP_Mu_E; last var; [tcrush|stcrush].
   have HpxSubst: Γ' v⊢ₚ[fromPDotG] x0 @ "types" : fromPDotPaperAbsTypesTBodySubst, 0.
   by eapply (iP_Mu_E (T := fromPDotPaperAbsTypesTBody)
     (p := x0 @ "types")), Hpx; tcrush.

--- a/theories/Dot/examples/from_pdot_mutual_rec_sem.v
+++ b/theories/Dot/examples/from_pdot_mutual_rec_sem.v
@@ -183,8 +183,8 @@ Let newTypeRefΓ Γ :=
   x2 @ "symbols" @; "Symbol" ::
   TAnd fromPDotPaperTypesTBody (TSing (x1 @ "types")) ::
   fromPDotPaperAbsTBody x1 :: optionModTInv :: Γ.
-Lemma Hsub0X0 Γ g :
-  newTypeRefΓ Γ v⊢ₜ[g] x2 @ "symbols" @; "Symbol", 0 <:
+Lemma Hsub0X0 Γ :
+  newTypeRefΓ Γ u⊢ₜ x2 @ "symbols" @; "Symbol", 0 <:
     val "tpe" : optionTy x3 x2 , 1.
 Proof.
   ettrans; last apply iLater_Sub; stcrush.
@@ -195,8 +195,8 @@ Proof.
   ltcrush; mltcrush.
 Qed.
 
-Lemma HoptSubT Γ g:
-  newTypeRefΓ Γ v⊢ₜ[g]
+Lemma HoptSubT Γ :
+  newTypeRefΓ Γ u⊢ₜ
     val "tpe" : optionTy x3 x2, 1 <:
     val "tpe" : TLater (hoptionTyConcr1 hoasNotation.hx2), 1.
 Proof.
@@ -215,8 +215,8 @@ Proof.
     asideLaters; mltcrush.
 Qed.
 
-Lemma Hsublast Γ g:
-  newTypeRefΓ Γ v⊢ₜ[g] shift typeRefTBody, 0 <: x1 @; "TypeRef", 0.
+Lemma Hsublast Γ:
+  newTypeRefΓ Γ u⊢ₜ shift typeRefTBody, 0 <: x1 @; "TypeRef", 0.
 Proof.
   eapply iSub_Sel'; tcrush.
   varsub; lThis.
@@ -235,9 +235,9 @@ Proof.
   varsub. eapply iSub_Trans, iSub_Trans, iSub_Later;
     [apply Hsub0X0 | apply HoptSubT | tcrush].
 Qed.
-Lemma HvT Γ g : newTypeRefΓ Γ v⊢ₜ[g] hnoneConcrT, 0 <: val "isEmpty" : TSing true, 0.
+Lemma HvT Γ : newTypeRefΓ Γ u⊢ₜ hnoneConcrT, 0 <: val "isEmpty" : TSing true, 0.
 Proof. mltcrush. Qed.
-Lemma HvF Γ g : newTypeRefΓ Γ v⊢ₜ[g]
+Lemma HvF Γ : newTypeRefΓ Γ u⊢ₜ
   hsomeType hoasNotation.hx2, 0 <: val "isEmpty" : TSing false, 0.
 Proof. lThis; mltcrush. Qed.
 
@@ -267,7 +267,7 @@ Proof.
   have [n HpOptV] := path_wp_exec_pure _ _ Hal; wp_pure => {HpOptV n}.
   rewrite /hoptionTyConcr1; lrSimpl in "HoptV".
   iDestruct "HoptV" as "[Hw|Hw]"; [have Hv := HvT | have Hv := HvF].
-  all: iPoseProof (fundamental_subtype (Hv Γ g) with "Hs") as "Hv";
+  all: iPoseProof (fundamental_subtype (Hv Γ)) as "Hv";
     iSpecialize ("Hv" $! _ optV with "Hg Hw"); lrSimpl in "Hv";
     iDestruct "Hv" as (? Hl' pb ->) "Hpb"; lrSimpl in "Hpb";
     rewrite path_wp_pure_exec; iDestruct "Hpb" as %(bv & [n1 ?] & Heq).
@@ -277,7 +277,7 @@ Proof.
   by iApply wp_wand; [iApply loopSemT | iIntros "% []"].
   wp_pure.
   (* To conclude, prove the right subtyping for hsomeType and TypeRef. *)
-  iPoseProof (fundamental_subtype (Hsublast Γ g) with "Hs Hg") as "{Hs} Hsub"; lrSimpl in "Hsub".
+  iPoseProof (fundamental_subtype (Hsublast Γ) with "Hg") as "{Hs} Hsub"; lrSimpl in "Hsub".
   iApply "Hsub"; iClear "Hsub".
 
   (* Just to restate the current goal (for some extra readability). *)
@@ -398,7 +398,7 @@ Proof.
 Qed.
 
 Lemma fromPDotPaperTypesSub Γ:
-  ⊢ (▶: fromPDotPaperAbsTBody x1)%ty :: optionModTInv :: Γ ⊨[ fromPDotGφ ]
+  ⊢ (▶: fromPDotPaperAbsTBody x1)%ty :: optionModTInv :: Γ ⊨
   μ fromPDotPaperTypesTBody, 0 <: μ fromPDotPaperAbsTypesTBody, 0.
 Proof.
   iApply fundamental_subtype.
@@ -437,7 +437,7 @@ Proof.
   iApply T_Obj_I.
   iApply D_Cons; [done| |].
   - iApply D_Path_Sub; last iApply D_Val_New.
-    + iApply (fromPDotPaperTypesSub with "Hs").
+    + iApply fromPDotPaperTypesSub.
     + iApply (semFromPDotPaperTypesTyp with "Hs").
 
   - iApply D_Cons; [done| iApply D_Val | iApply D_Nil].

--- a/theories/Dot/examples/prim_boolean_option.v
+++ b/theories/Dot/examples/prim_boolean_option.v
@@ -194,7 +194,7 @@ Proof.
   ltcrush; rewrite iterate_0.
   eapply iSub_Sel'; tcrush; varsub; ltcrush.
   all: try eapply iSub_Sel', (path_tp_delay (i := 0));
-    try (typconstructor; varsub; ltcrush); wtcrush.
+    try (varsub; ltcrush); wtcrush.
   all: try (ettrans; last eapply iSub_Or2); mltcrush.
 Qed.
 

--- a/theories/Dot/examples/storeless_typing_ex.v
+++ b/theories/Dot/examples/storeless_typing_ex.v
@@ -127,7 +127,7 @@ Proof.
 
   have Htp: ∀ Γ', T0 :: Γ' v⊢ₜ[ g ] x0 : val "hashCode" : TAll ⊤ TInt. {
     intros. eapply iT_Sub_nocoerce.
-    eapply iT_Mu_E'; by [exact: iT_Var'|].
+    by eapply iT_Mu_E'; [exact: iT_Var'| |stcrush].
     by apply iAnd1_Sub; tcrush.
   }
   apply (iT_Sub_nocoerce (val "hashCode" : TAll ⊤ 𝐙)). exact: Htp.

--- a/theories/Dot/examples/storeless_typing_ex_utils.v
+++ b/theories/Dot/examples/storeless_typing_ex_utils.v
@@ -237,9 +237,10 @@ Proof. by intros; apply iT_Path'; pvarsub. Qed.
 Lemma iT_Mu_E' Γ x T1 T2:
   Γ v⊢ₜ[ g ] tv (var_vl x): TMu T1 →
   T2 = T1.|[var_vl x/] →
+  is_unstamped_ty' (S (length Γ)) T1 →
   (*──────────────────────*)
   Γ v⊢ₜ[ g ] tv (var_vl x): T2.
-Proof. intros; subst; auto. Qed.
+Proof. intros; subst; tcrush. Qed.
 
 Lemma iT_Sub_nocoerce T1 T2 {Γ e} :
   Γ v⊢ₜ[ g ] e : T1 →

--- a/theories/Dot/examples/storeless_typing_ex_utils.v
+++ b/theories/Dot/examples/storeless_typing_ex_utils.v
@@ -5,8 +5,8 @@ From stdpp Require Import strings gmap.
 
 From D Require Import tactics.
 From D.Dot Require Import syn.
-From D.Dot Require Export storeless_typing ex_utils hoas.
-Export DBNotation.
+From D.Dot Require Export storeless_typing ex_utils hoas old_subtyping_derived_rules ast_stamping.
+Export DBNotation old_subtyping_derived_rules.
 
 Set Default Proof Using "Type".
 Set Suggest Proof Using.
@@ -113,9 +113,11 @@ Definition psAddStys {nvl} : stys → list (preTyMem nvl) → stys := foldr pAdd
 (* Prevent simplification from unfolding it, basically unconditionally. *)
 Arguments extraction : simpl never.
 
+From D.Dot Require Import unstampedness_binding stampedness_binding.
 (* For performance, keep these hints local to examples *)
 Hint Extern 5 => try_once extraction_weaken : core.
 Hint Extern 5 (is_stamped_ty _ _ _) => try_once is_stamped_weaken_ty : core.
+Hint Extern 5 (is_unstamped_ty _ _ _) => try_once is_unstamped_weaken_ty : core.
 Hint Extern 5 (is_stamped_dm _ _ _) => try_once is_stamped_weaken_dm : core.
 Hint Extern 5 (is_stamped_ren _ _ _ _) => progress cbn : core.
 
@@ -124,8 +126,9 @@ Ltac tcrush := repeat first [ eassumption | reflexivity | typconstructor | stcru
 Ltac wtcrush := repeat first [fast_done | typconstructor | stcrush]; try solve [ done |
   first [
     (* by eauto 3 using is_stamped_TLater_n, is_stamped_ren1_ty, is_stamped_ren1_path *)
-    by eauto 3 using is_stamped_ren1_ty |
+    by eauto 3 using is_stamped_ren1_ty, is_unstamped_ren1_ty |
     try_once extraction_weaken |
+    try_once is_unstamped_weaken_ty |
     try_once is_stamped_weaken_dm |
     try_once is_stamped_weaken_ty ]; eauto ].
 
@@ -150,16 +153,12 @@ Ltac hideCtx :=
 Lemma storeless_typing_mono_mut Γ g :
   (∀ e T, Γ v⊢ₜ[ g ] e : T → ∀ g' (Hle : g ⊆ g'), Γ v⊢ₜ[ g' ] e : T) ∧
   (∀ ds T, Γ v⊢ds[ g ] ds : T → ∀ g' (Hle : g ⊆ g'), Γ v⊢ds[ g' ] ds : T) ∧
-  (∀ l d T, Γ v⊢[ g ]{ l := d } : T → ∀ g' (Hle : g ⊆ g'), Γ v⊢[ g' ]{ l := d } : T) ∧
-  (∀ p T i, Γ v⊢ₚ[ g ] p : T, i → ∀ g' (Hle : g ⊆ g'), Γ v⊢ₚ[ g' ] p : T, i) ∧
-  (∀ T1 i1 T2 i2, Γ v⊢ₜ[ g ] T1, i1 <: T2, i2 → ∀ g' (Hle : g ⊆ g'), Γ v⊢ₜ[ g' ] T1, i1 <: T2, i2).
+  (∀ l d T, Γ v⊢[ g ]{ l := d } : T → ∀ g' (Hle : g ⊆ g'), Γ v⊢[ g' ]{ l := d } : T).
 Proof.
   eapply storeless_typing_mut_ind with
       (P := λ Γ g e T _, ∀ g' (Hle : g ⊆ g'), Γ v⊢ₜ[ g' ] e : T)
       (P0 := λ Γ g ds T _, ∀ g' (Hle : g ⊆ g'), Γ v⊢ds[ g' ] ds : T)
-      (P1 := λ Γ g l d T _, ∀ g' (Hle : g ⊆ g'), Γ v⊢[ g' ]{ l := d } : T)
-      (P2 := λ Γ g p T i _, ∀ g' (Hle : g ⊆ g'), Γ v⊢ₚ[ g' ] p : T, i)
-      (P3 := λ Γ g T1 i1 T2 i2 _, ∀ g' (Hle : g ⊆ g'), Γ v⊢ₜ[ g' ] T1, i1 <: T2, i2);
+      (P1 := λ Γ g l d T _, ∀ g' (Hle : g ⊆ g'), Γ v⊢[ g' ]{ l := d } : T);
   clear Γ g; intros;
     repeat match goal with
     | H : forall g : stys, _ |- _ => specialize (H g' Hle)
@@ -168,15 +167,16 @@ Qed.
 
 Hint Resolve is_stamped_idsσ_ren : core.
 
-Ltac asideLaters :=
+(* XXX drop *)
+Ltac asideLaters' :=
   repeat first
     [ettrans; last (apply iSub_Later; tcrush)|
     ettrans; first (apply iLater_Sub; tcrush)].
 
-Ltac lNext := ettrans; first apply iAnd2_Sub; tcrush.
-Ltac lThis := ettrans; first apply iAnd1_Sub; tcrush.
+Ltac lNext' := ettrans; first apply iAnd2_Sub; tcrush.
+Ltac lThis' := ettrans; first apply iAnd1_Sub; tcrush.
 
-Ltac lookup :=
+Ltac lookup' :=
   lazymatch goal with
   | |- _ v⊢ₜ[ _ ] ?T1, _ <: ?T2, _ =>
     let T1' := eval hnf in T1 in
@@ -185,12 +185,13 @@ Ltac lookup :=
       (* first [unify (label_of_ty T11) (label_of_ty T2); lThis | lNext] *)
       let ls := eval cbv in (label_of_ty T11, label_of_ty T2) in
       match ls with
-      | (Some ?l1, Some ?l1) => lThis
-      | (Some ?l1, Some ?l2) => lNext
+      | (Some ?l1, Some ?l1) => lThis'
+      | (Some ?l1, Some ?l2) => lNext'
       end
     end
   end.
 Ltac ltcrush := tcrush; repeat lookup.
+Ltac ltcrush' := tcrush; repeat lookup'.
 
 (*******************)
 (** DERIVED RULES **)
@@ -211,13 +212,27 @@ Lemma iT_Var' Γ x T1 T2 :
   T2 = shiftN x T1 →
   (*──────────────────────*)
   Γ v⊢ₜ[ g ] tv (var_vl x) : T2.
-Proof. intros; subst; tcrush. Qed.
+Proof. intros; apply iT_Path'; pvar. Qed.
 
 Lemma iT_Var0 Γ T :
   Γ !! 0 = Some T →
   (*──────────────────────*)
   Γ v⊢ₜ[ g ] tv (var_vl 0) : T.
-Proof. intros; eapply iT_Var'; by rewrite ?hsubst_id. Qed.
+Proof. intros; apply iT_Path'; pvar. Qed.
+
+Lemma iT_Var_Sub Γ x T1 T2 :
+  Γ !! x = Some T1 →
+  Γ v⊢ₜ[ g ] shiftN x T1, 0 <: T2, 0 →
+  (*──────────────────────*)
+  Γ v⊢ₜ[ g ] tv (var_vl x) : T2.
+Proof. by intros; apply iT_Path'; pvarsub. Qed.
+
+Lemma iT_Var0_Sub Γ T1 T2 :
+  Γ !! 0 = Some T1 →
+  Γ v⊢ₜ[ g ] T1, 0 <: T2, 0 →
+  (*──────────────────────*)
+  Γ v⊢ₜ[ g ] tv (var_vl 0) : T2.
+Proof. by intros; apply iT_Path'; pvarsub. Qed.
 
 Lemma iT_Mu_E' Γ x T1 T2:
   Γ v⊢ₜ[ g ] tv (var_vl x): TMu T1 →
@@ -226,60 +241,6 @@ Lemma iT_Mu_E' Γ x T1 T2:
   Γ v⊢ₜ[ g ] tv (var_vl x): T2.
 Proof. intros; subst; auto. Qed.
 
-Lemma iSub_Bind_1 Γ T1 T2 i:
-  is_stamped_ty (S (length Γ)) g T1 → is_stamped_ty (length Γ) g T2 →
-  iterate TLater i T1 :: Γ v⊢ₜ[g] T1, i <: shift T2, i →
-  Γ v⊢ₜ[g] μ T1, i <: T2, i.
-Proof.
-  intros Hus1 Hus2 Hsub.
-  ettrans. exact: (iMu_Sub_Mu Hsub).
-  exact: iMu_Sub.
-Qed.
-
-Lemma iSub_Bind_2 Γ T1 T2 i:
-  is_stamped_ty (length Γ) g T1 → is_stamped_ty (S (length Γ)) g T2 →
-  iterate TLater i (shift T1) :: Γ v⊢ₜ[g] shift T1, i <: T2, i →
-  Γ v⊢ₜ[g] T1, i <: μ T2, i.
-Proof.
-  intros Hus1 Hus2 Hsub.
-  ettrans; last apply (iMu_Sub_Mu Hsub); [exact: iSub_Mu | wtcrush].
-Qed.
-
-Lemma iSub_Bind_1' Γ T1 T2:
-  is_stamped_ty (S (length Γ)) g T1 → is_stamped_ty (length Γ) g T2 →
-  T1 :: Γ v⊢ₜ[g] T1, 0 <: shift T2, 0 →
-  Γ v⊢ₜ[g] μ T1, 0 <: T2, 0.
-Proof. intros; exact: iSub_Bind_1. Qed.
-
-Lemma iP_Sngl_Sym Γ p q i:
-  is_stamped_path (length Γ) g q →
-  Γ v⊢ₚ[g] p : TSing q, i →
-  Γ v⊢ₚ[g] q : TSing p, i.
-Proof.
-  intros Hus Hpq. eapply iP_Sub'.
-  eapply (iSngl_Sub_Sym Hpq). by apply iSngl_Sub_Self, Hpq.
-  eapply iP_Sngl_Refl.
-  by apply (iP_Sngl_Inv Hpq).
-Qed.
-
-Lemma iSngl_pq_Sub_inv {Γ i p q T1 T2}:
-  T1 ~Tp[ p := q ]* T2 →
-  is_stamped_ty   (length Γ) g T1 →
-  is_stamped_ty   (length Γ) g T2 →
-  is_stamped_path (length Γ) g p →
-  Γ v⊢ₚ[g] q : TSing p, i →
-  Γ v⊢ₜ[g] T1, i <: T2, i.
-Proof. intros. by eapply iSngl_pq_Sub, iP_Sngl_Sym. Qed.
-
-Lemma iP_And {Γ p T1 T2 i}:
-  Γ v⊢ₚ[g] p : T1, i →
-  Γ v⊢ₚ[g] p : T2, i →
-  Γ v⊢ₚ[g] p : TAnd T1 T2, i.
-Proof.
-  intros Hp1 Hp2. eapply iP_Sub', iP_Sngl_Refl, Hp1.
-  constructor; exact: iSngl_Sub_Self.
-Qed.
-
 Lemma iT_Sub_nocoerce T1 T2 {Γ e} :
   Γ v⊢ₜ[ g ] e : T1 →
   Γ v⊢ₜ[ g ] T1, 0 <: T2, 0 →
@@ -287,192 +248,13 @@ Lemma iT_Sub_nocoerce T1 T2 {Γ e} :
 Proof. intros. exact: (iT_Sub (i:=0)). Qed.
 Hint Resolve iT_Sub_nocoerce : core.
 
-Lemma iT_Var_Sub Γ x T1 T2 :
-  Γ !! x = Some T1 →
-  Γ v⊢ₜ[ g ] shiftN x T1, 0 <: T2, 0 →
-  (*──────────────────────*)
-  Γ v⊢ₜ[ g ] tv (var_vl x) : T2.
-Proof. intros; eapply iT_Sub_nocoerce; by [exact: iT_Var|]. Qed.
-
-Lemma iT_Var0_Sub Γ T1 T2 :
-  Γ !! 0 = Some T1 →
-  Γ v⊢ₜ[ g ] T1, 0 <: T2, 0 →
-  (*──────────────────────*)
-  Γ v⊢ₜ[ g ] tv (var_vl 0) : T2.
-Proof. intros. by eapply iT_Var_Sub; [| rewrite ?hsubst_id]. Qed.
-
-Lemma iSub_SelL {Γ p U l L i}:
-  Γ v⊢ₚ[ g ] p : TTMemL l L U, i →
-  Γ v⊢ₜ[ g ] TLater L, i <: TSel p l, i.
-Proof. intros; exact: iSub_Sel. Qed.
-
-Lemma iSel_SubL {Γ p L l U i}:
-  Γ v⊢ₚ[ g ] p : TTMemL l L U, i →
-  Γ v⊢ₜ[ g ] TSel p l, i <: TLater U, i.
-Proof. intros; exact: iSel_Sub. Qed.
-
-Lemma iSub_Sel' U {Γ p l L i}:
-  is_stamped_ty (length Γ) g L →
-  Γ v⊢ₚ[ g ] p : TTMemL l L U, i →
-  Γ v⊢ₜ[ g ] L, i <: TSel p l, i.
-Proof. intros; ettrans; last exact: (iSub_Sel (p := p)); tcrush. Qed.
-
-(** Specialization of [iSub_Sel'] for convenience. *)
-Lemma iSub_Sel'' Γ {p l L i}:
-  is_stamped_ty (length Γ) g L →
-  Γ v⊢ₚ[ g ] p : TTMemL l L L, i → Γ v⊢ₜ[ g ] L, i <: TSel p l, i.
-Proof. apply iSub_Sel'. Qed.
-
-Lemma iSub_AddIJ' {Γ T i j} (Hst: is_stamped_ty (length Γ) g T) (Hle : i <= j):
-  Γ v⊢ₜ[ g ] T, i <: T, j.
-Proof.
-  rewrite (le_plus_minus i j Hle) Nat.add_comm; move: {j Hle} (j - i) => k.
-  elim: k => [|n IHn] /=; first tcrush.
-  ettrans; first apply IHn.
-  ettrans; [exact: iSub_Add_Later | tcrush].
-Qed.
-
-Lemma iSub_AddI Γ T i (Hst: is_stamped_ty (length Γ) g T) :
-  Γ v⊢ₜ[ g ] T, 0 <: T, i.
-Proof. apply: iSub_AddIJ'; by [|lia]. Qed.
-
-Lemma iLaterN_Sub {Γ T i j} :
-  is_stamped_ty (length Γ) g T →
-  Γ v⊢ₜ[g] iterate TLater j T, i <: T, j + i.
-Proof.
-  elim: j T => /= [|j IHj] T HuT; rewrite ?iterate_0 ?iterate_Sr /=; tcrush.
-  ettrans.
-  - apply (IHj (TLater T)); stcrush.
-  - exact: iLater_Sub.
-Qed.
-
-Lemma path_tp_delay {Γ p T i j} (Hst: is_stamped_ty (length Γ) g T) : i <= j →
+Lemma path_tp_delay {Γ p T i j} (Hst: is_unstamped_ty' (length Γ) T) : i <= j →
   Γ v⊢ₚ[ g ] p : T, i → Γ v⊢ₚ[ g ] p : T, j.
 Proof.
   intros Hle Hp.
   rewrite (le_plus_minus i j Hle); move: {j Hle} (j - i) => k.
   eapply iP_Sub, Hp.
   apply: iSub_AddIJ'; by [|lia].
-Qed.
-
-Lemma iAnd_Later_Sub_Distr Γ T1 T2 i :
-  is_stamped_ty (length Γ) g T1 →
-  is_stamped_ty (length Γ) g T2 →
-  Γ v⊢ₜ[ g ] TAnd (TLater T1) (TLater T2), i <: TLater (TAnd T1 T2), i.
-Proof. intros; asideLaters; tcrush; [lThis|lNext]. Qed.
-
-
-(* Lattice theory *)
-Lemma iOr_Sub_split Γ T1 T2 U1 U2 i:
-  is_stamped_ty (length Γ) g U1 →
-  is_stamped_ty (length Γ) g U2 →
-  Γ v⊢ₜ[ g ] T1, i <: U1, i →
-  Γ v⊢ₜ[ g ] T2, i <: U2, i →
-  Γ v⊢ₜ[ g ] TOr T1 T2, i <: TOr U1 U2, i.
-Proof.
-  intros.
-  apply iOr_Sub; [
-    eapply iSub_Trans, iSub_Or1 | eapply iSub_Trans, iSub_Or2]; tcrush.
-Qed.
-
-Lemma iSub_And_split Γ T1 T2 U1 U2 i:
-  is_stamped_ty (length Γ) g T1 →
-  is_stamped_ty (length Γ) g T2 →
-  Γ v⊢ₜ[ g ] T1, i <: U1, i →
-  Γ v⊢ₜ[ g ] T2, i <: U2, i →
-  Γ v⊢ₜ[ g ] TAnd T1 T2, i <: TAnd U1 U2, i.
-Proof.
-  intros; apply iSub_And; [
-    eapply iSub_Trans; first apply iAnd1_Sub |
-    eapply iSub_Trans; first apply iAnd2_Sub]; tcrush.
-Qed.
-
-Lemma iDistr_And_Or_Sub_inv {Γ S T U i}:
-  is_stamped_ty (length Γ) g S →
-  is_stamped_ty (length Γ) g T →
-  is_stamped_ty (length Γ) g U →
-  Γ v⊢ₜ[ g ] TOr (TAnd S U) (TAnd T U), i <: TAnd (TOr S T) U , i.
-Proof.
-  intros; apply iOr_Sub; apply iSub_And; tcrush;
-    (ettrans; first apply iAnd1_Sub); tcrush.
-Qed.
-
-Lemma iDistr_Or_And_Sub {Γ S T U i}:
-  is_stamped_ty (length Γ) g S →
-  is_stamped_ty (length Γ) g T →
-  is_stamped_ty (length Γ) g U →
-  Γ v⊢ₜ[ g ] TOr (TAnd S T) U , i <: TAnd (TOr S U) (TOr T U), i.
-Proof.
-  intros; apply iOr_Sub; apply iSub_And; tcrush;
-    (ettrans; last apply iSub_Or1); tcrush.
-Qed.
-
-Lemma comm_and {Γ T U i} :
-  is_stamped_ty (length Γ) g T →
-  is_stamped_ty (length Γ) g U →
-  Γ v⊢ₜ[ g ] TAnd T U, i <: TAnd U T, i.
-Proof. intros; tcrush. Qed.
-
-Lemma comm_or {Γ T U i} :
-  is_stamped_ty (length Γ) g T →
-  is_stamped_ty (length Γ) g U →
-  Γ v⊢ₜ[ g ] TOr T U, i <: TOr U T, i.
-Proof. intros; tcrush. Qed.
-
-Lemma absorb_and_or {Γ T U i} :
-  is_stamped_ty (length Γ) g T →
-  is_stamped_ty (length Γ) g U →
-  Γ v⊢ₜ[ g ] TAnd U (TOr T U), i <: U, i.
-Proof. intros; tcrush. Qed.
-
-Lemma absorb_or_and {Γ T U i} :
-  is_stamped_ty (length Γ) g T →
-  is_stamped_ty (length Γ) g U →
-  Γ v⊢ₜ[ g ] TOr U (TAnd T U), i <: U, i.
-Proof. intros; tcrush. Qed.
-
-Lemma absorb_or_and2 {Γ T U i} :
-  is_stamped_ty (length Γ) g T →
-  is_stamped_ty (length Γ) g U →
-  Γ v⊢ₜ[ g ] TOr (TAnd T U) T, i <: T, i.
-Proof. intros; ettrans; first apply comm_or; tcrush. Qed.
-
-Lemma assoc_or {Γ S T U i} :
-  is_stamped_ty (length Γ) g S →
-  is_stamped_ty (length Γ) g T →
-  is_stamped_ty (length Γ) g U →
-  Γ v⊢ₜ[ g ] TOr (TOr S T) U, i <: TOr S (TOr T U), i.
-Proof. intros; tcrush; (ettrans; last apply iSub_Or2); tcrush. Qed.
-
-Lemma assoc_and {Γ S T U i} :
-  is_stamped_ty (length Γ) g S →
-  is_stamped_ty (length Γ) g T →
-  is_stamped_ty (length Γ) g U →
-  Γ v⊢ₜ[ g ] TAnd (TAnd S T) U, i <: TAnd S (TAnd T U), i.
-Proof. intros. tcrush; lThis. Qed.
-
-(* Based on Lemma 4.3 in
-https://books.google.co.uk/books?id=vVVTxeuiyvQC&lpg=PA104&pg=PA85#v=onepage&q&f=false.
-Would be much easier to formalize with setoid rewriting.
-*)
-Lemma iDistr_Or_And_Sub_inv {Γ S T U i}:
-  is_stamped_ty (length Γ) g S →
-  is_stamped_ty (length Γ) g T →
-  is_stamped_ty (length Γ) g U →
-  Γ v⊢ₜ[ g ] TAnd (TOr S U) (TOr T U), i <: TOr (TAnd S T) U , i.
-Proof.
-  intros.
-  ettrans; first apply iDistr_And_Or_Sub; stcrush => //.
-  ettrans; first apply iOr_Sub_split, absorb_and_or; try apply iSub_Refl;
-    stcrush => //.
-  ettrans; first apply iOr_Sub_split; try apply (iSub_Refl _ (T := U));
-    try (ettrans; first apply (comm_and (T := S))); try apply iDistr_And_Or_Sub; stcrush => //.
-  ettrans; first apply assoc_or; stcrush => //.
-  ettrans; first apply iOr_Sub_split.
-  3: apply iSub_Refl; tcrush.
-  3: ettrans; first apply absorb_or_and2; tcrush.
-  all: tcrush.
-  ettrans; first eapply comm_and; tcrush.
 Qed.
 
 Lemma is_stamped_pvar i n : i < n → is_stamped_path n g (pv (var_vl i)).
@@ -494,18 +276,22 @@ Definition packTV n s := (ν {@ type "A" = (shift (idsσ n); s)}).
 Lemma iD_Typ T {Γ l s σ}:
   T ~[ length Γ ] (g, (s, σ)) →
   is_stamped_σ (length Γ) g σ →
-  is_stamped_ty (length Γ) g T →
+  is_unstamped_ty' (length Γ) T →
   Γ v⊢[ g ]{ l := dtysem σ s } : TTMemL l T T.
-Proof. intros. apply (iD_Typ_Abs T); auto 3. Qed.
+Proof. intros. apply (iD_Typ_Abs T); subtcrush. Qed.
 
 Lemma packTV_typed' s T n Γ :
   g !! s = Some T →
-  is_stamped_ty n g T →
+  is_unstamped_ty' n T →
   n <= length Γ →
   Γ v⊢ₜ[ g ] packTV n s : typeEq "A" T.
 Proof.
-  move => Hlp HsT1 Hle; move: (Hle) (HsT1) => /le_n_S Hles /is_stamped_ren1_ty HsT2.
-  move: (is_stamped_nclosed_ty HsT1) => Hcl.
+  move => Hlp HuT1 Hle; move: (Hle)  (HuT1) => /le_n_S Hles /is_unstamped_ren1_ty HuT2.
+  move: (is_unstamped_nclosed_ty HuT1) => Hcl.
+
+  (* XXX *)
+  have HsT1 := unstamped_stamped_type g HuT1; move: (HsT1) => /is_stamped_ren1_ty HsT2.
+
   apply (iT_Sub_nocoerce (μ {@ typeEq "A" (shift T) }));
     last (ettrans; first apply: (iMu_Sub (T := {@ typeEq "A" T })); tcrush).
   apply iT_Obj_I; tcrush.
@@ -516,7 +302,7 @@ Qed.
 
 Lemma packTV_typed s T Γ :
   g !! s = Some T →
-  is_stamped_ty (length Γ) g T →
+  is_unstamped_ty' (length Γ) T →
   Γ v⊢ₜ[ g ] packTV (length Γ) s : typeEq "A" T.
 Proof. intros; exact: packTV_typed'. Qed.
 
@@ -545,14 +331,16 @@ Lemma typeApp_typed s Γ T U V t :
     for ML and Scala: that is, producing a type [V] that does not refer to
     variables bound by let in the expression. *)
   (∀ L, typeEq "A" (shiftN 2 T) :: L :: Γ v⊢ₜ[ g ] U.|[up (ren (+1))], 0 <: shiftN 2 V, 0) →
-  is_stamped_ty (length Γ) g T →
-  is_stamped_ty (S (length Γ)) g U →
+  is_unstamped_ty' (length Γ) T →
+  is_unstamped_ty' (S (length Γ)) U →
   g !! s = Some (shift T) →
   Γ v⊢ₜ[ g ] tApp Γ t s : V.
 Proof.
-  move => Ht Hsub HsT1 HsU1 Hl; move: (HsT1) => /is_stamped_ren1_ty HsT2.
-  move: (HsT2) => /is_stamped_ren1_ty HsT3.
-  rewrite -hrenS in HsT3.
+  move => Ht Hsub HuT1 HuU1 Hl.
+  move: (HuT1) => /is_unstamped_ren1_ty HuT2; move: (HuT2) => /is_unstamped_ren1_ty HuT3.
+  have HsT1 := unstamped_stamped_type g HuT1; move: (HsT1) => /is_stamped_ren1_ty HsT2.
+  have HsU1 := unstamped_stamped_type g HuU1.
+  rewrite -hrenS in HuT3.
   eapply iT_Let; [exact: Ht| |tcrush].
   eapply iT_Let; [by apply packTV_typed| |tcrush].
   rewrite /= -!hrenS -/(typeEq _ _).
@@ -568,6 +356,7 @@ End examples_lemmas.
 
 Hint Resolve is_stamped_pvar is_stamped_pvars iT_Sub_nocoerce : core.
 
-Ltac var := exact: iT_Var0 || exact: iT_Var'.
-Ltac varsub := (eapply iT_Var0_Sub || eapply iT_Var_Sub); first done.
+Ltac var := exact: iT_Var0 || exact: iT_Var' || pvar.
+Ltac varsub := (eapply iP_Var_Sub || eapply iP_Var0_Sub ||
+  eapply iT_Var0_Sub || eapply iT_Var_Sub); first done.
 Ltac mltcrush := tcrush; try ((apply iSub_Bind_1' || apply iSub_Bind_1); tcrush); repeat lookup.

--- a/theories/Dot/fundamental.v
+++ b/theories/Dot/fundamental.v
@@ -107,7 +107,6 @@ Section fundamental.
       + iApply T_All_I_Strong; [|by iApply H].
         by apply fundamental_ctx_sub, ctx_strip_to_sub.
       + iApply T_Obj_I. by iApply H.
-      + by iApply T_Var.
       + by iApply T_Sub; [iApply H |iApply fundamental_subtype].
       + iApply T_Path. by iApply fundamental_path_typed.
       + by iApply T_Un; [|iApply H].

--- a/theories/Dot/fundamental.v
+++ b/theories/Dot/fundamental.v
@@ -34,46 +34,16 @@ Section fundamental.
   Definition fundamental_typed_def Γ g e T (HT: Γ v⊢ₜ[ g ] e : T) := ⊢ Γ ⊨[ Vs⟦ g ⟧ ] e : T.
   Definition fundamental_dms_typed_def Γ g ds T (HT: Γ v⊢ds[ g ] ds : T) := ⊢ Γ ⊨ds[ Vs⟦ g ⟧ ] ds : T.
   Definition fundamental_dm_typed_def Γ g l d T (HT : Γ v⊢[ g ]{ l := d } : T) := ⊢ Γ ⊨[ Vs⟦ g ⟧ ] { l := d } : T.
-  Definition fundamental_path_typed_def Γ g p T i (HT : Γ v⊢ₚ[ g ] p : T, i) := ⊢ Γ ⊨p[ Vs⟦ g ⟧ ] p : T, i.
-  Definition fundamental_subtype_def Γ g T1 i1 T2 i2 (HT: Γ v⊢ₜ[ g ] T1, i1 <: T2, i2) :=
-    ⊢ Γ ⊨[ Vs⟦ g ⟧ ] T1, i1 <: T2, i2.
+  Definition fundamental_path_typed_def Γ p T i (HT : Γ u⊢ₚ p : T, i) := ⊢ Γ ⊨p p : T, i.
+  Definition fundamental_subtype_def Γ T1 i1 T2 i2 (HT: Γ u⊢ₜ T1, i1 <: T2, i2) :=
+    ⊢ Γ ⊨ T1, i1 <: T2, i2.
 
-  Theorem fundamental_mut Γ g :
-    (∀ e T HT, @fundamental_typed_def Γ g e T HT) ∧
-    (∀ ds T HT, @fundamental_dms_typed_def Γ g ds T HT) ∧
-    (∀ l d T HT, @fundamental_dm_typed_def Γ g l d T HT) ∧
-    (∀ p T i HT, @fundamental_path_typed_def Γ g p T i HT) ∧
-    (∀ T1 i1 T2 i2 HT, @fundamental_subtype_def Γ g T1 i1 T2 i2 HT).
+  Theorem subtype_fundamental_mut Γ :
+    (∀ p T i HT, @fundamental_path_typed_def Γ p T i HT) ∧
+    (∀ T1 i1 T2 i2 HT, @fundamental_subtype_def Γ T1 i1 T2 i2 HT).
   Proof.
-    apply storeless_typing_mut_ind; clear Γ g; intros; iIntros "#Hm".
-      + by iApply T_All_Ex; [iApply H|iApply H0].
-      + by iApply T_All_Ex_p; [|iApply H|iApply H0].
-      + by iApply T_All_E; [iApply H|iApply H0].
-      + by iApply T_Obj_E; iApply H.
-      + by iApply T_Mu_E; iApply H.
-      + iApply T_All_I_Strong; [|by iApply H].
-        by apply fundamental_ctx_sub, ctx_strip_to_sub.
-      + iApply T_Obj_I. by iApply H.
-      + iApply T_Mu_I. by iApply H.
-      + by iApply T_Var.
-      + by iApply T_Sub; [iApply H0|iApply H].
-      + iApply T_Path. by iApply H.
-      + by iApply T_Un; [|iApply H].
-      + by iApply T_Bin; [| iApply H| iApply H0].
-      + by iApply sT_If; [iApply H|iApply H0|iApply H1].
-
-      + by iApply D_Nil.
-      + by iApply D_Cons; [|iApply H|iApply H0].
-
-      + by iApply D_Typ_Abs; [> iApply H | iApply H0|
-          iApply extraction_to_leadsto_envD_equiv].
-      + iApply D_Val. by iApply H.
-      + iApply D_Path. by iApply H.
-      + iApply D_Val_New. by iApply H.
-      + iApply D_Path_Sub; by [> iApply H|iApply H0].
-
-      + (* XXX unclean, but temporary. *)
-        iApply sP_Val. by iApply H.
+    apply old_pure_typing_mut_ind; clear Γ; intros; red.
+      + by iApply P_Var.
 
       + by iApply sP_Nat_I.
       + by iApply sP_Bool_I.
@@ -117,6 +87,46 @@ Section fundamental.
       + iApply sDistr_And_Or_Sub.
       + iApply Sub_Skolem_P. by iApply H.
   Qed.
+  Lemma fundamental_path_typed Γ p T i :
+    Γ u⊢ₚ p : T, i → ⊢ Γ ⊨p p : T, i.
+  Proof. apply (subtype_fundamental_mut Γ). Qed.
+  Lemma fundamental_subtype Γ T1 i1 T2 i2 :
+    Γ u⊢ₜ T1, i1 <: T2, i2 → ⊢ Γ ⊨ T1, i1 <: T2, i2.
+  Proof. apply (subtype_fundamental_mut Γ). Qed.
+
+  Theorem fundamental_mut Γ g :
+    (∀ e T HT, @fundamental_typed_def Γ g e T HT) ∧
+    (∀ ds T HT, @fundamental_dms_typed_def Γ g ds T HT) ∧
+    (∀ l d T HT, @fundamental_dm_typed_def Γ g l d T HT).
+  Proof.
+    apply storeless_typing_mut_ind; clear Γ g; intros; iIntros "#Hm".
+      + by iApply T_All_Ex; [iApply H|iApply H0].
+      + by iApply T_All_Ex_p; [|iApply H|iApply fundamental_path_typed].
+      + by iApply T_All_E; [iApply H|iApply H0].
+      + by iApply T_Obj_E; iApply H.
+      + by iApply T_Mu_E; iApply H.
+      + iApply T_All_I_Strong; [|by iApply H].
+        by apply fundamental_ctx_sub, ctx_strip_to_sub.
+      + iApply T_Obj_I. by iApply H.
+      + iApply T_Mu_I. by iApply H.
+      + by iApply T_Var.
+      + by iApply T_Sub; [iApply H |iApply fundamental_subtype].
+      + iApply T_Path. by iApply fundamental_path_typed.
+      + by iApply T_Un; [|iApply H].
+      + by iApply T_Bin; [| iApply H| iApply H0].
+      + by iApply sT_If; [iApply H|iApply H0|iApply H1].
+
+      + by iApply D_Nil.
+      + by iApply D_Cons; [|iApply H|iApply H0].
+
+      + by iApply D_Typ_Abs; [> iApply fundamental_subtype.. |
+          iApply extraction_to_leadsto_envD_equiv].
+      + iApply D_Val. by iApply H.
+      + iApply D_Path. by iApply fundamental_path_typed.
+      + iApply D_Val_New. by iApply H.
+      + by iApply D_Path_Sub; [> iApply fundamental_subtype|iApply H].
+    Qed.
+
 
   (** * Fundamental theorem 5.4. *)
   Lemma fundamental_typed Γ g e T :
@@ -127,12 +137,6 @@ Section fundamental.
   Proof. apply (fundamental_mut Γ g). Qed.
   Lemma fundamental_dm_typed Γ g l d T :
     Γ v⊢[ g ]{ l := d } : T → ⊢ Γ ⊨[ Vs⟦ g ⟧ ] { l := d } : T.
-  Proof. apply (fundamental_mut Γ g). Qed.
-  Lemma fundamental_path_typed Γ g p T i :
-    Γ v⊢ₚ[ g ] p : T, i → ⊢ Γ ⊨p[ Vs⟦ g ⟧ ] p : T, i.
-  Proof. apply (fundamental_mut Γ g). Qed.
-  Lemma fundamental_subtype Γ g T1 i1 T2 i2 :
-    Γ v⊢ₜ[ g ] T1, i1 <: T2, i2 → ⊢ Γ ⊨[ Vs⟦ g ⟧ ] T1, i1 <: T2, i2.
   Proof. apply (fundamental_mut Γ g). Qed.
 End fundamental.
 
@@ -162,7 +166,7 @@ Proof.
 Qed.
 
 (** Normalization for gDOT paths. *)
-Lemma path_normalization_storeless {g p T i}
+Lemma path_normalization_storeless {p T i}
   (Ht : [] v⊢ₚ[ g ] p : T, i) :
   terminates (path2tm p).
 Proof.

--- a/theories/Dot/fundamental.v
+++ b/theories/Dot/fundamental.v
@@ -104,11 +104,9 @@ Section fundamental.
       + by iApply T_All_Ex_p; [|iApply H|iApply fundamental_path_typed].
       + by iApply T_All_E; [iApply H|iApply H0].
       + by iApply T_Obj_E; iApply H.
-      + by iApply T_Mu_E; iApply H.
       + iApply T_All_I_Strong; [|by iApply H].
         by apply fundamental_ctx_sub, ctx_strip_to_sub.
       + iApply T_Obj_I. by iApply H.
-      + iApply T_Mu_I. by iApply H.
       + by iApply T_Var.
       + by iApply T_Sub; [iApply H |iApply fundamental_subtype].
       + iApply T_Path. by iApply fundamental_path_typed.

--- a/theories/Dot/lr/unary_lr.v
+++ b/theories/Dot/lr/unary_lr.v
@@ -655,15 +655,14 @@ Proof.
 Qed.
 
 (** Adequacy of normalization for gDOT paths. *)
-Lemma ipwp_gs_adequacy Σ `{!dlangPreG Σ} `{!SwapPropI Σ} {g p T i}
-  (Hwp : ∀ `(Hdlang : !dlangG Σ) `(!SwapPropI Σ), ⊢ [] ⊨p[ Vs⟦ g ⟧ ] p : T , i):
+Lemma ipwp_gs_adequacy Σ `{!dlangPreG Σ} `{!SwapPropI Σ} {p T i}
+  (Hwp : ∀ `(Hdlang : !dlangG Σ) `(!SwapPropI Σ), ⊢ [] ⊨p p : T , i):
   terminates (path2tm p).
 Proof.
   eapply (@soundness (iResUR Σ) _ i).
   apply (bupd_plain_soundness _).
   iMod (gen_iheap_init (L := stamp) ∅) as (hG) "Hgs".
   set (DLangΣ := DLangG Σ).
-  iMod (transfer_empty (Hdlang := DLangΣ) Vs⟦ g ⟧ with "Hgs") as "Hgs".
   iApply ipwp_terminates.
-  iApply (Hwp DLangΣ with "Hgs").
+  iApply (Hwp DLangΣ).
 Qed.

--- a/theories/Dot/stamping/unstampedness_binding.v
+++ b/theories/Dot/stamping/unstampedness_binding.v
@@ -377,3 +377,9 @@ Proof.
   eapply is_unstamped_sub_rev_ty, Hu.
   eapply nclosed_ren_inv_ty_one, is_unstamped_nclosed_ty, Hu.
 Qed.
+
+(* XXX *)
+Lemma is_unstamped_TLater_n {i n T}:
+  is_unstamped_ty' n T →
+  is_unstamped_ty' n (iterate TLater i T).
+Proof. elim: i => [|//i IHi]; rewrite ?iterate_0 ?iterate_S //; auto. Qed.

--- a/theories/Dot/typing/old_subtyping.v
+++ b/theories/Dot/typing/old_subtyping.v
@@ -9,11 +9,7 @@ Unset Strict Implicit.
 
 Implicit Types (L T U : ty) (v : vl) (e : tm) (d : dm) (p: path) (ds : dms) (Γ : list ty).
 
-(* The typing judgement comes from [s/⊢/u⊢/] over [Dot/stamped_typing.v], and dropping stamping. *)
-Reserved Notation "Γ u⊢ₜ e : T" (at level 74, e, T at next level).
 Reserved Notation "Γ u⊢ₚ p : T , i" (at level 74, p, T, i at next level).
-Reserved Notation "Γ u⊢{ l := d  } : T" (at level 74, l, d, T at next level).
-Reserved Notation "Γ u⊢ds ds : T" (at level 74, ds, T at next level).
 Reserved Notation "Γ u⊢ₜ T1 , i1 <: T2 , i2" (at level 74, T1, T2, i1, i2 at next level).
 Inductive path_typed Γ : path → ty → nat → Prop :=
 | iP_Var x T:
@@ -191,6 +187,18 @@ with subtype Γ : ty → nat → ty → nat → Prop :=
     Γ u⊢ₜ T1, i <: T2, j
 
 where "Γ u⊢ₜ T1 , i1 <: T2 , i2" := (subtype Γ T1 i1 T2 i2).
+
+(* Compatibility *)
+Notation "Γ v⊢ₚ[ g  ] p : T , i" := (path_typed Γ p T i)
+  (at level 74, p, T, i at next level, only parsing).
+Notation "Γ v⊢ₜ[ g  ] T1 , i1 <: T2 , i2" := (subtype Γ T1 i1 T2 i2)
+  (at level 74, T1, T2, i1, i2 at next level, only parsing).
+
+Notation "Γ s⊢ₚ[ g  ] p : T , i" := (path_typed Γ p T i)
+  (at level 74, p, T, i at next level, only parsing).
+Notation "Γ s⊢ₜ[ g  ] T1 , i1 <: T2 , i2" := (subtype Γ T1 i1 T2 i2)
+  (at level 74, T1, T2, i1, i2 at next level, only parsing).
+
 
 Scheme unstamped_path_typed_mut_ind := Induction for path_typed Sort Prop
 with   unstamped_subtype_mut_ind := Induction for subtype Sort Prop.

--- a/theories/Dot/typing/old_subtyping.v
+++ b/theories/Dot/typing/old_subtyping.v
@@ -1,6 +1,6 @@
 (** * Judgments defining the previous version of gDOT subtyping. *)
 From D Require Import tactics.
-From D.Dot Require Export syn path_repl lr_syn_aux.
+From D.Dot Require Export syn path_repl path_repl_lemmas lr_syn_aux.
 From D.Dot.typing Require Export typing_aux_defs.
 From D.Dot.stamping Require Export core_stamping_defs.
 
@@ -279,6 +279,19 @@ Lemma iP_Var0_Sub Γ T1 T2 :
 Proof. intros. by eapply iP_Var_Sub; [| rewrite ?hsubst_id]. Qed.
 
 Ltac pvarsub := (eapply iP_Var0_Sub || eapply iP_Var_Sub); first done.
+
+Lemma iP_Mu_I' x T {Γ i} :
+  is_unstamped_ty' (S (length Γ)) T →
+  Γ u⊢ₚ pv (var_vl x) : T.|[ var_vl x /], i →
+  Γ u⊢ₚ pv (var_vl x) : TMu T, i.
+Proof.
+  intros Hu Hp. by eapply iP_Mu_I; last rewrite (psubst_subst_agree_ty _ Hu).
+Qed.
+Lemma iP_Mu_E' x T {Γ i} :
+  is_unstamped_ty' (S (length Γ)) T →
+  Γ u⊢ₚ pv (var_vl x) : TMu T, i →
+  Γ u⊢ₚ pv (var_vl x) : T.|[ var_vl x /], i.
+Proof. intros Hu Hp; rewrite -(psubst_subst_agree_ty _ Hu); exact: iP_Mu_E. Qed.
 
 Ltac typconstructor_blacklist Γ :=
   lazymatch goal with

--- a/theories/Dot/typing/old_subtyping.v
+++ b/theories/Dot/typing/old_subtyping.v
@@ -20,6 +20,10 @@ Inductive path_typed Γ : path → ty → nat → Prop :=
     Γ !! x = Some T →
     (* After looking up in Γ, we must weaken T for the variables on top of x. *)
     Γ u⊢ₚ pv (var_vl x) : shiftN x T, 0
+| iP_Nat_I n:
+    Γ u⊢ₚ pv (vint n): TInt, 0
+| iP_Bool_I b:
+    Γ u⊢ₚ pv (vbool b): TBool, 0
 | iP_Fld_E p T i l:
     Γ u⊢ₚ p : TVMem l T, i →
     Γ u⊢ₚ pself p l : T, i

--- a/theories/Dot/typing/old_subtyping.v
+++ b/theories/Dot/typing/old_subtyping.v
@@ -1,0 +1,204 @@
+(** * Judgments defining the previous version of gDOT subtyping. *)
+From D Require Import tactics.
+From D.Dot Require Export syn path_repl lr_syn_aux.
+From D.Dot.typing Require Export typing_aux_defs.
+From D.Dot.stamping Require Export core_stamping_defs.
+
+Set Implicit Arguments.
+Unset Strict Implicit.
+
+Implicit Types (L T U : ty) (v : vl) (e : tm) (d : dm) (p: path) (ds : dms) (Γ : list ty).
+
+(* The typing judgement comes from [s/⊢/u⊢/] over [Dot/stamped_typing.v], and dropping stamping. *)
+Reserved Notation "Γ u⊢ₜ e : T" (at level 74, e, T at next level).
+Reserved Notation "Γ u⊢ₚ p : T , i" (at level 74, p, T, i at next level).
+Reserved Notation "Γ u⊢{ l := d  } : T" (at level 74, l, d, T at next level).
+Reserved Notation "Γ u⊢ds ds : T" (at level 74, ds, T at next level).
+Reserved Notation "Γ u⊢ₜ T1 , i1 <: T2 , i2" (at level 74, T1, T2, i1, i2 at next level).
+Inductive path_typed Γ : path → ty → nat → Prop :=
+| iP_Var x T:
+    Γ !! x = Some T →
+    (* After looking up in Γ, we must weaken T for the variables on top of x. *)
+    Γ u⊢ₚ pv (var_vl x) : shiftN x T, 0
+| iP_Fld_E p T i l:
+    Γ u⊢ₚ p : TVMem l T, i →
+    Γ u⊢ₚ pself p l : T, i
+| iP_Sub p T1 T2 i j :
+    Γ u⊢ₜ T1, i <: T2, i + j →
+    Γ u⊢ₚ p : T1, i →
+    (*───────────────────────────────*)
+    Γ u⊢ₚ p : T2, i + j
+| iP_Mu_I p T {i} :
+    is_unstamped_ty' (S (length Γ)) T →
+    Γ u⊢ₚ p : T .Tp[ p /], i →
+    Γ u⊢ₚ p : TMu T, i
+| iP_Mu_E p T {i} :
+    is_unstamped_ty' (S (length Γ)) T →
+    Γ u⊢ₚ p : TMu T, i →
+    Γ u⊢ₚ p : T .Tp[ p /], i
+| iP_Fld_I p T i l:
+    Γ u⊢ₚ pself p l : T, i →
+    (*─────────────────────────*)
+    Γ u⊢ₚ p : TVMem l T, i
+| iP_Sngl_Refl T p i :
+    Γ u⊢ₚ p : T, i →
+    Γ u⊢ₚ p : TSing p, i
+| iP_Sngl_Inv p q i:
+    Γ u⊢ₚ p : TSing q, i →
+    is_unstamped_path' (length Γ) q →
+    Γ u⊢ₚ q : TTop, i
+| iP_Sngl_Trans p q T i:
+    Γ u⊢ₚ p : TSing q, i →
+    Γ u⊢ₚ q : T, i →
+    Γ u⊢ₚ p : T, i
+| iP_Sngl_E T p q l i:
+    Γ u⊢ₚ p : TSing q, i →
+    Γ u⊢ₚ pself q l : T, i →
+    Γ u⊢ₚ pself p l : TSing (pself q l), i
+where "Γ u⊢ₚ p : T , i" := (path_typed Γ p T i)
+(* Γ u⊢ₜ T1, i1 <: T2, i2 means that TLater^i1 T1 <: TLater^i2 T2. *)
+with subtype Γ : ty → nat → ty → nat → Prop :=
+| iSub_Refl i T :
+    is_unstamped_ty' (length Γ) T →
+    Γ u⊢ₜ T, i <: T, i
+| iSub_Trans i2 T2 {i1 i3 T1 T3}:
+    Γ u⊢ₜ T1, i1 <: T2, i2 →
+    Γ u⊢ₜ T2, i2 <: T3, i3 →
+    Γ u⊢ₜ T1, i1 <: T3, i3
+| iLater_Sub i T:
+    is_unstamped_ty' (length Γ) T →
+    Γ u⊢ₜ TLater T, i <: T, S i
+| iSub_Later i T:
+    is_unstamped_ty' (length Γ) T →
+    Γ u⊢ₜ T, S i <: TLater T, i
+
+(* "Structural" rule about indexes *)
+| iSub_Add_Later T i:
+    is_unstamped_ty' (length Γ) T →
+    Γ u⊢ₜ T, i <: TLater T, i
+
+(* "Logical" connectives *)
+| iSub_Top i T :
+    is_unstamped_ty' (length Γ) T →
+    Γ u⊢ₜ T, i <: TTop, i
+| iBot_Sub i T :
+    is_unstamped_ty' (length Γ) T →
+    Γ u⊢ₜ TBot, i <: T, i
+| iAnd1_Sub T1 T2 i:
+    is_unstamped_ty' (length Γ) T1 →
+    is_unstamped_ty' (length Γ) T2 →
+    Γ u⊢ₜ TAnd T1 T2, i <: T1, i
+| iAnd2_Sub T1 T2 i:
+    is_unstamped_ty' (length Γ) T1 →
+    is_unstamped_ty' (length Γ) T2 →
+    Γ u⊢ₜ TAnd T1 T2, i <: T2, i
+| iSub_And T U1 U2 i j:
+    Γ u⊢ₜ T, i <: U1, j →
+    Γ u⊢ₜ T, i <: U2, j →
+    Γ u⊢ₜ T, i <: TAnd U1 U2, j
+| iSub_Or1 T1 T2 i:
+    is_unstamped_ty' (length Γ) T1 →
+    is_unstamped_ty' (length Γ) T2 →
+    Γ u⊢ₜ T1, i <: TOr T1 T2, i
+| iSub_Or2 T1 T2 i:
+    is_unstamped_ty' (length Γ) T1 →
+    is_unstamped_ty' (length Γ) T2 →
+    Γ u⊢ₜ T2, i <: TOr T1 T2, i
+| iOr_Sub T1 T2 U i j:
+    Γ u⊢ₜ T1, i <: U, j →
+    Γ u⊢ₜ T2, i <: U, j →
+    Γ u⊢ₜ TOr T1 T2, i <: U, j
+
+(* Type selections *)
+| iSel_Sub p L {l U i}:
+    Γ u⊢ₚ p : TTMem l L U, i →
+    Γ u⊢ₜ TSel p l, i <: U, i
+| iSub_Sel p U {l L i}:
+    Γ u⊢ₚ p : TTMem l L U, i →
+    Γ u⊢ₜ L, i <: TSel p l, i
+
+| iSngl_pq_Sub p q {i T1 T2}:
+    T1 ~Tp[ p := q ]* T2 →
+    is_unstamped_ty' (length Γ) T1 →
+    is_unstamped_ty' (length Γ) T2 →
+    Γ u⊢ₚ p : TSing q, i →
+    Γ u⊢ₜ T1, i <: T2, i
+| iSngl_Sub_Sym T {p q i}:
+    Γ u⊢ₚ p : T, i →
+    Γ u⊢ₜ TSing p, i <: TSing q, i →
+    Γ u⊢ₜ TSing q, i <: TSing p, i
+| iSngl_Sub_Self {p T i} :
+    Γ u⊢ₚ p : T, i →
+    Γ u⊢ₜ TSing p, i <: T, i
+
+(* Subtyping for recursive types. Congruence, and opening in both directions. *)
+| iMu_Sub_Mu T1 T2 i j:
+    (iterate TLater i T1 :: Γ) u⊢ₜ T1, i <: T2, j →
+    is_unstamped_ty' (S (length Γ)) T1 →
+    Γ u⊢ₜ TMu T1, i <: TMu T2, j
+| iMu_Sub T i:
+    is_unstamped_ty' (length Γ) T →
+    Γ u⊢ₜ TMu (shift T), i <: T, i
+| iSub_Mu T i:
+    is_unstamped_ty' (length Γ) T →
+    Γ u⊢ₜ T, i <: TMu (shift T), i
+
+(* "Congruence" or "variance" rules for subtyping. Unneeded for "logical" types. *)
+| iAll_Sub_All T1 T2 U1 U2 i:
+    Γ u⊢ₜ TLater T2, i <: TLater T1, i →
+    iterate TLater (S i) (shift T2) :: Γ u⊢ₜ TLater U1, i <: TLater U2, i →
+    is_unstamped_ty' (length Γ) T2 →
+    Γ u⊢ₜ TAll T1 U1, i <: TAll T2 U2, i
+| iFld_Sub_Fld T1 T2 i l:
+    Γ u⊢ₜ T1, i <: T2, i →
+    Γ u⊢ₜ TVMem l T1, i <: TVMem l T2, i
+| iTyp_Sub_Typ L1 L2 U1 U2 i l:
+    Γ u⊢ₜ L2, i <: L1, i →
+    Γ u⊢ₜ U1, i <: U2, i →
+    Γ u⊢ₜ TTMem l L1 U1, i <: TTMem l L2 U2, i
+  (* Is it true that for covariant F, F[A ∧ B] = F[A] ∧ F[B]?
+    Dotty assumes that, tho DOT didn't capture it.
+    F[A ∧ B] <: F[A] ∧ F[B] is provable by covariance.
+    Let's prove F[A] ∧ F[B] <: F[A ∧ B] in the model.
+    *)
+| iAnd_All_Sub_Distr T U1 U2 i:
+    is_unstamped_ty' (length Γ) T →
+    is_unstamped_ty' (S (length Γ)) U1 →
+    is_unstamped_ty' (S (length Γ)) U2 →
+    Γ u⊢ₜ TAnd (TAll T U1) (TAll T U2), i <: TAll T (TAnd U1 U2), i
+| iAnd_Fld_Sub_Distr l T1 T2 i:
+    is_unstamped_ty' (length Γ) T1 →
+    is_unstamped_ty' (length Γ) T2 →
+    Γ u⊢ₜ TAnd (TVMem l T1) (TVMem l T2), i <: TVMem l (TAnd T1 T2), i
+| iAnd_Typ_Sub_Distr l L U1 U2 i:
+    is_unstamped_ty' (length Γ) L →
+    is_unstamped_ty' (length Γ) U1 →
+    is_unstamped_ty' (length Γ) U2 →
+    Γ u⊢ₜ TAnd (TTMem l L U1) (TTMem l L U2), i <: TTMem l L (TAnd U1 U2), i
+| iDistr_And_Or_Sub {S T U i}:
+    is_unstamped_ty' (length Γ) S →
+    is_unstamped_ty' (length Γ) T →
+    is_unstamped_ty' (length Γ) U →
+    Γ u⊢ₜ TAnd (TOr S T) U , i <: TOr (TAnd S U) (TAnd T U), i
+| iSub_Skolem_P {T1 T2 i j}:
+    is_unstamped_ty' (length Γ) T1 →
+    iterate TLater i (shift T1) :: Γ u⊢ₚ pv (ids 0) : shift T2, j →
+    (*───────────────────────────────*)
+    Γ u⊢ₜ T1, i <: T2, j
+
+where "Γ u⊢ₜ T1 , i1 <: T2 , i2" := (subtype Γ T1 i1 T2 i2).
+
+Scheme unstamped_path_typed_mut_ind := Induction for path_typed Sort Prop
+with   unstamped_subtype_mut_ind := Induction for subtype Sort Prop.
+Combined Scheme old_pure_typing_mut_ind from unstamped_path_typed_mut_ind, unstamped_subtype_mut_ind.
+
+Hint Constructors path_typed subtype : core.
+(** Ensure [eauto]'s proof search does not diverge due to transitivity. *)
+Remove Hints iSub_Trans : core.
+Hint Extern 10 => try_once iSub_Trans : core.
+
+Lemma unstamped_path_root_is_var Γ p T i:
+  Γ u⊢ₚ p : T, i →
+  (∃ x, path_root p = var_vl x) ∨
+  (∃ l, path_root p = vlit l).
+Proof. by elim; intros; cbn; eauto 3 using is_unstamped_path_root. Qed.

--- a/theories/Dot/typing/old_subtyping_derived_rules.v
+++ b/theories/Dot/typing/old_subtyping_derived_rules.v
@@ -238,7 +238,7 @@ Lemma singleton_Mu_2 {Γ p T i} :
 Proof. intros Hp Hu; apply iSngl_Sub_Self, (iP_Mu_I Hu Hp). Qed.
 
 (* Avoid automation, to ensure we don't use [iP_Mu_E] to show them. *)
-Lemma iP_Mu_E' {Γ T p i} :
+Lemma iP_Mu_E_alt {Γ T p i} :
   Γ u⊢ₚ p : TMu T, i →
   is_unstamped_ty' (S (length Γ)) T →
   Γ u⊢ₚ p : T .Tp[ p /], i.
@@ -247,7 +247,7 @@ Proof.
   apply (singleton_Mu_1 Hp Hu).
 Qed.
 
-Lemma iP_Mu_I' {Γ T p i} :
+Lemma iP_Mu_I_alt {Γ T p i} :
   Γ u⊢ₚ p : T .Tp[ p /], i →
   is_unstamped_ty' (S (length Γ)) T →
   Γ u⊢ₚ p : TMu T, i.

--- a/theories/Dot/typing/old_subtyping_derived_rules.v
+++ b/theories/Dot/typing/old_subtyping_derived_rules.v
@@ -426,34 +426,3 @@ Proof.
   all: subtcrush.
   ettrans; first eapply comm_and; subtcrush.
 Qed.
-
-Lemma iP_Var' Γ x T1 T2 :
-  Γ !! x = Some T1 →
-  T2 = shiftN x T1 →
-  (*──────────────────────*)
-  Γ u⊢ₚ pv (var_vl x) : T2, 0.
-Proof. intros; subst; subtcrush. Qed.
-
-Lemma iP_Var0 Γ T :
-  Γ !! 0 = Some T →
-  (*──────────────────────*)
-  Γ u⊢ₚ pv (var_vl 0) : T, 0.
-Proof. intros; eapply iP_Var'; by rewrite ?hsubst_id. Qed.
-
-Ltac pvar := exact: iP_Var0 || exact: iP_Var'.
-
-Lemma iP_Var_Sub Γ x T1 T2 :
-  Γ !! x = Some T1 →
-  Γ u⊢ₜ shiftN x T1, 0 <: T2, 0 →
-  (*──────────────────────*)
-  Γ u⊢ₚ pv (var_vl x) : T2, 0.
-Proof. by intros; eapply iP_Sub'; [|pvar]. Qed.
-
-Lemma iP_Var0_Sub Γ T1 T2 :
-  Γ !! 0 = Some T1 →
-  Γ u⊢ₜ T1, 0 <: T2, 0 →
-  (*──────────────────────*)
-  Γ u⊢ₚ pv (var_vl 0) : T2, 0.
-Proof. intros. by eapply iP_Var_Sub; [| rewrite ?hsubst_id]. Qed.
-
-Ltac pvarsub := (eapply iP_Var0_Sub || eapply iP_Var_Sub); first done.

--- a/theories/Dot/typing/old_subtyping_derived_rules.v
+++ b/theories/Dot/typing/old_subtyping_derived_rules.v
@@ -313,3 +313,116 @@ Proof.
   by apply is_unstamped_TLater_n; stcrush.
   by asideLaters; subwtcrush.
 Qed.
+
+(* Lattice theory *)
+Lemma iOr_Sub_split Γ T1 T2 U1 U2 i:
+  is_unstamped_ty' (length Γ) U1 →
+  is_unstamped_ty' (length Γ) U2 →
+  Γ u⊢ₜ T1, i <: U1, i →
+  Γ u⊢ₜ T2, i <: U2, i →
+  Γ u⊢ₜ TOr T1 T2, i <: TOr U1 U2, i.
+Proof.
+  intros.
+  apply iOr_Sub; [
+    eapply iSub_Trans, iSub_Or1 | eapply iSub_Trans, iSub_Or2]; subtcrush.
+Qed.
+
+Lemma iSub_And_split Γ T1 T2 U1 U2 i:
+  is_unstamped_ty' (length Γ) T1 →
+  is_unstamped_ty' (length Γ) T2 →
+  Γ u⊢ₜ T1, i <: U1, i →
+  Γ u⊢ₜ T2, i <: U2, i →
+  Γ u⊢ₜ TAnd T1 T2, i <: TAnd U1 U2, i.
+Proof.
+  intros; apply iSub_And; [
+    eapply iSub_Trans; first apply iAnd1_Sub |
+    eapply iSub_Trans; first apply iAnd2_Sub]; subtcrush.
+Qed.
+
+Lemma iDistr_And_Or_Sub_inv {Γ S T U i}:
+  is_unstamped_ty' (length Γ) S →
+  is_unstamped_ty' (length Γ) T →
+  is_unstamped_ty' (length Γ) U →
+  Γ u⊢ₜ TOr (TAnd S U) (TAnd T U), i <: TAnd (TOr S T) U , i.
+Proof.
+  intros; apply iOr_Sub; apply iSub_And; subtcrush;
+    (ettrans; first apply iAnd1_Sub); subtcrush.
+Qed.
+
+Lemma iDistr_Or_And_Sub {Γ S T U i}:
+  is_unstamped_ty' (length Γ) S →
+  is_unstamped_ty' (length Γ) T →
+  is_unstamped_ty' (length Γ) U →
+  Γ u⊢ₜ TOr (TAnd S T) U , i <: TAnd (TOr S U) (TOr T U), i.
+Proof.
+  intros; apply iOr_Sub; apply iSub_And; subtcrush;
+    (ettrans; last apply iSub_Or1); subtcrush.
+Qed.
+
+Lemma comm_and {Γ T U i} :
+  is_unstamped_ty' (length Γ) T →
+  is_unstamped_ty' (length Γ) U →
+  Γ u⊢ₜ TAnd T U, i <: TAnd U T, i.
+Proof. intros; subtcrush. Qed.
+
+Lemma comm_or {Γ T U i} :
+  is_unstamped_ty' (length Γ) T →
+  is_unstamped_ty' (length Γ) U →
+  Γ u⊢ₜ TOr T U, i <: TOr U T, i.
+Proof. intros; subtcrush. Qed.
+
+Lemma absorb_and_or {Γ T U i} :
+  is_unstamped_ty' (length Γ) T →
+  is_unstamped_ty' (length Γ) U →
+  Γ u⊢ₜ TAnd U (TOr T U), i <: U, i.
+Proof. intros; subtcrush. Qed.
+
+Lemma absorb_or_and {Γ T U i} :
+  is_unstamped_ty' (length Γ) T →
+  is_unstamped_ty' (length Γ) U →
+  Γ u⊢ₜ TOr U (TAnd T U), i <: U, i.
+Proof. intros; subtcrush. Qed.
+
+Lemma absorb_or_and2 {Γ T U i} :
+  is_unstamped_ty' (length Γ) T →
+  is_unstamped_ty' (length Γ) U →
+  Γ u⊢ₜ TOr (TAnd T U) T, i <: T, i.
+Proof. intros; ettrans; first apply comm_or; subtcrush. Qed.
+
+Lemma assoc_or {Γ S T U i} :
+  is_unstamped_ty' (length Γ) S →
+  is_unstamped_ty' (length Γ) T →
+  is_unstamped_ty' (length Γ) U →
+  Γ u⊢ₜ TOr (TOr S T) U, i <: TOr S (TOr T U), i.
+Proof. intros; subtcrush; (ettrans; last apply iSub_Or2); subtcrush. Qed.
+
+Lemma assoc_and {Γ S T U i} :
+  is_unstamped_ty' (length Γ) S →
+  is_unstamped_ty' (length Γ) T →
+  is_unstamped_ty' (length Γ) U →
+  Γ u⊢ₜ TAnd (TAnd S T) U, i <: TAnd S (TAnd T U), i.
+Proof. intros. subtcrush; lThis. Qed.
+
+(* Based on Lemma 4.3 in
+https://books.google.co.uk/books?id=vVVTxeuiyvQC&lpg=PA104&pg=PA85#v=onepage&q&f=false.
+Would be much easier to formalize with setoid rewriting.
+*)
+Lemma iDistr_Or_And_Sub_inv {Γ S T U i}:
+  is_unstamped_ty' (length Γ) S →
+  is_unstamped_ty' (length Γ) T →
+  is_unstamped_ty' (length Γ) U →
+  Γ u⊢ₜ TAnd (TOr S U) (TOr T U), i <: TOr (TAnd S T) U , i.
+Proof.
+  intros.
+  ettrans; first apply iDistr_And_Or_Sub; stcrush => //.
+  ettrans; first apply iOr_Sub_split, absorb_and_or; try apply iSub_Refl;
+    stcrush => //.
+  ettrans; first apply iOr_Sub_split; try apply (iSub_Refl _ (T := U));
+    try (ettrans; first apply (comm_and (T := S))); try apply iDistr_And_Or_Sub; stcrush => //.
+  ettrans; first apply assoc_or; stcrush => //.
+  ettrans; first apply iOr_Sub_split.
+  3: apply iSub_Refl; subtcrush.
+  3: ettrans; first apply absorb_or_and2; subtcrush.
+  all: subtcrush.
+  ettrans; first eapply comm_and; subtcrush.
+Qed.

--- a/theories/Dot/typing/old_subtyping_derived_rules.v
+++ b/theories/Dot/typing/old_subtyping_derived_rules.v
@@ -426,3 +426,34 @@ Proof.
   all: subtcrush.
   ettrans; first eapply comm_and; subtcrush.
 Qed.
+
+Lemma iP_Var' Γ x T1 T2 :
+  Γ !! x = Some T1 →
+  T2 = shiftN x T1 →
+  (*──────────────────────*)
+  Γ u⊢ₚ pv (var_vl x) : T2, 0.
+Proof. intros; subst; subtcrush. Qed.
+
+Lemma iP_Var0 Γ T :
+  Γ !! 0 = Some T →
+  (*──────────────────────*)
+  Γ u⊢ₚ pv (var_vl 0) : T, 0.
+Proof. intros; eapply iP_Var'; by rewrite ?hsubst_id. Qed.
+
+Ltac pvar := exact: iP_Var0 || exact: iP_Var'.
+
+Lemma iP_Var_Sub Γ x T1 T2 :
+  Γ !! x = Some T1 →
+  Γ u⊢ₜ shiftN x T1, 0 <: T2, 0 →
+  (*──────────────────────*)
+  Γ u⊢ₚ pv (var_vl x) : T2, 0.
+Proof. by intros; eapply iP_Sub'; [|pvar]. Qed.
+
+Lemma iP_Var0_Sub Γ T1 T2 :
+  Γ !! 0 = Some T1 →
+  Γ u⊢ₜ T1, 0 <: T2, 0 →
+  (*──────────────────────*)
+  Γ u⊢ₚ pv (var_vl 0) : T2, 0.
+Proof. intros. by eapply iP_Var_Sub; [| rewrite ?hsubst_id]. Qed.
+
+Ltac pvarsub := (eapply iP_Var0_Sub || eapply iP_Var_Sub); first done.

--- a/theories/Dot/typing/old_subtyping_derived_rules.v
+++ b/theories/Dot/typing/old_subtyping_derived_rules.v
@@ -1,0 +1,315 @@
+From D Require Import tactics.
+From D.Dot Require Import unstampedness_binding.
+From D.Dot Require Import path_repl_lemmas.
+From D.Dot Require Import syn syn_lemmas ex_utils old_subtyping.
+Import DBNotation.
+
+Ltac subtcrush := repeat first [ eassumption | reflexivity | subtypconstructor | stcrush ].
+
+Ltac subwtcrush := repeat first [ fast_done | subtypconstructor | stcrush ] ; try solve [
+  first [
+    by eauto 3 using is_unstamped_TLater_n, is_unstamped_ren1_ty, is_unstamped_ren1_path |
+    try_once is_unstamped_weaken_dm |
+    try_once is_unstamped_weaken_ty |
+    try_once is_unstamped_weaken_path ]; eauto].
+
+Ltac asideLaters :=
+  repeat first
+    [ettrans; last (apply iSub_Later; subtcrush)|
+    ettrans; first (apply iLater_Sub; subtcrush)].
+
+Ltac lNext := ettrans; first apply iAnd2_Sub; subtcrush.
+Ltac lThis := ettrans; first apply iAnd1_Sub; subtcrush.
+
+Ltac lookup :=
+  lazymatch goal with
+  | |- _ u⊢ₜ ?T1, _ <: ?T2, _ =>
+    let T1' := eval hnf in T1 in
+    match T1' with
+    | (TAnd ?T11 ?T12) =>
+      (* first [unify (label_of_ty T11) (label_of_ty T2); lThis | lNext] *)
+      let ls := eval cbv in (label_of_ty T11, label_of_ty T2) in
+      match ls with
+      | (Some ?l1, Some ?l1) => lThis
+      | (Some ?l1, Some ?l2) => lNext
+      end
+    end
+  end.
+Ltac subltcrush := subtcrush; repeat lookup.
+
+Lemma iSub_SelL {Γ p U l L i}:
+  Γ u⊢ₚ p : TTMemL l L U, i →
+  Γ u⊢ₜ TLater L, i <: TSel p l, i.
+Proof. intros; exact: iSub_Sel. Qed.
+
+Lemma iSel_SubL {Γ p L l U i}:
+  Γ u⊢ₚ p : TTMemL l L U, i →
+  Γ u⊢ₜ TSel p l, i <: TLater U, i.
+Proof. intros; exact: iSel_Sub. Qed.
+
+Lemma iSub_Sel' U {Γ p l L i}:
+  is_unstamped_ty' (length Γ) L →
+  Γ u⊢ₚ p : TTMemL l L U, i →
+  Γ u⊢ₜ L, i <: TSel p l, i.
+Proof. intros; ettrans; last exact: (iSub_Sel (p := p)); subtcrush. Qed.
+
+(** Specialization of [iSub_Sel'] for convenience. *)
+Lemma iSub_Sel'' Γ {p l L i}:
+  is_unstamped_ty' (length Γ) L →
+  Γ u⊢ₚ p : TTMemL l L L, i → Γ u⊢ₜ L, i <: TSel p l, i.
+Proof. apply iSub_Sel'. Qed.
+
+(** * Manipulating laters, basics. *)
+
+Lemma iSub_AddIJ {Γ T} i j (Hst: is_unstamped_ty' (length Γ) T) :
+  Γ u⊢ₜ T, j <: T, i + j.
+Proof.
+  elim: i => [|n IHn]; first subtcrush.
+  ettrans; first apply IHn.
+  ettrans; [exact: iSub_Add_Later | subtcrush].
+Qed.
+
+Lemma iSub_AddIJ' {Γ T} i j (Hst: is_unstamped_ty' (length Γ) T) (Hle : i <= j) :
+  Γ u⊢ₜ T, i <: T, j.
+Proof. rewrite (le_plus_minus i j Hle) Nat.add_comm. exact: iSub_AddIJ. Qed.
+
+Lemma iSub_AddI Γ T i (Hst: is_unstamped_ty' (length Γ) T) :
+  Γ u⊢ₜ T, 0 <: T, i.
+Proof. apply (iSub_AddIJ' 0 i); by [|lia]. Qed.
+
+Lemma path_tp_delay {Γ p T i j} (Hst: is_unstamped_ty' (length Γ) T) : i <= j →
+  Γ u⊢ₚ p : T, i → Γ u⊢ₚ p : T, j.
+Proof.
+  intros Hle Hp.
+  rewrite (le_plus_minus i j Hle); move: {j Hle} (j - i) => k.
+  eapply iP_Sub, Hp.
+  apply: iSub_AddIJ'; by [|lia].
+Qed.
+
+(** * Derived constructions. *)
+(* We can derive rules iSub_Bind_1 and iSub_Bind_2 (the latter only conjectured) from
+  "Type Soundness for Dependent Object Types (DOT)", Rompf and Amin, OOPSLA '16. *)
+Lemma iSub_Bind_1 Γ T1 T2 i:
+  is_unstamped_ty' (S (length Γ)) T1 → is_unstamped_ty' (length Γ) T2 →
+  iterate TLater i T1 :: Γ u⊢ₜ T1, i <: shift T2, i →
+  Γ u⊢ₜ μ T1, i <: T2, i.
+Proof.
+  intros Hus1 Hus2 Hsub.
+  ettrans; first exact: (iMu_Sub_Mu Hsub).
+  exact: iMu_Sub.
+Qed.
+
+Lemma iSub_Bind_2 Γ T1 T2 i:
+  is_unstamped_ty' (length Γ) T1 → is_unstamped_ty' (S (length Γ)) T2 →
+  iterate TLater i (shift T1) :: Γ u⊢ₜ shift T1, i <: T2, i →
+  Γ u⊢ₜ T1, i <: μ T2, i.
+Proof.
+  intros Hus1 Hus2 Hsub.
+  ettrans; last apply (iMu_Sub_Mu Hsub); [exact: iSub_Mu | subwtcrush].
+Qed.
+
+Lemma iSub_Bind_1' Γ T1 T2:
+  is_unstamped_ty' (S (length Γ)) T1 → is_unstamped_ty' (length Γ) T2 →
+  T1 :: Γ u⊢ₜ T1, 0 <: shift T2, 0 →
+  Γ u⊢ₜ μ T1, 0 <: T2, 0.
+Proof. intros; exact: iSub_Bind_1. Qed.
+
+Lemma iSub_Bind_2' Γ T1 T2:
+  is_unstamped_ty' (length Γ) T1 → is_unstamped_ty' (S (length Γ)) T2 →
+  shift T1 :: Γ u⊢ₜ shift T1, 0 <: T2, 0 →
+  Γ u⊢ₜ T1, 0 <: μ T2, 0.
+Proof. intros; exact: iSub_Bind_2. Qed.
+
+Lemma iMu_Sub' {Γ T T' i}:
+  T' = shift T →
+  is_unstamped_ty' (length Γ) T →
+  Γ u⊢ₜ μ T', i <: T, i.
+Proof. intros; subst. auto. Qed.
+
+
+Lemma iP_Sngl_Sym Γ p q i:
+  is_unstamped_path' (length Γ) q →
+  Γ u⊢ₚ p : TSing q, i →
+  Γ u⊢ₚ q : TSing p, i.
+Proof.
+  intros Hus Hpq. eapply iP_Sub'.
+  eapply (iSngl_Sub_Sym Hpq). by apply iSngl_Sub_Self, Hpq.
+  eapply iP_Sngl_Refl.
+  by apply (iP_Sngl_Inv Hpq).
+Qed.
+
+Lemma iSngl_pq_Sub_inv {Γ i p q T1 T2}:
+  T1 ~Tp[ p := q ]* T2 →
+  is_unstamped_ty' (length Γ) T1 →
+  is_unstamped_ty' (length Γ) T2 →
+  is_unstamped_path' (length Γ) p →
+  Γ u⊢ₚ q : TSing p, i →
+  Γ u⊢ₜ T1, i <: T2, i.
+Proof. intros. by eapply iSngl_pq_Sub, iP_Sngl_Sym. Qed.
+
+Lemma iP_And {Γ p T1 T2 i}:
+  Γ u⊢ₚ p : T1, i →
+  Γ u⊢ₚ p : T2, i →
+  Γ u⊢ₚ p : TAnd T1 T2, i.
+Proof.
+  intros Hp1 Hp2. eapply iP_Sub', iP_Sngl_Refl, Hp1.
+  apply iSub_And; exact: iSngl_Sub_Self.
+Qed.
+
+(** * Manipulating laters, more. *)
+Lemma iSub_LaterN Γ T i j:
+  is_unstamped_ty' (length Γ) T →
+  Γ u⊢ₜ T, j + i <: iterate TLater j T, i.
+Proof.
+  elim: j T => /= [|j IHj] T HuT; rewrite ?iterate_0 ?iterate_Sr /=; subtcrush.
+  ettrans.
+  - exact: iSub_Later.
+  - apply (IHj (TLater T)); stcrush.
+Qed.
+
+Lemma iLaterN_Sub {Γ T} i j :
+  is_unstamped_ty' (length Γ) T →
+  Γ u⊢ₜ iterate TLater j T, i <: T, j + i.
+Proof.
+  elim: j T => /= [|j IHj] T HuT; rewrite ?iterate_0 ?iterate_Sr /=; subtcrush.
+  ettrans.
+  - apply (IHj (TLater T)); stcrush.
+  - exact: iLater_Sub.
+Qed.
+
+Lemma selfIntersect Γ T U i j:
+  is_unstamped_ty' (length Γ) T →
+  Γ u⊢ₜ T, i <: U, j + i →
+  Γ u⊢ₜ T, i <: TAnd U T, j + i .
+Proof. intros; subtcrush. exact: iSub_AddIJ. Qed.
+
+Lemma iAnd_Later_Sub_Distr Γ T1 T2 i :
+  is_unstamped_ty' (length Γ) T1 →
+  is_unstamped_ty' (length Γ) T2 →
+  Γ u⊢ₜ TAnd (TLater T1) (TLater T2), i <: TLater (TAnd T1 T2), i.
+Proof. intros; asideLaters; subtcrush; [lThis|lNext]. Qed.
+
+(** Inverse of [iAnd_Later_Sub_Distr]. *)
+Lemma iAnd_Later_Sub_Distr_inv Γ T1 T2 i :
+  is_unstamped_ty' (length Γ) T1 →
+  is_unstamped_ty' (length Γ) T2 →
+  Γ u⊢ₜ TLater (TAnd T1 T2), i <: TAnd (TLater T1) (TLater T2), i.
+Proof. intros; subtcrush. Qed.
+
+Lemma iOr_Later_Sub_Distr Γ T1 T2 i :
+  is_unstamped_ty' (length Γ) T1 →
+  is_unstamped_ty' (length Γ) T2 →
+  Γ u⊢ₜ TOr (TLater T1) (TLater T2), i <: TLater (TOr T1 T2), i.
+Proof. intros; subtcrush. Qed.
+
+(** Inverse of [iOr_Later_Sub_Distr]. *)
+Lemma iOr_Later_Sub_Distr_inv Γ T1 T2 i :
+  is_unstamped_ty' (length Γ) T1 →
+  is_unstamped_ty' (length Γ) T2 →
+  Γ u⊢ₜ TLater (TOr T1 T2), i <: TOr (TLater T1) (TLater T2), i.
+Proof.
+  intros; asideLaters; subtypconstructor; ettrans;
+    [| apply iSub_Or1 | | apply iSub_Or2]; subtcrush.
+Qed.
+
+(** TLater swaps with TMu, part 1. *)
+Lemma iMu_Later_Sub_Distr Γ T i :
+  is_unstamped_ty' (S (length Γ)) T →
+  Γ u⊢ₜ TMu (TLater T), i <: TLater (TMu T), i.
+Proof. intros; asideLaters; subtcrush. Qed.
+
+(** TLater swaps with TMu, part 2. *)
+Lemma iMu_Later_Sub_Distr_inv Γ T i :
+  is_unstamped_ty' (S (length Γ)) T →
+  Γ u⊢ₜ TLater (TMu T), i <: TMu (TLater T), i.
+Proof. intros; asideLaters; subtcrush. Qed.
+
+(** Show that [singleton_Mu_[12]] and [iP_Mu_[IE]] are interderivable. *)
+Lemma singleton_Mu_1 {Γ p T i} :
+  Γ u⊢ₚ p : TMu T, i →
+  is_unstamped_ty' (S (length Γ)) T →
+  Γ u⊢ₜ TSing p, i <: T .Tp[ p /], i.
+Proof. intros Hp Hu; apply iSngl_Sub_Self, (iP_Mu_E Hu Hp). Qed.
+
+Lemma singleton_Mu_2 {Γ p T i} :
+  Γ u⊢ₚ p : T .Tp[ p /], i →
+  is_unstamped_ty' (S (length Γ)) T →
+  Γ u⊢ₜ TSing p, i <: TMu T, i.
+Proof. intros Hp Hu; apply iSngl_Sub_Self, (iP_Mu_I Hu Hp). Qed.
+
+(* Avoid automation, to ensure we don't use [iP_Mu_E] to show them. *)
+Lemma iP_Mu_E' {Γ T p i} :
+  Γ u⊢ₚ p : TMu T, i →
+  is_unstamped_ty' (S (length Γ)) T →
+  Γ u⊢ₚ p : T .Tp[ p /], i.
+Proof.
+  intros Hp Hu. eapply iP_Sub', (iP_Sngl_Refl Hp).
+  apply (singleton_Mu_1 Hp Hu).
+Qed.
+
+Lemma iP_Mu_I' {Γ T p i} :
+  Γ u⊢ₚ p : T .Tp[ p /], i →
+  is_unstamped_ty' (S (length Γ)) T →
+  Γ u⊢ₚ p : TMu T, i.
+Proof.
+  intros Hp Hu. eapply iP_Sub', (iP_Sngl_Refl Hp).
+  apply (singleton_Mu_2 Hp Hu).
+Qed.
+
+(**
+Show soundness of subtyping for recursive types in the Dotty compiler — just cases in subtype checking.
+
+The first case is in
+https://github.com/lampepfl/dotty/blob/0.20.0-RC1/compiler/src/dotty/tools/dotc/core/TypeComparer.scala#L550-L552
+And that matches iMu_Sub_Mu.
+
+https://github.com/lampepfl/dotty/blob/0.20.0-RC1/compiler/src/dotty/tools/dotc/core/TypeComparer.scala#L554-L557
+We formalize that as the derived rule below.
+
+The action of [fixRecs] depends on the type [T1] of [p].
+Hence, here we we assume the action of [fixRecs] has already been carried out:
+to do that, one must unfold top-level recursive types in the type of [p],
+as allowed through [P_Mu_E], rules for intersection types and intersection introduction.
+On the other hand, this derived rule handles the substitution in [T2] directly.
+*)
+Lemma singleton_Mu_dotty1 {Γ p i T1' T2} :
+  Γ u⊢ₜ T1', i <: T2 .Tp[ p /], i →
+  Γ u⊢ₚ p : T1', i →
+  is_unstamped_ty' (S (length Γ)) T2 →
+  Γ u⊢ₜ TSing p, i <: TMu T2, i.
+Proof.
+  intros Hsub Hp Hu.
+  apply singleton_Mu_2, Hu.
+  apply (iP_Sub' Hsub Hp).
+Qed.
+
+Lemma iP_LaterN {Γ p T i j} :
+  is_unstamped_ty' (length Γ) T →
+  Γ u⊢ₚ p : iterate TLater j T, i →
+  Γ u⊢ₚ p : T, i + j.
+Proof.
+  elim: j i => [|j IHj] i Hu Hp; rewrite (plusnO, plusnS); first done.
+  apply (IHj (S i)), iP_Later, Hp; subtcrush; exact: is_unstamped_TLater_n.
+Qed.
+
+Lemma iMu_LaterN_Sub_Distr_inv {Γ T i n} :
+  is_unstamped_ty' (S (length Γ)) T →
+  Γ u⊢ₜ iterate TLater n (TMu T), i <: TMu (iterate TLater n T), i.
+Proof.
+  intros Hu.
+  elim: n i => [|n IHn] i; first subtcrush; rewrite !iterate_S.
+  ettrans; last apply iMu_Later_Sub_Distr_inv.
+  by asideLaters; subwtcrush.
+  by apply is_unstamped_TLater_n; stcrush.
+Qed.
+
+Lemma iMu_LaterN_Sub_Distr {Γ T i n} :
+  is_unstamped_ty' (S (length Γ)) T →
+  Γ u⊢ₜ TMu (iterate TLater n T), i <: iterate TLater n (TMu T), i.
+Proof.
+  intros Hu.
+  elim: n i => [|n IHn] i; first subtcrush; rewrite !iterate_S.
+  ettrans; first apply iMu_Later_Sub_Distr.
+  by apply is_unstamped_TLater_n; stcrush.
+  by asideLaters; subwtcrush.
+Qed.

--- a/theories/Dot/typing/old_unstamped_typing.v
+++ b/theories/Dot/typing/old_unstamped_typing.v
@@ -17,10 +17,8 @@ Unset Strict Implicit.
 Implicit Types (L T U : ty) (v : vl) (e : tm) (d : dm) (p: path) (ds : dms) (Γ : list ty).
 
 Reserved Notation "Γ u⊢ₜ e : T" (at level 74, e, T at next level).
-Reserved Notation "Γ u⊢ₚ p : T , i" (at level 74, p, T, i at next level).
 Reserved Notation "Γ u⊢{ l := d  } : T" (at level 74, l, d, T at next level).
 Reserved Notation "Γ u⊢ds ds : T" (at level 74, ds, T at next level).
-Reserved Notation "Γ u⊢ₜ T1 , i1 <: T2 , i2" (at level 74, T1, T2, i1, i2 at next level).
 
 (** ** Judgments for typing, subtyping, path and definition typing. *)
 Inductive typed Γ : tm → ty → Prop :=

--- a/theories/Dot/typing/old_unstamped_typing.v
+++ b/theories/Dot/typing/old_unstamped_typing.v
@@ -209,7 +209,7 @@ Lemma iT_Var {Γ x T}
   Γ u⊢ₜ tv (var_vl x) : shiftN x T.
 Proof. apply iT_Path'. eauto. Qed.
 
-Lemma iP_Var' {Γ x T} :
+Lemma iP_VarT {Γ x T} :
   Γ u⊢ₜ tv (var_vl x) : T →
   Γ u⊢ₚ pv (var_vl x) : T, 0.
 Proof.
@@ -234,7 +234,7 @@ Ltac typconstructor :=
       constructor]
   | |- dms_typed ?Γ _ _ => constructor
   | |- dm_typed ?Γ _ _ _ => first [apply iD_All | constructor]
-  | |- path_typed ?Γ _ _ _ => first [apply iP_Later | apply iP_Var' | constructor]
+  | |- path_typed ?Γ _ _ _ => first [apply iP_Later | apply iP_VarT | constructor]
   | |- subtype ?Γ _ _ _ _ =>
     first [apply Sub_later_shift | constructor ]; typconstructor_blacklist Γ
   end.

--- a/theories/Dot/typing/old_unstamped_typing.v
+++ b/theories/Dot/typing/old_unstamped_typing.v
@@ -8,7 +8,7 @@ This judgment allowing only variables in paths, and not arbitrary values.
 *)
 From D Require Import tactics.
 From D.Dot Require Export syn path_repl lr_syn_aux.
-From D.Dot.typing Require Export typing_aux_defs.
+From D.Dot.typing Require Export typing_aux_defs old_subtyping.
 From D.Dot.stamping Require Export core_stamping_defs.
 
 Set Implicit Arguments.
@@ -114,205 +114,17 @@ with dm_typed Γ : label → dm → ty → Prop :=
     Γ u⊢ₜ T1, 0 <: T2, 0 →
     Γ u⊢{ l := dpt p } : TVMem l T1 →
     Γ u⊢{ l := dpt p } : TVMem l T2
-where "Γ u⊢{ l := d  } : T" := (dm_typed Γ l d T)
-with path_typed Γ : path → ty → nat → Prop :=
-| iP_Var x T:
-    Γ !! x = Some T →
-    (* After looking up in Γ, we must weaken T for the variables on top of x. *)
-    Γ u⊢ₚ pv (var_vl x) : shiftN x T, 0
-| iP_Fld_E p T i l:
-    Γ u⊢ₚ p : TVMem l T, i →
-    Γ u⊢ₚ pself p l : T, i
-| iP_Sub p T1 T2 i j :
-    Γ u⊢ₜ T1, i <: T2, i + j →
-    Γ u⊢ₚ p : T1, i →
-    (*───────────────────────────────*)
-    Γ u⊢ₚ p : T2, i + j
-| iP_Mu_I p T {i} :
-    is_unstamped_ty' (S (length Γ)) T →
-    Γ u⊢ₚ p : T .Tp[ p /], i →
-    Γ u⊢ₚ p : TMu T, i
-| iP_Mu_E p T {i} :
-    is_unstamped_ty' (S (length Γ)) T →
-    Γ u⊢ₚ p : TMu T, i →
-    Γ u⊢ₚ p : T .Tp[ p /], i
-| iP_Fld_I p T i l:
-    Γ u⊢ₚ pself p l : T, i →
-    (*─────────────────────────*)
-    Γ u⊢ₚ p : TVMem l T, i
-| iP_Sngl_Refl T p i :
-    Γ u⊢ₚ p : T, i →
-    Γ u⊢ₚ p : TSing p, i
-| iP_Sngl_Inv p q i:
-    Γ u⊢ₚ p : TSing q, i →
-    is_unstamped_path' (length Γ) q →
-    Γ u⊢ₚ q : TTop, i
-| iP_Sngl_Trans p q T i:
-    Γ u⊢ₚ p : TSing q, i →
-    Γ u⊢ₚ q : T, i →
-    Γ u⊢ₚ p : T, i
-| iP_Sngl_E T p q l i:
-    Γ u⊢ₚ p : TSing q, i →
-    Γ u⊢ₚ pself q l : T, i →
-    Γ u⊢ₚ pself p l : TSing (pself q l), i
-where "Γ u⊢ₚ p : T , i" := (path_typed Γ p T i)
-(* Γ u⊢ₜ T1, i1 <: T2, i2 means that TLater^i1 T1 <: TLater^i2 T2. *)
-with subtype Γ : ty → nat → ty → nat → Prop :=
-| iSub_Refl i T :
-    is_unstamped_ty' (length Γ) T →
-    Γ u⊢ₜ T, i <: T, i
-| iSub_Trans i2 T2 {i1 i3 T1 T3}:
-    Γ u⊢ₜ T1, i1 <: T2, i2 →
-    Γ u⊢ₜ T2, i2 <: T3, i3 →
-    Γ u⊢ₜ T1, i1 <: T3, i3
-| iLater_Sub i T:
-    is_unstamped_ty' (length Γ) T →
-    Γ u⊢ₜ TLater T, i <: T, S i
-| iSub_Later i T:
-    is_unstamped_ty' (length Γ) T →
-    Γ u⊢ₜ T, S i <: TLater T, i
-
-(* "Structural" rule about indexes *)
-| iSub_Add_Later T i:
-    is_unstamped_ty' (length Γ) T →
-    Γ u⊢ₜ T, i <: TLater T, i
-
-(* "Logical" connectives *)
-| iSub_Top i T :
-    is_unstamped_ty' (length Γ) T →
-    Γ u⊢ₜ T, i <: TTop, i
-| iBot_Sub i T :
-    is_unstamped_ty' (length Γ) T →
-    Γ u⊢ₜ TBot, i <: T, i
-| iAnd1_Sub T1 T2 i:
-    is_unstamped_ty' (length Γ) T1 →
-    is_unstamped_ty' (length Γ) T2 →
-    Γ u⊢ₜ TAnd T1 T2, i <: T1, i
-| iAnd2_Sub T1 T2 i:
-    is_unstamped_ty' (length Γ) T1 →
-    is_unstamped_ty' (length Γ) T2 →
-    Γ u⊢ₜ TAnd T1 T2, i <: T2, i
-| iSub_And T U1 U2 i j:
-    Γ u⊢ₜ T, i <: U1, j →
-    Γ u⊢ₜ T, i <: U2, j →
-    Γ u⊢ₜ T, i <: TAnd U1 U2, j
-| iSub_Or1 T1 T2 i:
-    is_unstamped_ty' (length Γ) T1 →
-    is_unstamped_ty' (length Γ) T2 →
-    Γ u⊢ₜ T1, i <: TOr T1 T2, i
-| iSub_Or2 T1 T2 i:
-    is_unstamped_ty' (length Γ) T1 →
-    is_unstamped_ty' (length Γ) T2 →
-    Γ u⊢ₜ T2, i <: TOr T1 T2, i
-| iOr_Sub T1 T2 U i j:
-    Γ u⊢ₜ T1, i <: U, j →
-    Γ u⊢ₜ T2, i <: U, j →
-    Γ u⊢ₜ TOr T1 T2, i <: U, j
-
-(* Type selections *)
-| iSel_Sub p L {l U i}:
-    Γ u⊢ₚ p : TTMem l L U, i →
-    Γ u⊢ₜ TSel p l, i <: U, i
-| iSub_Sel p U {l L i}:
-    Γ u⊢ₚ p : TTMem l L U, i →
-    Γ u⊢ₜ L, i <: TSel p l, i
-
-| iSngl_pq_Sub p q {i T1 T2}:
-    T1 ~Tp[ p := q ]* T2 →
-    is_unstamped_ty' (length Γ) T1 →
-    is_unstamped_ty' (length Γ) T2 →
-    Γ u⊢ₚ p : TSing q, i →
-    Γ u⊢ₜ T1, i <: T2, i
-| iSngl_Sub_Sym T {p q i}:
-    Γ u⊢ₚ p : T, i →
-    Γ u⊢ₜ TSing p, i <: TSing q, i →
-    Γ u⊢ₜ TSing q, i <: TSing p, i
-| iSngl_Sub_Self {p T i} :
-    Γ u⊢ₚ p : T, i →
-    Γ u⊢ₜ TSing p, i <: T, i
-
-(* Subtyping for recursive types. Congruence, and opening in both directions. *)
-| iMu_Sub_Mu T1 T2 i j:
-    (iterate TLater i T1 :: Γ) u⊢ₜ T1, i <: T2, j →
-    is_unstamped_ty' (S (length Γ)) T1 →
-    Γ u⊢ₜ TMu T1, i <: TMu T2, j
-| iMu_Sub T i:
-    is_unstamped_ty' (length Γ) T →
-    Γ u⊢ₜ TMu (shift T), i <: T, i
-| iSub_Mu T i:
-    is_unstamped_ty' (length Γ) T →
-    Γ u⊢ₜ T, i <: TMu (shift T), i
-
-(* "Congruence" or "variance" rules for subtyping. Unneeded for "logical" types. *)
-| iAll_Sub_All T1 T2 U1 U2 i:
-    Γ u⊢ₜ TLater T2, i <: TLater T1, i →
-    iterate TLater (S i) (shift T2) :: Γ u⊢ₜ TLater U1, i <: TLater U2, i →
-    is_unstamped_ty' (length Γ) T2 →
-    Γ u⊢ₜ TAll T1 U1, i <: TAll T2 U2, i
-| iFld_Sub_Fld T1 T2 i l:
-    Γ u⊢ₜ T1, i <: T2, i →
-    Γ u⊢ₜ TVMem l T1, i <: TVMem l T2, i
-| iTyp_Sub_Typ L1 L2 U1 U2 i l:
-    Γ u⊢ₜ L2, i <: L1, i →
-    Γ u⊢ₜ U1, i <: U2, i →
-    Γ u⊢ₜ TTMem l L1 U1, i <: TTMem l L2 U2, i
-  (* Is it true that for covariant F, F[A ∧ B] = F[A] ∧ F[B]?
-    Dotty assumes that, tho DOT didn't capture it.
-    F[A ∧ B] <: F[A] ∧ F[B] is provable by covariance.
-    Let's prove F[A] ∧ F[B] <: F[A ∧ B] in the model.
-    *)
-| iAnd_All_Sub_Distr T U1 U2 i:
-    is_unstamped_ty' (length Γ) T →
-    is_unstamped_ty' (S (length Γ)) U1 →
-    is_unstamped_ty' (S (length Γ)) U2 →
-    Γ u⊢ₜ TAnd (TAll T U1) (TAll T U2), i <: TAll T (TAnd U1 U2), i
-| iAnd_Fld_Sub_Distr l T1 T2 i:
-    is_unstamped_ty' (length Γ) T1 →
-    is_unstamped_ty' (length Γ) T2 →
-    Γ u⊢ₜ TAnd (TVMem l T1) (TVMem l T2), i <: TVMem l (TAnd T1 T2), i
-| iAnd_Typ_Sub_Distr l L U1 U2 i:
-    is_unstamped_ty' (length Γ) L →
-    is_unstamped_ty' (length Γ) U1 →
-    is_unstamped_ty' (length Γ) U2 →
-    Γ u⊢ₜ TAnd (TTMem l L U1) (TTMem l L U2), i <: TTMem l L (TAnd U1 U2), i
-| iDistr_And_Or_Sub {S T U i}:
-    is_unstamped_ty' (length Γ) S →
-    is_unstamped_ty' (length Γ) T →
-    is_unstamped_ty' (length Γ) U →
-    Γ u⊢ₜ TAnd (TOr S T) U , i <: TOr (TAnd S U) (TAnd T U), i
-
-| iSub_Skolem_P {T1 T2 i j}:
-    is_unstamped_ty' (length Γ) T1 →
-    iterate TLater i (shift T1) :: Γ u⊢ₚ pv (ids 0) : shift T2, j →
-    (*───────────────────────────────*)
-    Γ u⊢ₜ T1, i <: T2, j
-where "Γ u⊢ₜ T1 , i1 <: T2 , i2" := (subtype Γ T1 i1 T2 i2).
+where "Γ u⊢{ l := d  } : T" := (dm_typed Γ l d T).
 
 (* Make [T] first argument: Hide Γ for e.g. typing examples. *)
 Global Arguments iD_Typ_Abs {Γ} T _ _ _ _ _ _ : assert.
 
 Scheme unstamped_typed_mut_ind := Induction for typed Sort Prop
 with   unstamped_dms_typed_mut_ind := Induction for dms_typed Sort Prop
-with   unstamped_dm_typed_mut_ind := Induction for dm_typed Sort Prop
-with   unstamped_path_typed_mut_ind := Induction for path_typed Sort Prop
-with   unstamped_subtype_mut_ind := Induction for subtype Sort Prop.
+with   unstamped_dm_typed_mut_ind := Induction for dm_typed Sort Prop.
 
-Combined Scheme old_unstamped_typing_mut_ind from unstamped_typed_mut_ind, unstamped_dms_typed_mut_ind, unstamped_dm_typed_mut_ind,
-  unstamped_path_typed_mut_ind, unstamped_subtype_mut_ind.
-
-Scheme exp_unstamped_typed_mut_ind := Induction for typed Sort Prop
-with   exp_unstamped_dms_typed_mut_ind := Induction for dms_typed Sort Prop
-with   exp_unstamped_dm_typed_mut_ind := Induction for dm_typed Sort Prop
-with   exp_unstamped_path_typed_mut_ind := Induction for path_typed Sort Prop.
-
-Combined Scheme exp_old_unstamped_typing_mut_ind from exp_unstamped_typed_mut_ind, exp_unstamped_dms_typed_mut_ind,
-  exp_unstamped_dm_typed_mut_ind, exp_unstamped_path_typed_mut_ind.
-
-Lemma unstamped_path_root_is_var Γ p T i:
-  Γ u⊢ₚ p : T, i →
-  (∃ x, path_root p = var_vl x) ∨
-  (∃ l, path_root p = vlit l).
-Proof. by elim; intros; cbn; eauto 3 using is_unstamped_path_root. Qed.
+Combined Scheme old_unstamped_typing_mut_ind from
+  unstamped_typed_mut_ind, unstamped_dms_typed_mut_ind, unstamped_dm_typed_mut_ind.
 
 Lemma dtysem_not_utyped Γ l d T :
   Γ u⊢{ l := d } : T → ∀ σ s, d ≠ dtysem σ s.
@@ -320,11 +132,7 @@ Proof. by case. Qed.
 
 (** ** A few derived rules, and some automation to use them in examples. *)
 
-Hint Constructors typed dms_typed dm_typed path_typed subtype : core.
-
-(** Ensure [eauto]'s proof search does not diverge due to transitivity. *)
-Remove Hints iSub_Trans : core.
-Hint Extern 10 => try_once iSub_Trans : core.
+Hint Constructors typed dms_typed dm_typed : core.
 
 Lemma iT_All_I Γ e T1 T2:
   is_unstamped_ty' (length Γ) T1 →

--- a/theories/Dot/typing/old_unstamped_typing.v
+++ b/theories/Dot/typing/old_unstamped_typing.v
@@ -180,10 +180,11 @@ Qed.
 
 Ltac typconstructor :=
   match goal with
-  | |- typed ?Γ _ _ =>
-    first [apply iT_All_I_strip1 | apply iT_All_I | apply iT_Var |
-      apply iT_Nat_I | apply iT_Bool_I |
-      constructor]
+  | |- typed ?Γ _ _ => first [
+    apply iT_All_I_strip1 | apply iT_All_I |
+    apply iT_Var |
+    apply iT_Nat_I | apply iT_Bool_I |
+    constructor]
   | |- dms_typed ?Γ _ _ => constructor
   | |- dm_typed ?Γ _ _ _ => first [apply iD_All | constructor]
   | |- path_typed ?Γ _ _ _ => first [apply iP_VarT | subtypconstructor]

--- a/theories/Dot/typing/old_unstamped_typing.v
+++ b/theories/Dot/typing/old_unstamped_typing.v
@@ -67,10 +67,6 @@ Inductive typed Γ : tm → ty → Prop :=
     Γ u⊢ₜ path2tm p : T
 
 (** Primitives. *)
-| iT_Nat_I n:
-    Γ u⊢ₜ tv (vint n): TInt
-| iT_Bool_I b:
-    Γ u⊢ₜ tv (vbool b): TBool
 | iT_Un u e1 B1 Br (Hu : un_op_syntype u B1 Br) :
     Γ u⊢ₜ e1 : TPrim B1 →
     Γ u⊢ₜ tun u e1 : TPrim Br
@@ -133,6 +129,16 @@ Proof. by case. Qed.
 (** ** A few derived rules, and some automation to use them in examples. *)
 
 Hint Constructors typed dms_typed dm_typed : core.
+
+Lemma iT_Path' Γ v T
+  (Ht : Γ u⊢ₚ pv v : T, 0) : Γ u⊢ₜ tv v : T.
+Proof. exact: (iT_Path (p := pv _)). Qed.
+
+Lemma iT_Nat_I Γ n : Γ u⊢ₜ tv (vint n): TInt.
+Proof. apply iT_Path'; constructor. Qed.
+
+Lemma iT_Bool_I Γ b : Γ u⊢ₜ tv (vbool b): TBool.
+Proof. apply iT_Path'; constructor. Qed.
 
 Lemma iT_All_I Γ e T1 T2:
   is_unstamped_ty' (length Γ) T1 →
@@ -198,10 +204,6 @@ Proof.
   by eapply iP_Sub, Hp; rewrite plusnO.
 Qed.
 
-Lemma iT_Path' Γ v T
-  (Ht : Γ u⊢ₚ pv v : T, 0) : Γ u⊢ₜ tv v : T.
-Proof. exact: (iT_Path (p := pv _)). Qed.
-
 Lemma iT_Var {Γ x T}
   (Hx : Γ !! x = Some T) :
   Γ u⊢ₜ tv (var_vl x) : shiftN x T.
@@ -227,7 +229,9 @@ Ltac typconstructor_blacklist Γ :=
 Ltac typconstructor :=
   match goal with
   | |- typed ?Γ _ _ =>
-    first [apply iT_All_I_strip1 | apply iT_All_I | apply iT_Var | constructor]
+    first [apply iT_All_I_strip1 | apply iT_All_I | apply iT_Var |
+      apply iT_Nat_I | apply iT_Bool_I |
+      constructor]
   | |- dms_typed ?Γ _ _ => constructor
   | |- dm_typed ?Γ _ _ _ => first [apply iD_All | constructor]
   | |- path_typed ?Γ _ _ _ => first [apply iP_Later | apply iP_Var' | constructor]

--- a/theories/Dot/typing/old_unstamped_typing_derived_rules.v
+++ b/theories/Dot/typing/old_unstamped_typing_derived_rules.v
@@ -24,23 +24,16 @@ Proof. by move => /unstamped_subject_closed/fv_of_val_inv/nclosed_var_lt. Qed.
 
 Lemma iT_Mu_E {Γ x T}:
   Γ u⊢ₜ tv (var_vl x): TMu T →
-  (*──────────────────────*)
   is_unstamped_ty' (S (length Γ)) T →
   Γ u⊢ₜ tv (var_vl x): T.|[(var_vl x)/].
-Proof.
-  move => + Hu. rewrite -(psubst_subst_agree_ty (n := S (length Γ))) // => Hx.
-  by apply iT_Path', iP_Mu_E, iP_VarT, Hx.
-Qed.
+Proof. move => Hx Hu. by eapply iT_Path', iP_Mu_E', iP_VarT, Hx. Qed.
 
 Lemma iT_Mu_I {Γ x T}:
   Γ u⊢ₜ tv (var_vl x): T.|[(var_vl x)/] →
   (*──────────────────────*)
   is_unstamped_ty' (S (length Γ)) T →
   Γ u⊢ₜ tv (var_vl x): TMu T.
-Proof.
-  move => + Hu. rewrite -(psubst_subst_agree_ty (n := S (length Γ))) // => Hx.
-  by apply iT_Path', iP_Mu_I, iP_VarT, Hx.
-Qed.
+Proof. move => Hx Hu. by eapply iT_Path', iP_Mu_I', iP_VarT, Hx. Qed.
 
 Ltac tcrush :=
   repeat first [ eassumption | reflexivity |

--- a/theories/Dot/typing/old_unstamped_typing_derived_rules.v
+++ b/theories/Dot/typing/old_unstamped_typing_derived_rules.v
@@ -22,20 +22,6 @@ Qed.
 Lemma var_typed_closed {Γ x T} : Γ u⊢ₜ tv (ids x) : T → x < length Γ.
 Proof. by move => /unstamped_subject_closed/fv_of_val_inv/nclosed_var_lt. Qed.
 
-Ltac tcrush := repeat first [ eassumption | reflexivity | typconstructor | stcrush ].
-
-Lemma iT_All_Ex Γ e1 x2 T1 T2:
-  Γ u⊢ₜ e1: TAll T1 T2 →
-  Γ u⊢ₜ tv (var_vl x2) : T1 →
-  is_unstamped_ty' (S (length Γ)) T2 →
-  (*────────────────────────────────────────────────────────────*)
-  Γ u⊢ₜ tapp e1 (tv (var_vl x2)) : T2.|[(var_vl x2)/].
-Proof.
-  intros He1 Hx2 Hu. have Hlx2 := var_typed_closed Hx2.
-  rewrite -(psubst_subst_agree_ty (n := S (length Γ))); tcrush.
-  eapply iT_All_Ex_p with (p2 := pv (var_vl x2)); tcrush.
-Qed.
-
 Lemma iT_Mu_E {Γ x T}:
   Γ u⊢ₜ tv (var_vl x): TMu T →
   (*──────────────────────*)
@@ -56,10 +42,22 @@ Proof.
   by apply iT_Path', iP_Mu_I, iP_VarT, Hx.
 Qed.
 
-Ltac tcrush ::=
+Ltac tcrush :=
   repeat first [ eassumption | reflexivity |
   apply iT_Mu_I | apply iT_Mu_E |
   typconstructor | stcrush ].
+
+Lemma iT_All_Ex Γ e1 x2 T1 T2:
+  Γ u⊢ₜ e1: TAll T1 T2 →
+  Γ u⊢ₜ tv (var_vl x2) : T1 →
+  is_unstamped_ty' (S (length Γ)) T2 →
+  (*────────────────────────────────────────────────────────────*)
+  Γ u⊢ₜ tapp e1 (tv (var_vl x2)) : T2.|[(var_vl x2)/].
+Proof.
+  intros He1 Hx2 Hu. have Hlx2 := var_typed_closed Hx2.
+  rewrite -(psubst_subst_agree_ty (n := S (length Γ))); tcrush.
+  eapply iT_All_Ex_p with (p2 := pv (var_vl x2)); tcrush.
+Qed.
 
 Ltac wtcrush := repeat first [ fast_done | typconstructor | stcrush ] ; try solve [
   first [

--- a/theories/Dot/typing/old_unstamped_typing_derived_rules.v
+++ b/theories/Dot/typing/old_unstamped_typing_derived_rules.v
@@ -78,21 +78,6 @@ Ltac hideCtx :=
   | |- ?Γ u⊢ds _ : _ => hideCtx' Γ
   end.
 
-Lemma iP_Var' Γ x T1 T2 :
-  Γ !! x = Some T1 →
-  T2 = shiftN x T1 →
-  (*──────────────────────*)
-  Γ u⊢ₚ pv (var_vl x) : T2, 0.
-Proof. intros; subst; tcrush. Qed.
-
-Lemma iP_Var0 Γ T :
-  Γ !! 0 = Some T →
-  (*──────────────────────*)
-  Γ u⊢ₚ pv (var_vl 0) : T, 0.
-Proof. intros; eapply iP_Var'; by rewrite ?hsubst_id. Qed.
-
-Ltac pvar := exact: iP_Var0 || exact: iP_Var'.
-
 Lemma iT_Var' Γ x T1 T2 :
   Γ !! x = Some T1 →
   T2 = shiftN x T1 →
@@ -107,22 +92,6 @@ Lemma iT_Var0 Γ T :
 Proof. intros; apply iT_Path'; pvar. Qed.
 
 Ltac var := exact: iT_Var0 || exact: iT_Var' || pvar.
-
-Lemma iP_Var_Sub Γ x T1 T2 :
-  Γ !! x = Some T1 →
-  Γ u⊢ₜ shiftN x T1, 0 <: T2, 0 →
-  (*──────────────────────*)
-  Γ u⊢ₚ pv (var_vl x) : T2, 0.
-Proof. by intros; eapply iP_Sub'; [|pvar]. Qed.
-
-Lemma iP_Var0_Sub Γ T1 T2 :
-  Γ !! 0 = Some T1 →
-  Γ u⊢ₜ T1, 0 <: T2, 0 →
-  (*──────────────────────*)
-  Γ u⊢ₚ pv (var_vl 0) : T2, 0.
-Proof. intros. by eapply iP_Var_Sub; [| rewrite ?hsubst_id]. Qed.
-
-Ltac pvarsub := (eapply iP_Var0_Sub || eapply iP_Var_Sub); first done.
 
 Lemma iT_Var_Sub Γ x T1 T2 :
   Γ !! x = Some T1 →

--- a/theories/Dot/typing/old_unstamped_typing_derived_rules.v
+++ b/theories/Dot/typing/old_unstamped_typing_derived_rules.v
@@ -59,11 +59,6 @@ Ltac tcrush ::=
   apply iT_Mu_I | apply iT_Mu_E |
   typconstructor | stcrush ].
 
-Lemma is_unstamped_TLater_n i {n T}:
-  is_unstamped_ty' n T →
-  is_unstamped_ty' n (iterate TLater i T).
-Proof. elim: i => [|//i IHi]; rewrite ?iterate_0 ?iterate_S //; auto. Qed.
-
 Ltac wtcrush := repeat first [ fast_done | typconstructor | stcrush ] ; try solve [
   first [
     by eauto 3 using is_unstamped_TLater_n, is_unstamped_ren1_ty, is_unstamped_ren1_path |

--- a/theories/Dot/typing/old_unstamped_typing_derived_rules.v
+++ b/theories/Dot/typing/old_unstamped_typing_derived_rules.v
@@ -1,8 +1,10 @@
 From D Require Import tactics.
 From D.Dot Require Import syn syn_lemmas ex_utils old_unstamped_typing.
 From D.Dot Require Import unstampedness_binding.
-From D.Dot Require Import path_repl_lemmas typing_stamping.
+From D.Dot Require Import path_repl_lemmas typing_stamping
+  old_subtyping_derived_rules.
 Import DBNotation.
+Export old_subtyping_derived_rules.
 
 Lemma is_unstamped_pvar i n b : i < n → is_unstamped_path n b (pv (var_vl i)).
 Proof. eauto 7. Qed.
@@ -66,15 +68,15 @@ Ltac wtcrush := repeat first [ fast_done | typconstructor | stcrush ] ; try solv
     try_once is_unstamped_weaken_ty |
     try_once is_unstamped_weaken_path ]; eauto].
 
-Ltac asideLaters :=
+Ltac asideLaters' :=
   repeat first
     [ettrans; last (apply iSub_Later; tcrush)|
     ettrans; first (apply iLater_Sub; tcrush)].
 
-Ltac lNext := ettrans; first apply iAnd2_Sub; tcrush.
-Ltac lThis := ettrans; first apply iAnd1_Sub; tcrush.
+Ltac lNext' := ettrans; first apply iAnd2_Sub; tcrush.
+Ltac lThis' := ettrans; first apply iAnd1_Sub; tcrush.
 
-Ltac lookup :=
+Ltac lookup' :=
   lazymatch goal with
   | |- _ u⊢ₜ ?T1, _ <: ?T2, _ =>
     let T1' := eval hnf in T1 in
@@ -83,12 +85,13 @@ Ltac lookup :=
       (* first [unify (label_of_ty T11) (label_of_ty T2); lThis | lNext] *)
       let ls := eval cbv in (label_of_ty T11, label_of_ty T2) in
       match ls with
-      | (Some ?l1, Some ?l1) => lThis
-      | (Some ?l1, Some ?l2) => lNext
+      | (Some ?l1, Some ?l1) => lThis'
+      | (Some ?l1, Some ?l2) => lNext'
       end
     end
   end.
 Ltac ltcrush := tcrush; repeat lookup.
+Ltac ltcrush' := tcrush; repeat lookup'.
 
 Ltac hideCtx :=
   let hideCtx' Γ := (let x := fresh "Γ" in set x := Γ) in
@@ -100,20 +103,68 @@ Ltac hideCtx :=
   | |- ?Γ u⊢ds _ : _ => hideCtx' Γ
   end.
 
+Lemma iP_Var' Γ x T1 T2 :
+  Γ !! x = Some T1 →
+  T2 = shiftN x T1 →
+  (*──────────────────────*)
+  Γ u⊢ₚ pv (var_vl x) : T2, 0.
+Proof. intros; subst; tcrush. Qed.
+
+Lemma iP_Var0 Γ T :
+  Γ !! 0 = Some T →
+  (*──────────────────────*)
+  Γ u⊢ₚ pv (var_vl 0) : T, 0.
+Proof. intros; eapply iP_Var'; by rewrite ?hsubst_id. Qed.
+
+Ltac pvar := exact: iP_Var0 || exact: iP_Var'.
+
 Lemma iT_Var' Γ x T1 T2 :
   Γ !! x = Some T1 →
   T2 = shiftN x T1 →
   (*──────────────────────*)
   Γ u⊢ₜ tv (var_vl x) : T2.
-Proof. intros; subst; tcrush. Qed.
+Proof. intros; apply iT_Path'; pvar. Qed.
 
 Lemma iT_Var0 Γ T :
   Γ !! 0 = Some T →
   (*──────────────────────*)
   Γ u⊢ₜ tv (var_vl 0) : T.
-Proof. intros; eapply iT_Var'; by rewrite ?hsubst_id. Qed.
+Proof. intros; apply iT_Path'; pvar. Qed.
 
-Ltac var := exact: iT_Var0 || exact: iT_Var'.
+Ltac var := exact: iT_Var0 || exact: iT_Var' || pvar.
+
+Lemma iP_Var_Sub Γ x T1 T2 :
+  Γ !! x = Some T1 →
+  Γ u⊢ₜ shiftN x T1, 0 <: T2, 0 →
+  (*──────────────────────*)
+  Γ u⊢ₚ pv (var_vl x) : T2, 0.
+Proof. by intros; eapply iP_Sub'; [|pvar]. Qed.
+
+Lemma iP_Var0_Sub Γ T1 T2 :
+  Γ !! 0 = Some T1 →
+  Γ u⊢ₜ T1, 0 <: T2, 0 →
+  (*──────────────────────*)
+  Γ u⊢ₚ pv (var_vl 0) : T2, 0.
+Proof. intros. by eapply iP_Var_Sub; [| rewrite ?hsubst_id]. Qed.
+
+Ltac pvarsub := (eapply iP_Var0_Sub || eapply iP_Var_Sub); first done.
+
+Lemma iT_Var_Sub Γ x T1 T2 :
+  Γ !! x = Some T1 →
+  Γ u⊢ₜ shiftN x T1, 0 <: T2, 0 →
+  (*──────────────────────*)
+  Γ u⊢ₜ tv (var_vl x) : T2.
+Proof. by intros; apply iT_Path'; pvarsub. Qed.
+
+Lemma iT_Var0_Sub Γ T1 T2 :
+  Γ !! 0 = Some T1 →
+  Γ u⊢ₜ T1, 0 <: T2, 0 →
+  (*──────────────────────*)
+  Γ u⊢ₜ tv (var_vl 0) : T2.
+Proof. by intros; apply iT_Path'; pvarsub. Qed.
+
+Ltac varsub := (eapply iP_Var_Sub || eapply iP_Var0_Sub ||
+  eapply iT_Var0_Sub || eapply iT_Var_Sub); first done.
 
 Lemma iT_Sub_nocoerce T1 T2 {Γ e} :
   Γ u⊢ₜ e : T1 →
@@ -121,22 +172,6 @@ Lemma iT_Sub_nocoerce T1 T2 {Γ e} :
   Γ u⊢ₜ e : T2.
 Proof. intros. exact: (iT_Sub (i:=0)). Qed.
 Hint Resolve iT_Sub_nocoerce : core.
-
-Lemma iT_Var_Sub Γ x T1 T2 :
-  Γ !! x = Some T1 →
-  Γ u⊢ₜ shiftN x T1, 0 <: T2, 0 →
-  (*──────────────────────*)
-  Γ u⊢ₜ tv (var_vl x) : T2.
-Proof. by intros; eapply iT_Sub_nocoerce; [var|]. Qed.
-
-Lemma iT_Var0_Sub Γ T1 T2 :
-  Γ !! 0 = Some T1 →
-  Γ u⊢ₜ T1, 0 <: T2, 0 →
-  (*──────────────────────*)
-  Γ u⊢ₜ tv (var_vl 0) : T2.
-Proof. intros. by eapply iT_Var_Sub; [| rewrite ?hsubst_id]. Qed.
-
-Ltac varsub := (eapply iT_Var0_Sub || eapply iT_Var_Sub); first done.
 
 Lemma iT_All_Ex' T2 {Γ e1 x2 T1 T3} :
   Γ u⊢ₜ e1: TAll T1 T2 →                        Γ u⊢ₜ tv (ids x2) : T1 →
@@ -154,64 +189,7 @@ Lemma iT_Mu_E' {Γ x T1 T2}:
   Γ u⊢ₜ tv (ids x): T2.
 Proof. intros; subst; tcrush. Qed.
 
-Lemma iSub_SelL {Γ p U l L i}:
-  Γ u⊢ₚ p : TTMemL l L U, i →
-  Γ u⊢ₜ TLater L, i <: TSel p l, i.
-Proof. intros; exact: iSub_Sel. Qed.
-
-Lemma iSel_SubL {Γ p L l U i}:
-  Γ u⊢ₚ p : TTMemL l L U, i →
-  Γ u⊢ₜ TSel p l, i <: TLater U, i.
-Proof. intros; exact: iSel_Sub. Qed.
-
-Lemma iSub_Sel' U {Γ p l L i}:
-  is_unstamped_ty' (length Γ) L →
-  Γ u⊢ₚ p : TTMemL l L U, i →
-  Γ u⊢ₜ L, i <: TSel p l, i.
-Proof. intros; ettrans; last exact: (iSub_Sel (p := p)); tcrush. Qed.
-
-(** Specialization of [iSub_Sel'] for convenience. *)
-Lemma iSub_Sel'' Γ {p l L i}:
-  is_unstamped_ty' (length Γ) L →
-  Γ u⊢ₚ p : TTMemL l L L, i → Γ u⊢ₜ L, i <: TSel p l, i.
-Proof. apply iSub_Sel'. Qed.
-
-(** * Manipulating laters, basics. *)
-
-Lemma iSub_AddIJ {Γ T} i j (Hst: is_unstamped_ty' (length Γ) T) :
-  Γ u⊢ₜ T, j <: T, i + j.
-Proof.
-  elim: i => [|n IHn]; first tcrush.
-  ettrans; first apply IHn.
-  ettrans; [exact: iSub_Add_Later | tcrush].
-Qed.
-
-Lemma iSub_AddIJ' {Γ T} i j (Hst: is_unstamped_ty' (length Γ) T) (Hle : i <= j) :
-  Γ u⊢ₜ T, i <: T, j.
-Proof. rewrite (le_plus_minus i j Hle) Nat.add_comm. exact: iSub_AddIJ. Qed.
-
-Lemma iSub_AddI Γ T i (Hst: is_unstamped_ty' (length Γ) T) :
-  Γ u⊢ₜ T, 0 <: T, i.
-Proof. apply (iSub_AddIJ' 0 i); by [|lia]. Qed.
-
-Lemma path_tp_delay {Γ p T i j} (Hst: is_unstamped_ty' (length Γ) T) : i <= j →
-  Γ u⊢ₚ p : T, i → Γ u⊢ₚ p : T, j.
-Proof.
-  intros Hle Hp.
-  rewrite (le_plus_minus i j Hle); move: {j Hle} (j - i) => k.
-  eapply iP_Sub, Hp.
-  apply: iSub_AddIJ'; by [|lia].
-Qed.
-
 (** * Derived constructions. *)
-
-Lemma iT_Let Γ t u T U :
-  Γ u⊢ₜ t : T →
-  shift T :: Γ u⊢ₜ u : shift U →
-  is_unstamped_ty' (length Γ) T →
-  Γ u⊢ₜ lett t u : U.
-Proof. move => Ht Hu HsT. apply /iT_All_E /Ht /iT_All_I /Hu /HsT. Qed.
-
 Lemma val_LB L U Γ i x l :
   is_unstamped_ty' (length Γ) L →
   is_unstamped_ty' (length Γ) U →
@@ -234,43 +212,22 @@ Proof.
   apply (path_tp_delay (i := 0)); wtcrush.
 Qed.
 
+Lemma iT_Let Γ t u T U :
+  Γ u⊢ₜ t : T →
+  shift T :: Γ u⊢ₜ u : shift U →
+  is_unstamped_ty' (length Γ) T →
+  Γ u⊢ₜ lett t u : U.
+Proof. move => Ht Hu HsT. apply /iT_All_E /Ht /iT_All_I /Hu /HsT. Qed.
+
 Lemma iD_Typ Γ T l:
   is_unstamped_ty' (length Γ) T →
   Γ u⊢{ l := dtysyn T } : TTMemL l T T.
 Proof. intros. tcrush. Qed.
 
-(* We can derive rules iSub_Bind_1 and iSub_Bind_2 (the latter only conjectured) from
-  "Type Soundness for Dependent Object Types (DOT)", Rompf and Amin, OOPSLA '16. *)
-Lemma iSub_Bind_1 Γ T1 T2 i:
-  is_unstamped_ty' (S (length Γ)) T1 → is_unstamped_ty' (length Γ) T2 →
-  iterate TLater i T1 :: Γ u⊢ₜ T1, i <: shift T2, i →
-  Γ u⊢ₜ μ T1, i <: T2, i.
-Proof.
-  intros Hus1 Hus2 Hsub.
-  ettrans; first exact: (iMu_Sub_Mu Hsub).
-  exact: iMu_Sub.
-Qed.
-
-Lemma iSub_Bind_2 Γ T1 T2 i:
-  is_unstamped_ty' (length Γ) T1 → is_unstamped_ty' (S (length Γ)) T2 →
-  iterate TLater i (shift T1) :: Γ u⊢ₜ shift T1, i <: T2, i →
-  Γ u⊢ₜ T1, i <: μ T2, i.
-Proof.
-  intros Hus1 Hus2 Hsub.
-  ettrans; last apply (iMu_Sub_Mu Hsub); [exact: iSub_Mu | wtcrush].
-Qed.
-
-Lemma iSub_Bind_1' Γ T1 T2:
-  is_unstamped_ty' (S (length Γ)) T1 → is_unstamped_ty' (length Γ) T2 →
-  T1 :: Γ u⊢ₜ T1, 0 <: shift T2, 0 →
-  Γ u⊢ₜ μ T1, 0 <: T2, 0.
-Proof. intros; exact: iSub_Bind_1. Qed.
-
-Lemma iSub_Bind_2' Γ T1 T2:
-  is_unstamped_ty' (length Γ) T1 → is_unstamped_ty' (S (length Γ)) T2 →
-  shift T1 :: Γ u⊢ₜ shift T1, 0 <: T2, 0 →
-  Γ u⊢ₜ T1, 0 <: μ T2, 0.
-Proof. intros; exact: iSub_Bind_2. Qed.
+Lemma iD_Path_Sngl {Γ} p l T :
+  Γ u⊢ₚ p : T, 0 →
+  Γ u⊢{ l := dpt p } : TVMem l (TSing p).
+Proof. intros Hp. eapply iD_Path, iP_Sngl_Refl, Hp. Qed.
 
 Ltac mltcrush := tcrush; try ((apply iSub_Bind_1' || apply iSub_Bind_1); tcrush); repeat lookup.
 
@@ -286,41 +243,6 @@ Proof.
   eapply iT_Sub_nocoerce with (T1 := μ {@ type "A" >: T <: T }); ltcrush.
 Qed.
 
-Lemma iP_Sngl_Sym Γ p q i:
-  is_unstamped_path' (length Γ) q →
-  Γ u⊢ₚ p : TSing q, i →
-  Γ u⊢ₚ q : TSing p, i.
-Proof.
-  intros Hus Hpq. eapply iP_Sub'.
-  eapply (iSngl_Sub_Sym Hpq). by apply iSngl_Sub_Self, Hpq.
-  eapply iP_Sngl_Refl.
-  by apply (iP_Sngl_Inv Hpq).
-Qed.
-
-Lemma iSngl_pq_Sub_inv {Γ i p q T1 T2}:
-  T1 ~Tp[ p := q ]* T2 →
-  is_unstamped_ty' (length Γ) T1 →
-  is_unstamped_ty' (length Γ) T2 →
-  is_unstamped_path' (length Γ) p →
-  Γ u⊢ₚ q : TSing p, i →
-  Γ u⊢ₜ T1, i <: T2, i.
-Proof. intros. by eapply iSngl_pq_Sub, iP_Sngl_Sym. Qed.
-
-Lemma iP_And {Γ p T1 T2 i}:
-  Γ u⊢ₚ p : T1, i →
-  Γ u⊢ₚ p : T2, i →
-  Γ u⊢ₚ p : TAnd T1 T2, i.
-Proof.
-  intros Hp1 Hp2. eapply iP_Sub', iP_Sngl_Refl, Hp1.
-  apply iSub_And; exact: iSngl_Sub_Self.
-Qed.
-
-Lemma iMu_Sub' {Γ T T' i}:
-  T' = shift T →
-  is_unstamped_ty' (length Γ) T →
-  Γ u⊢ₜ μ T', i <: T, i.
-Proof. intros; subst. auto. Qed.
-
 Lemma iD_Lam_Sub {Γ} V T1 T2 e l L:
   shift T1 :: V :: Γ u⊢ₜ e : T2 →
   TLater V :: Γ u⊢ₜ TAll T1 T2, 0 <: L, 0 →
@@ -331,11 +253,6 @@ Proof.
   eapply (iT_Sub (i := 0)); first apply Hsub.
   by apply iT_All_I_strip1.
 Qed.
-
-Lemma iD_Path_Sngl {Γ} p l T :
-  Γ u⊢ₚ p : T, 0 →
-  Γ u⊢{ l := dpt p } : TVMem l (TSing p).
-Proof. intros Hp. eapply iD_Path, iP_Sngl_Refl, Hp. Qed.
 
 (* Note how we must weaken the type (or its environment) to account for the
    self-variable of the created object. *)
@@ -386,29 +303,7 @@ Proof.
   by move => [|i] Hi //=; [constructor => /=| eauto].
 Qed.
 
-(** * Manipulating laters, more.
-
- *)
-Lemma iSub_LaterN Γ T i j:
-  is_unstamped_ty' (length Γ) T →
-  Γ u⊢ₜ T, j + i <: iterate TLater j T, i.
-Proof.
-  elim: j T => /= [|j IHj] T HuT; rewrite ?iterate_0 ?iterate_Sr /=; tcrush.
-  ettrans.
-  - exact: iSub_Later.
-  - apply (IHj (TLater T)); stcrush.
-Qed.
-
-Lemma iLaterN_Sub {Γ T} i j :
-  is_unstamped_ty' (length Γ) T →
-  Γ u⊢ₜ iterate TLater j T, i <: T, j + i.
-Proof.
-  elim: j T => /= [|j IHj] T HuT; rewrite ?iterate_0 ?iterate_Sr /=; tcrush.
-  ettrans.
-  - apply (IHj (TLater T)); stcrush.
-  - exact: iLater_Sub.
-Qed.
-
+(** * Manipulating laters, more. *)
 (* This can be useful when [T] is a singleton type. *)
 Lemma dropLaters Γ e T U i:
   Γ u⊢ₜ e : T →
@@ -481,112 +376,6 @@ Proof.
   rewrite -{3}(plusnO i). apply iLaterN_Sub; wtcrush.
 Qed.
 
-Lemma selfIntersect Γ T U i j:
-  is_unstamped_ty' (length Γ) T →
-  Γ u⊢ₜ T, i <: U, j + i →
-  Γ u⊢ₜ T, i <: TAnd U T, j + i .
-Proof. intros; tcrush. exact: iSub_AddIJ. Qed.
-
-Lemma iAnd_Later_Sub_Distr Γ T1 T2 i :
-  is_unstamped_ty' (length Γ) T1 →
-  is_unstamped_ty' (length Γ) T2 →
-  Γ u⊢ₜ TAnd (TLater T1) (TLater T2), i <: TLater (TAnd T1 T2), i.
-Proof. intros; asideLaters; tcrush; [lThis|lNext]. Qed.
-
-(** Inverse of [iAnd_Later_Sub_Distr]. *)
-Lemma iAnd_Later_Sub_Distr_inv Γ T1 T2 i :
-  is_unstamped_ty' (length Γ) T1 →
-  is_unstamped_ty' (length Γ) T2 →
-  Γ u⊢ₜ TLater (TAnd T1 T2), i <: TAnd (TLater T1) (TLater T2), i.
-Proof. intros; tcrush. Qed.
-
-Lemma iOr_Later_Sub_Distr Γ T1 T2 i :
-  is_unstamped_ty' (length Γ) T1 →
-  is_unstamped_ty' (length Γ) T2 →
-  Γ u⊢ₜ TOr (TLater T1) (TLater T2), i <: TLater (TOr T1 T2), i.
-Proof. intros; tcrush. Qed.
-
-(** Inverse of [iOr_Later_Sub_Distr]. *)
-Lemma iOr_Later_Sub_Distr_inv Γ T1 T2 i :
-  is_unstamped_ty' (length Γ) T1 →
-  is_unstamped_ty' (length Γ) T2 →
-  Γ u⊢ₜ TLater (TOr T1 T2), i <: TOr (TLater T1) (TLater T2), i.
-Proof.
-  intros; asideLaters; typconstructor; ettrans;
-    [| apply iSub_Or1 | | apply iSub_Or2]; tcrush.
-Qed.
-
-(** TLater swaps with TMu, part 1. *)
-Lemma iMu_Later_Sub_Distr Γ T i :
-  is_unstamped_ty' (S (length Γ)) T →
-  Γ u⊢ₜ TMu (TLater T), i <: TLater (TMu T), i.
-Proof. intros; asideLaters; tcrush. Qed.
-
-(** TLater swaps with TMu, part 2. *)
-Lemma iMu_Later_Sub_Distr_inv Γ T i :
-  is_unstamped_ty' (S (length Γ)) T →
-  Γ u⊢ₜ TLater (TMu T), i <: TMu (TLater T), i.
-Proof. intros; asideLaters; tcrush. Qed.
-
-(** Show that [singleton_Mu_[12]] and [iP_Mu_[IE]] are interderivable. *)
-Lemma singleton_Mu_1 {Γ p T i} :
-  Γ u⊢ₚ p : TMu T, i →
-  is_unstamped_ty' (S (length Γ)) T →
-  Γ u⊢ₜ TSing p, i <: T .Tp[ p /], i.
-Proof. intros Hp Hu; apply iSngl_Sub_Self, (iP_Mu_E Hu Hp). Qed.
-
-Lemma singleton_Mu_2 {Γ p T i} :
-  Γ u⊢ₚ p : T .Tp[ p /], i →
-  is_unstamped_ty' (S (length Γ)) T →
-  Γ u⊢ₜ TSing p, i <: TMu T, i.
-Proof. intros Hp Hu; apply iSngl_Sub_Self, (iP_Mu_I Hu Hp). Qed.
-
-(* Avoid automation, to ensure we don't use [iP_Mu_E] to show them. *)
-Lemma iP_Mu_E' {Γ T p i} :
-  Γ u⊢ₚ p : TMu T, i →
-  is_unstamped_ty' (S (length Γ)) T →
-  Γ u⊢ₚ p : T .Tp[ p /], i.
-Proof.
-  intros Hp Hu. eapply iP_Sub', (iP_Sngl_Refl Hp).
-  apply (singleton_Mu_1 Hp Hu).
-Qed.
-
-Lemma iP_Mu_I' {Γ T p i} :
-  Γ u⊢ₚ p : T .Tp[ p /], i →
-  is_unstamped_ty' (S (length Γ)) T →
-  Γ u⊢ₚ p : TMu T, i.
-Proof.
-  intros Hp Hu. eapply iP_Sub', (iP_Sngl_Refl Hp).
-  apply (singleton_Mu_2 Hp Hu).
-Qed.
-
-(**
-Show soundness of subtyping for recursive types in the Dotty compiler — just cases in subtype checking.
-
-The first case is in
-https://github.com/lampepfl/dotty/blob/0.20.0-RC1/compiler/src/dotty/tools/dotc/core/TypeComparer.scala#L550-L552
-And that matches iMu_Sub_Mu.
-
-https://github.com/lampepfl/dotty/blob/0.20.0-RC1/compiler/src/dotty/tools/dotc/core/TypeComparer.scala#L554-L557
-We formalize that as the derived rule below.
-
-The action of [fixRecs] depends on the type [T1] of [p].
-Hence, here we we assume the action of [fixRecs] has already been carried out:
-to do that, one must unfold top-level recursive types in the type of [p],
-as allowed through [P_Mu_E], rules for intersection types and intersection introduction.
-On the other hand, this derived rule handles the substitution in [T2] directly.
-*)
-Lemma singleton_Mu_dotty1 {Γ p i T1' T2} :
-  Γ u⊢ₜ T1', i <: T2 .Tp[ p /], i →
-  Γ u⊢ₚ p : T1', i →
-  is_unstamped_ty' (S (length Γ)) T2 →
-  Γ u⊢ₜ TSing p, i <: TMu T2, i.
-Proof.
-  intros Hsub Hp Hu.
-  apply singleton_Mu_2, Hu.
-  apply (iP_Sub' Hsub Hp).
-Qed.
-
 Definition anfBind t := lett t (tv x0).
 
 Lemma AnfBind_typed Γ t (T U: ty) :
@@ -600,37 +389,6 @@ Lemma pDOT_Def_Path_derived Γ l p T
   (Hx : Γ u⊢ₚ p : T, 0):
   Γ u⊢{ l := dpt p } : TVMem l (TSing p).
 Proof. eapply iD_Path, (iP_Sngl_Refl (T := T)), Hx. Qed.
-
-Lemma iP_LaterN {Γ p T i j} :
-  is_unstamped_ty' (length Γ) T →
-  Γ u⊢ₚ p : iterate TLater j T, i →
-  Γ u⊢ₚ p : T, i + j.
-Proof.
-  elim: j i => [|j IHj] i Hu Hp; rewrite (plusnO, plusnS); first done.
-  apply (IHj (S i)), iP_Later, Hp; tcrush; exact: is_unstamped_TLater_n.
-Qed.
-
-Lemma iMu_LaterN_Sub_Distr_inv {Γ T i n} :
-  is_unstamped_ty' (S (length Γ)) T →
-  Γ u⊢ₜ iterate TLater n (TMu T), i <: TMu (iterate TLater n T), i.
-Proof.
-  intros Hu.
-  elim: n i => [|n IHn] i; first tcrush; rewrite !iterate_S.
-  ettrans; last apply iMu_Later_Sub_Distr_inv.
-  by asideLaters; wtcrush.
-  by apply is_unstamped_TLater_n; stcrush.
-Qed.
-
-Lemma iMu_LaterN_Sub_Distr {Γ T i n} :
-  is_unstamped_ty' (S (length Γ)) T →
-  Γ u⊢ₜ TMu (iterate TLater n T), i <: iterate TLater n (TMu T), i.
-Proof.
-  intros Hu.
-  elim: n i => [|n IHn] i; first tcrush; rewrite !iterate_S.
-  ettrans; first apply iMu_Later_Sub_Distr.
-  by apply is_unstamped_TLater_n; stcrush.
-  by asideLaters; wtcrush.
-Qed.
 
 (* If I add [iSub_Skolem_P] to the syntactic type system, what other rules
 can I derive? Apparently, subtyping for recursive types, almost. See below! *)

--- a/theories/Dot/typing/old_unstamped_typing_derived_rules.v
+++ b/theories/Dot/typing/old_unstamped_typing_derived_rules.v
@@ -41,7 +41,7 @@ Lemma iT_Mu_E {Γ x T}:
   Γ u⊢ₜ tv (var_vl x): T.|[(var_vl x)/].
 Proof.
   move => + Hu. rewrite -(psubst_subst_agree_ty (n := S (length Γ))) // => Hx.
-  by apply iT_Path', iP_Mu_E, iP_Var', Hx.
+  by apply iT_Path', iP_Mu_E, iP_VarT, Hx.
 Qed.
 
 Lemma iT_Mu_I {Γ x T}:
@@ -51,7 +51,7 @@ Lemma iT_Mu_I {Γ x T}:
   Γ u⊢ₜ tv (var_vl x): TMu T.
 Proof.
   move => + Hu. rewrite -(psubst_subst_agree_ty (n := S (length Γ))) // => Hx.
-  by apply iT_Path', iP_Mu_I, iP_Var', Hx.
+  by apply iT_Path', iP_Mu_I, iP_VarT, Hx.
 Qed.
 
 Ltac tcrush ::=

--- a/theories/Dot/typing/old_unstamped_typing_derived_rules.v
+++ b/theories/Dot/typing/old_unstamped_typing_derived_rules.v
@@ -68,30 +68,7 @@ Ltac wtcrush := repeat first [ fast_done | typconstructor | stcrush ] ; try solv
     try_once is_unstamped_weaken_ty |
     try_once is_unstamped_weaken_path ]; eauto].
 
-Ltac asideLaters' :=
-  repeat first
-    [ettrans; last (apply iSub_Later; tcrush)|
-    ettrans; first (apply iLater_Sub; tcrush)].
-
-Ltac lNext' := ettrans; first apply iAnd2_Sub; tcrush.
-Ltac lThis' := ettrans; first apply iAnd1_Sub; tcrush.
-
-Ltac lookup' :=
-  lazymatch goal with
-  | |- _ u⊢ₜ ?T1, _ <: ?T2, _ =>
-    let T1' := eval hnf in T1 in
-    match T1' with
-    | (TAnd ?T11 ?T12) =>
-      (* first [unify (label_of_ty T11) (label_of_ty T2); lThis | lNext] *)
-      let ls := eval cbv in (label_of_ty T11, label_of_ty T2) in
-      match ls with
-      | (Some ?l1, Some ?l1) => lThis'
-      | (Some ?l1, Some ?l2) => lNext'
-      end
-    end
-  end.
 Ltac ltcrush := tcrush; repeat lookup.
-Ltac ltcrush' := tcrush; repeat lookup'.
 
 Ltac hideCtx :=
   let hideCtx' Γ := (let x := fresh "Γ" in set x := Γ) in

--- a/theories/Dot/typing/old_unstamped_typing_derived_rules.v
+++ b/theories/Dot/typing/old_unstamped_typing_derived_rules.v
@@ -25,11 +25,11 @@ Proof. by move => /unstamped_subject_closed/fv_of_val_inv/nclosed_var_lt. Qed.
 Lemma iT_Mu_E {Γ x T}:
   Γ u⊢ₜ tv (var_vl x): TMu T →
   is_unstamped_ty' (S (length Γ)) T →
-  Γ u⊢ₜ tv (var_vl x): T.|[(var_vl x)/].
+  Γ u⊢ₜ tv (var_vl x): T.|[var_vl x/].
 Proof. move => Hx Hu. by eapply iT_Path', iP_Mu_E', iP_VarT, Hx. Qed.
 
 Lemma iT_Mu_I {Γ x T}:
-  Γ u⊢ₜ tv (var_vl x): T.|[(var_vl x)/] →
+  Γ u⊢ₜ tv (var_vl x): T.|[var_vl x/] →
   (*──────────────────────*)
   is_unstamped_ty' (S (length Γ)) T →
   Γ u⊢ₜ tv (var_vl x): TMu T.
@@ -45,7 +45,7 @@ Lemma iT_All_Ex Γ e1 x2 T1 T2:
   Γ u⊢ₜ tv (var_vl x2) : T1 →
   is_unstamped_ty' (S (length Γ)) T2 →
   (*────────────────────────────────────────────────────────────*)
-  Γ u⊢ₜ tapp e1 (tv (var_vl x2)) : T2.|[(var_vl x2)/].
+  Γ u⊢ₜ tapp e1 (tv (var_vl x2)) : T2.|[var_vl x2/].
 Proof.
   intros He1 Hx2 Hu. have Hlx2 := var_typed_closed Hx2.
   rewrite -(psubst_subst_agree_ty (n := S (length Γ))); tcrush.

--- a/theories/Dot/typing/storeless_typing.v
+++ b/theories/Dot/typing/storeless_typing.v
@@ -133,12 +133,12 @@ Notation "Γ s⊢ds[ g  ] ds : T" := (dms_typed Γ g ds T)
 (* Make [T] first argument: Hide [Γ] and [g] for e.g. typing examples. *)
 Global Arguments iD_Typ_Abs {Γ g} T _ _ _ _ _ _ _ _ _ : assert.
 
-Scheme stamped_typed_mut_ind := Induction for typed Sort Prop
-with   stamped_dms_typed_mut_ind := Induction for dms_typed Sort Prop
-with   stamped_dm_typed_mut_ind := Induction for dm_typed Sort Prop.
+Scheme storeless_typed_mut_ind := Induction for typed Sort Prop
+with   storeless_dms_typed_mut_ind := Induction for dms_typed Sort Prop
+with   storeless_dm_typed_mut_ind := Induction for dm_typed Sort Prop.
 
-Combined Scheme storeless_typing_mut_ind from stamped_typed_mut_ind, stamped_dms_typed_mut_ind,
-  stamped_dm_typed_mut_ind.
+Combined Scheme storeless_typing_mut_ind from storeless_typed_mut_ind,
+  storeless_dms_typed_mut_ind, storeless_dm_typed_mut_ind.
 
 (** ** A few derived rules, and some automation to use them in examples. *)
 

--- a/theories/Dot/typing/storeless_typing.v
+++ b/theories/Dot/typing/storeless_typing.v
@@ -48,7 +48,7 @@ Inductive typed Γ g : tm → ty → Prop :=
 | iT_All_Ex e1 x2 T1 T2:
     Γ v⊢ₜ[ g ] e1: TAll T1 T2 →                        Γ v⊢ₜ[g] tv (var_vl x2) : T1 →
     (*────────────────────────────────────────────────────────────*)
-    Γ v⊢ₜ[g] tapp e1 (tv (var_vl x2)) : T2.|[(var_vl x2)/]
+    Γ v⊢ₜ[g] tapp e1 (tv (var_vl x2)) : T2.|[var_vl x2/]
 
 | iT_All_Ex_p p2 e1 T1 T2 T2':
     T2 .Tp[ p2 /]~ T2' →

--- a/theories/Dot/typing/storeless_typing.v
+++ b/theories/Dot/typing/storeless_typing.v
@@ -15,29 +15,15 @@ Unset Strict Implicit.
 Implicit Types (L T U : ty) (v : vl) (e : tm) (d : dm) (p: path) (ds : dms) (Γ : list ty).
 Implicit Types (g : stys).
 
-(* Compatibility *)
-Reserved Notation "Γ s⊢ₜ[ g  ] e : T" (at level 74, e, T at next level).
-Reserved Notation "Γ s⊢ₚ[ g  ] p : T , i" (at level 74, p, T, i at next level).
-Reserved Notation "Γ s⊢[ g  ]{ l := d  } : T " (at level 74, l, d, T at next level).
-Reserved Notation "Γ s⊢ds[ g  ] ds : T" (at level 74, ds, T at next level).
-Reserved Notation "Γ s⊢ₜ[ g  ] T1 , i1 <: T2 , i2" (at level 74, T1, T2, i1, i2 at next level).
-
 Reserved Notation "Γ v⊢ₜ[ g ] e : T"
   (at level 74, e, T at next level,
   format "'[' '[' Γ ']'  '/' v⊢ₜ[  g  ]  '[' e ']'  :  '[' T ']' ']'").
-Reserved Notation "Γ v⊢ₚ[ g  ] p : T , i" (at level 74, p, T, i at next level).
 Reserved Notation "Γ v⊢[ g ]{ l := d } : T "
   (at level 74, l, d, T at next level,
    format "'[' '[' Γ  ']' '/' '[' v⊢[  g  ]{  l  :=  d  } ']' :  '[' T ']' ']'").
 Reserved Notation "Γ v⊢ds[ g ] ds : T"
   (at level 74, ds, T at next level,
   format "'[' '[' Γ  ']' '/' v⊢ds[  g  ]  '[' ds ']'  :  T ']'" ).
-Reserved Notation "Γ v⊢ₜ[ g  ] T1 , i1 <: T2 , i2" (at level 74, T1, T2, i1, i2 at next level).
-
-Notation "Γ v⊢ₚ[ g ] p : T , i" := (path_typed Γ p T i).
-Notation "Γ v⊢ₜ[ g ] T1 , i1 <: T2 , i2" := (subtype Γ T1 i1 T2 i2).
-Notation "Γ s⊢ₚ[ g ] p : T , i" := (path_typed Γ p T i).
-Notation "Γ s⊢ₜ[ g ] T1 , i1 <: T2 , i2" := (subtype Γ T1 i1 T2 i2).
 
 (**
 Judgments for typing, subtyping, path and definition typing.
@@ -137,9 +123,12 @@ with dm_typed Γ g : label → dm → ty → Prop :=
 where "Γ v⊢[ g ]{ l := d  } : T" := (dm_typed Γ g l d T).
 
 (* Compatibility *)
-Notation "Γ s⊢ₜ[ g ] e : T " := (typed Γ g e T).
-Notation "Γ s⊢ds[ g ] ds : T" := (dms_typed Γ g ds T).
-Notation "Γ s⊢[ g ]{ l := d  } : T" := (dm_typed Γ g l d T).
+Notation "Γ s⊢ₜ[ g  ] e : T" := (typed Γ g e T)
+  (at level 74, e, T at next level, only parsing).
+Notation "Γ s⊢[ g  ]{ l := d  } : T " := (dm_typed Γ g l d T)
+  (at level 74, l, d, T at next level, only parsing).
+Notation "Γ s⊢ds[ g  ] ds : T" := (dms_typed Γ g ds T)
+  (at level 74, ds, T at next level, only parsing).
 
 (* Make [T] first argument: Hide [Γ] and [g] for e.g. typing examples. *)
 Global Arguments iD_Typ_Abs {Γ g} T _ _ _ _ _ _ _ _ _ : assert.

--- a/theories/Dot/typing/storeless_typing.v
+++ b/theories/Dot/typing/storeless_typing.v
@@ -133,23 +133,12 @@ Notation "Γ s⊢ds[ g  ] ds : T" := (dms_typed Γ g ds T)
 (* Make [T] first argument: Hide [Γ] and [g] for e.g. typing examples. *)
 Global Arguments iD_Typ_Abs {Γ g} T _ _ _ _ _ _ _ _ _ : assert.
 
-Scheme exp_stamped_typed_mut_ind := Induction for typed Sort Prop
-with   exp_stamped_dms_typed_mut_ind := Induction for dms_typed Sort Prop
-with   exp_stamped_dm_typed_mut_ind := Induction for dm_typed Sort Prop.
-
-Combined Scheme exp_storeless_typing_mut_ind from exp_stamped_typed_mut_ind, exp_stamped_dms_typed_mut_ind,
-  exp_stamped_dm_typed_mut_ind.
-
 Scheme stamped_typed_mut_ind := Induction for typed Sort Prop
 with   stamped_dms_typed_mut_ind := Induction for dms_typed Sort Prop
 with   stamped_dm_typed_mut_ind := Induction for dm_typed Sort Prop.
-Scheme stamped_path_typed_mut_ind := Induction for path_typed Sort Prop
-with   stamped_subtype_mut_ind := Induction for subtype Sort Prop.
 
 Combined Scheme storeless_typing_mut_ind from stamped_typed_mut_ind, stamped_dms_typed_mut_ind,
   stamped_dm_typed_mut_ind.
-Combined Scheme pure_storeless_typing_mut_ind from stamped_path_typed_mut_ind,
-  stamped_subtype_mut_ind.
 
 (** ** A few derived rules, and some automation to use them in examples. *)
 

--- a/theories/Dot/typing/storeless_typing.v
+++ b/theories/Dot/typing/storeless_typing.v
@@ -6,7 +6,7 @@ Storeless typing resembles stamped typing, but used to allow arbitrary values
 in paths.
 *)
 From D.Dot Require Export syn path_repl lr_syn_aux.
-From D.Dot.typing Require Export typing_aux_defs.
+From D.Dot.typing Require Export typing_aux_defs old_subtyping.
 From D.Dot.stamping Require Export core_stamping_defs.
 
 Set Implicit Arguments.
@@ -14,6 +14,13 @@ Unset Strict Implicit.
 
 Implicit Types (L T U : ty) (v : vl) (e : tm) (d : dm) (p: path) (ds : dms) (Γ : list ty).
 Implicit Types (g : stys).
+
+(* Compatibility *)
+Reserved Notation "Γ s⊢ₜ[ g  ] e : T" (at level 74, e, T at next level).
+Reserved Notation "Γ s⊢ₚ[ g  ] p : T , i" (at level 74, p, T, i at next level).
+Reserved Notation "Γ s⊢[ g  ]{ l := d  } : T " (at level 74, l, d, T at next level).
+Reserved Notation "Γ s⊢ds[ g  ] ds : T" (at level 74, ds, T at next level).
+Reserved Notation "Γ s⊢ₜ[ g  ] T1 , i1 <: T2 , i2" (at level 74, T1, T2, i1, i2 at next level).
 
 Reserved Notation "Γ v⊢ₜ[ g ] e : T"
   (at level 74, e, T at next level,
@@ -26,6 +33,11 @@ Reserved Notation "Γ v⊢ds[ g ] ds : T"
   (at level 74, ds, T at next level,
   format "'[' '[' Γ  ']' '/' v⊢ds[  g  ]  '[' ds ']'  :  T ']'" ).
 Reserved Notation "Γ v⊢ₜ[ g  ] T1 , i1 <: T2 , i2" (at level 74, T1, T2, i1, i2 at next level).
+
+Notation "Γ v⊢ₚ[ g ] p : T , i" := (path_typed Γ p T i).
+Notation "Γ v⊢ₜ[ g ] T1 , i1 <: T2 , i2" := (subtype Γ T1 i1 T2 i2).
+Notation "Γ s⊢ₚ[ g ] p : T , i" := (path_typed Γ p T i).
+Notation "Γ s⊢ₜ[ g ] T1 , i1 <: T2 , i2" := (subtype Γ T1 i1 T2 i2).
 
 (**
 Judgments for typing, subtyping, path and definition typing.
@@ -136,205 +148,33 @@ with dm_typed Γ g : label → dm → ty → Prop :=
     Γ v⊢ₜ[ g ] T1, 0 <: T2, 0 →
     Γ v⊢[ g ]{ l := dpt p } : TVMem l T1 →
     Γ v⊢[ g ]{ l := dpt p } : TVMem l T2
-where "Γ v⊢[ g ]{ l := d  } : T" := (dm_typed Γ g l d T)
-with path_typed Γ g : path → ty → nat → Prop :=
-| iP_Var x T:
-    Γ v⊢ₜ[ g ] tv (var_vl x) : T →
-    Γ v⊢ₚ[ g ] pv (var_vl x) : T, 0
-(** Primitives literals. *)
-| iP_Nat_I n:
-    Γ v⊢ₚ[ g ] pv (vint n): TInt, 0
-| iP_Bool_I b:
-    Γ v⊢ₚ[ g ] pv (vbool b): TBool, 0
-| iP_Fld_E p T i l:
-    Γ v⊢ₚ[ g ] p : TVMem l T, i →
-    Γ v⊢ₚ[ g ] pself p l : T, i
-| iP_Sub p T1 T2 i j :
-    Γ v⊢ₜ[ g ] T1, i <: T2, i + j →
-    Γ v⊢ₚ[ g ] p : T1, i →
-    (*───────────────────────────────*)
-    Γ v⊢ₚ[ g ] p : T2, i + j
-| iP_Mu_I p T {i} :
-    is_unstamped_ty' (S (length Γ)) T →
-    Γ v⊢ₚ[ g ] p : T .Tp[ p /], i →
-    Γ v⊢ₚ[ g ] p : TMu T, i
-| iP_Mu_E p T {i} :
-    is_unstamped_ty' (S (length Γ)) T →
-    is_unstamped_path' (length Γ) p →
-    Γ v⊢ₚ[ g ] p : TMu T, i →
-    Γ v⊢ₚ[ g ] p : T .Tp[ p /], i
-| iP_Fld_I p T i l:
-    Γ v⊢ₚ[ g ] pself p l : T, i →
-    (*─────────────────────────*)
-    Γ v⊢ₚ[ g ] p : TVMem l T, i
-| iP_Sngl_Refl T p i :
-    Γ v⊢ₚ[ g ] p : T, i →
-    Γ v⊢ₚ[ g ] p : TSing p, i
-| iP_Sngl_Inv p q i:
-    Γ v⊢ₚ[ g ] p : TSing q, i →
-    is_stamped_path (length Γ) g q →
-    Γ v⊢ₚ[ g ] q : TTop, i
-| iP_Sngl_Trans p q T i:
-    Γ v⊢ₚ[ g ] p : TSing q, i →
-    Γ v⊢ₚ[ g ] q : T, i →
-    Γ v⊢ₚ[ g ] p : T, i
-| iP_Sngl_E T p q l i:
-    Γ v⊢ₚ[ g ] p : TSing q, i →
-    Γ v⊢ₚ[ g ] pself q l : T, i →
-    Γ v⊢ₚ[ g ] pself p l : TSing (pself q l), i
-where "Γ v⊢ₚ[ g ] p : T , i" := (path_typed Γ g p T i)
-(* Γ v⊢ₜ[ g ] T1, i1 <: T2, i2 means that TLater^i1 T1 <: TLater^i2 T2. *)
-with subtype Γ g : ty → nat → ty → nat → Prop :=
-| iSub_Refl i T :
-    is_stamped_ty (length Γ) g T →
-    Γ v⊢ₜ[ g ] T, i <: T, i
-| iSub_Trans i2 T2 {i1 i3 T1 T3}:
-    Γ v⊢ₜ[ g ] T1, i1 <: T2, i2 →
-    Γ v⊢ₜ[ g ] T2, i2 <: T3, i3 →
-    Γ v⊢ₜ[ g ] T1, i1 <: T3, i3
-| iLater_Sub i T:
-    is_stamped_ty (length Γ) g T →
-    Γ v⊢ₜ[ g ] TLater T, i <: T, S i
-| iSub_Later i T:
-    is_stamped_ty (length Γ) g T →
-    Γ v⊢ₜ[ g ] T, S i <: TLater T, i
+where "Γ v⊢[ g ]{ l := d  } : T" := (dm_typed Γ g l d T).
 
-(* "Structural" rule about indexes *)
-| iSub_Add_Later T i:
-    is_stamped_ty (length Γ) g T →
-    Γ v⊢ₜ[ g ] T, i <: TLater T, i
-
-(* "Logical" connectives *)
-| iSub_Top i T :
-    is_stamped_ty (length Γ) g T →
-    Γ v⊢ₜ[ g ] T, i <: TTop, i
-| iBot_Sub i T :
-    is_stamped_ty (length Γ) g T →
-    Γ v⊢ₜ[ g ] TBot, i <: T, i
-| iAnd1_Sub T1 T2 i:
-    is_stamped_ty (length Γ) g T1 →
-    is_stamped_ty (length Γ) g T2 →
-    Γ v⊢ₜ[ g ] TAnd T1 T2, i <: T1, i
-| iAnd2_Sub T1 T2 i:
-    is_stamped_ty (length Γ) g T1 →
-    is_stamped_ty (length Γ) g T2 →
-    Γ v⊢ₜ[ g ] TAnd T1 T2, i <: T2, i
-| iSub_And T U1 U2 i j:
-    Γ v⊢ₜ[ g ] T, i <: U1, j →
-    Γ v⊢ₜ[ g ] T, i <: U2, j →
-    Γ v⊢ₜ[ g ] T, i <: TAnd U1 U2, j
-| iSub_Or1 T1 T2 i:
-    is_stamped_ty (length Γ) g T1 →
-    is_stamped_ty (length Γ) g T2 →
-    Γ v⊢ₜ[ g ] T1, i <: TOr T1 T2, i
-| iSub_Or2 T1 T2 i:
-    is_stamped_ty (length Γ) g T1 →
-    is_stamped_ty (length Γ) g T2 →
-    Γ v⊢ₜ[ g ] T2, i <: TOr T1 T2, i
-| iOr_Sub T1 T2 U i j:
-    Γ v⊢ₜ[ g ] T1, i <: U, j →
-    Γ v⊢ₜ[ g ] T2, i <: U, j →
-    Γ v⊢ₜ[ g ] TOr T1 T2, i <: U, j
-
-(* Type selections *)
-| iSel_Sub p L {l U i}:
-    Γ v⊢ₚ[ g ] p : TTMem l L U, i →
-    Γ v⊢ₜ[ g ] TSel p l, i <: U, i
-| iSub_Sel p U {l L i}:
-    Γ v⊢ₚ[ g ] p : TTMem l L U, i →
-    Γ v⊢ₜ[ g ] L, i <: TSel p l, i
-
-| iSngl_pq_Sub p q {i T1 T2}:
-    T1 ~Tp[ p := q ]* T2 →
-    is_stamped_ty (length Γ) g T1 →
-    is_stamped_ty (length Γ) g T2 →
-    Γ v⊢ₚ[ g ] p : TSing q, i →
-    Γ v⊢ₜ[ g ] T1, i <: T2, i
-| iSngl_Sub_Sym T {p q i}:
-    Γ v⊢ₚ[ g ] p : T, i →
-    Γ v⊢ₜ[ g ] TSing p, i <: TSing q, i →
-    Γ v⊢ₜ[ g ] TSing q, i <: TSing p, i
-| iSngl_Sub_Self {p T i} :
-    Γ v⊢ₚ[ g ] p : T, i →
-    Γ v⊢ₜ[ g ] TSing p, i <: T, i
-
-(* Subtyping for recursive types. Congruence, and opening in both directions. *)
-| iMu_Sub_Mu T1 T2 i j:
-    (iterate TLater i T1 :: Γ) v⊢ₜ[ g ] T1, i <: T2, j →
-    is_stamped_ty (S (length Γ)) g T1 →
-    Γ v⊢ₜ[ g ] TMu T1, i <: TMu T2, j
-| iMu_Sub T i:
-    is_stamped_ty (length Γ) g T →
-    Γ v⊢ₜ[ g ] TMu (shift T), i <: T, i
-| iSub_Mu T i:
-    is_stamped_ty (length Γ) g T →
-    Γ v⊢ₜ[ g ] T, i <: TMu (shift T), i
-
-(* "Congruence" or "variance" rules for subtyping. Unneeded for "logical" types. *)
-| iAll_Sub_All T1 T2 U1 U2 i:
-    Γ v⊢ₜ[ g ] TLater T2, i <: TLater T1, i →
-    iterate TLater (S i) (shift T2) :: Γ v⊢ₜ[ g ] TLater U1, i <: TLater U2, i →
-    is_stamped_ty (length Γ) g T2 →
-    Γ v⊢ₜ[ g ] TAll T1 U1, i <: TAll T2 U2, i
-| iFld_Sub_Fld T1 T2 i l:
-    Γ v⊢ₜ[ g ] T1, i <: T2, i →
-    Γ v⊢ₜ[ g ] TVMem l T1, i <: TVMem l T2, i
-| iTyp_Sub_Typ L1 L2 U1 U2 i l:
-    Γ v⊢ₜ[ g ] L2, i <: L1, i →
-    Γ v⊢ₜ[ g ] U1, i <: U2, i →
-    Γ v⊢ₜ[ g ] TTMem l L1 U1, i <: TTMem l L2 U2, i
-  (* Is it true that for covariant F, F[A ∧ B] = F[A] ∧ F[B]?
-    Dotty assumes that, tho DOT didn't capture it.
-    F[A ∧ B] <: F[A] ∧ F[B] is provable by covariance.
-    Let's prove F[A] ∧ F[B] <: F[A ∧ B] in the model.
-    *)
-| iAnd_All_Sub_Distr T U1 U2 i:
-    is_stamped_ty (length Γ) g T →
-    is_stamped_ty (S (length Γ)) g U1 →
-    is_stamped_ty (S (length Γ)) g U2 →
-    Γ v⊢ₜ[ g ] TAnd (TAll T U1) (TAll T U2), i <: TAll T (TAnd U1 U2), i
-| iAnd_Fld_Sub_Distr l T1 T2 i:
-    is_stamped_ty (length Γ) g T1 →
-    is_stamped_ty (length Γ) g T2 →
-    Γ v⊢ₜ[ g ] TAnd (TVMem l T1) (TVMem l T2), i <: TVMem l (TAnd T1 T2), i
-| iAnd_Typ_Sub_Distr l L U1 U2 i:
-    is_stamped_ty (length Γ) g L →
-    is_stamped_ty (length Γ) g U1 →
-    is_stamped_ty (length Γ) g U2 →
-    Γ v⊢ₜ[ g ] TAnd (TTMem l L U1) (TTMem l L U2), i <: TTMem l L (TAnd U1 U2), i
-| iDistr_And_Or_Sub {S T U i}:
-    is_stamped_ty (length Γ) g S →
-    is_stamped_ty (length Γ) g T →
-    is_stamped_ty (length Γ) g U →
-    Γ v⊢ₜ[ g ] TAnd (TOr S T) U , i <: TOr (TAnd S U) (TAnd T U), i
-
-
-| iSub_Skolem_P {T1 T2 i j}:
-    is_stamped_ty (length Γ) g T1 →
-    iterate TLater i (shift T1) :: Γ v⊢ₚ[ g ] pv (ids 0) : shift T2, j →
-    (*───────────────────────────────*)
-    Γ v⊢ₜ[ g ] T1, i <: T2, j
-where "Γ v⊢ₜ[ g ] T1 , i1 <: T2 , i2" := (subtype Γ g T1 i1 T2 i2).
+(* Compatibility *)
+Notation "Γ s⊢ₜ[ g ] e : T " := (typed Γ g e T).
+Notation "Γ s⊢ds[ g ] ds : T" := (dms_typed Γ g ds T).
+Notation "Γ s⊢[ g ]{ l := d  } : T" := (dm_typed Γ g l d T).
 
 (* Make [T] first argument: Hide [Γ] and [g] for e.g. typing examples. *)
 Global Arguments iD_Typ_Abs {Γ g} T _ _ _ _ _ _ _ _ _ : assert.
 
 Scheme exp_stamped_typed_mut_ind := Induction for typed Sort Prop
 with   exp_stamped_dms_typed_mut_ind := Induction for dms_typed Sort Prop
-with   exp_stamped_dm_typed_mut_ind := Induction for dm_typed Sort Prop
-with   exp_stamped_path_typed_mut_ind := Induction for path_typed Sort Prop.
+with   exp_stamped_dm_typed_mut_ind := Induction for dm_typed Sort Prop.
 
 Combined Scheme exp_storeless_typing_mut_ind from exp_stamped_typed_mut_ind, exp_stamped_dms_typed_mut_ind,
-  exp_stamped_dm_typed_mut_ind, exp_stamped_path_typed_mut_ind.
+  exp_stamped_dm_typed_mut_ind.
 
 Scheme stamped_typed_mut_ind := Induction for typed Sort Prop
 with   stamped_dms_typed_mut_ind := Induction for dms_typed Sort Prop
-with   stamped_dm_typed_mut_ind := Induction for dm_typed Sort Prop
-with   stamped_path_typed_mut_ind := Induction for path_typed Sort Prop
+with   stamped_dm_typed_mut_ind := Induction for dm_typed Sort Prop.
+Scheme stamped_path_typed_mut_ind := Induction for path_typed Sort Prop
 with   stamped_subtype_mut_ind := Induction for subtype Sort Prop.
 
 Combined Scheme storeless_typing_mut_ind from stamped_typed_mut_ind, stamped_dms_typed_mut_ind,
-  stamped_dm_typed_mut_ind, stamped_path_typed_mut_ind, stamped_subtype_mut_ind.
+  stamped_dm_typed_mut_ind.
+Combined Scheme pure_storeless_typing_mut_ind from stamped_path_typed_mut_ind,
+  stamped_subtype_mut_ind.
 
 (** ** A few derived rules, and some automation to use them in examples. *)
 
@@ -344,7 +184,7 @@ Hint Extern 10 => try_once iSub_Trans : core.
 
 Lemma iT_Path' Γ v T g
   (Ht : Γ v⊢ₚ[ g ] pv v : T, 0) : Γ v⊢ₜ[ g ] tv v : T.
-Proof. exact: (iT_Path (p := pv _)). Qed.
+Proof. exact: (iT_Path _ (p := pv _)). Qed.
 
 Lemma iT_Nat_I Γ g n : Γ v⊢ₜ[ g ] tv (vint n): TInt.
 Proof. apply iT_Path'; constructor. Qed.
@@ -375,73 +215,14 @@ Lemma iD_All Γ V T1 T2 e l g:
   Γ |L V v⊢[ g ]{ l := dpt (pv (vabs e)) } : TVMem l (TAll T1 T2).
 Proof. by intros; apply iD_Val, iT_All_I_strip1. Qed.
 
-Lemma iP_Later {Γ p T i g} :
-  is_stamped_ty (length Γ) g T →
-  Γ v⊢ₚ[ g ] p : TLater T, i →
-  Γ v⊢ₚ[ g ] p : T, S i.
-Proof.
-  intros Hu Hp; apply iP_Sub with (j := 1) (T1 := TLater T) (T2 := T) in Hp;
-    move: Hp; rewrite (plusnS i 0) (plusnO i); intros; by [|constructor].
-Qed.
-
-Lemma iP_Sub' {Γ p T1 T2 i g} :
-  Γ v⊢ₜ[ g ] T1, i <: T2, i →
-  Γ v⊢ₚ[ g ] p : T1, i →
-  Γ v⊢ₚ[ g ] p : T2, i.
-Proof.
-  intros Hsub Hp; rewrite -(plusnO i).
-  by eapply iP_Sub, Hp; rewrite plusnO.
-Qed.
-
-Ltac ettrans := eapply iSub_Trans.
-
-Lemma Sub_later_shift {Γ T1 T2 i j g}
-  (Hs1: is_stamped_ty (length Γ) g T1)
-  (Hs2: is_stamped_ty (length Γ) g T2)
-  (Hsub: Γ v⊢ₜ[ g ] T1, S i <: T2, S j):
-  Γ v⊢ₜ[ g ] TLater T1, i <: TLater T2, j.
-Proof.
-  ettrans; first exact: iLater_Sub.
-  by eapply iSub_Trans, iSub_Later.
-Qed.
-
-Lemma Sub_later_shift_inv {Γ T1 T2 i j g}
-  (Hs1: is_stamped_ty (length Γ) g T1)
-  (Hs2: is_stamped_ty (length Γ) g T2)
-  (Hsub: Γ v⊢ₜ[ g ] TLater T1, i <: TLater T2, j):
-  Γ v⊢ₜ[ g ] T1, S i <: T2, S j.
-Proof.
-  ettrans; first exact: iSub_Later.
-  by eapply iSub_Trans, iLater_Sub.
-Qed.
-
-Ltac typconstructor_blacklist Γ :=
-  lazymatch goal with
-  | |- path_typed ?Γ' _ _ _ _ =>
-  tryif (unify Γ Γ') then idtac else fail 1 "Only applicable rule is iSub_Skolem_P"
-  | _ => idtac
-  end.
-
 Ltac typconstructor :=
   match goal with
-  | |- typed      ?Γ _ _ _ =>
-    first [apply iT_All_I_strip1 | apply iT_All_I | apply iT_Nat_I | apply iT_Bool_I | constructor]
+  | |- typed      ?Γ _ _ _ => first [
+    apply iT_All_I_strip1 | apply iT_All_I |
+    apply iT_Nat_I | apply iT_Bool_I |
+    constructor]
   | |- dms_typed  ?Γ _ _ _ => constructor
   | |- dm_typed   ?Γ _ _ _ _ => first [apply iD_All | constructor]
-  | |- path_typed ?Γ _ _ _ _ => first [apply iP_Later | constructor]
-  | |- subtype    ?Γ _ _ _ _ _ =>
-    first [apply Sub_later_shift | constructor ]; typconstructor_blacklist Γ
+  | |- path_typed ?Γ _ _ _ => first [subtypconstructor]
+  | |- subtype    ?Γ _ _ _ _ => subtypconstructor
   end.
-
-(* Compatibility *)
-Reserved Notation "Γ s⊢ₜ[ g  ] e : T" (at level 74, e, T at next level).
-Reserved Notation "Γ s⊢ₚ[ g  ] p : T , i" (at level 74, p, T, i at next level).
-Reserved Notation "Γ s⊢[ g  ]{ l := d  } : T " (at level 74, l, d, T at next level).
-Reserved Notation "Γ s⊢ds[ g  ] ds : T" (at level 74, ds, T at next level).
-Reserved Notation "Γ s⊢ₜ[ g  ] T1 , i1 <: T2 , i2" (at level 74, T1, T2, i1, i2 at next level).
-
-Notation "Γ s⊢ₜ[ g ] e : T " := (typed Γ g e T).
-Notation "Γ s⊢ds[ g ] ds : T" := (dms_typed Γ g ds T).
-Notation "Γ s⊢[ g ]{ l := d  } : T" := (dm_typed Γ g l d T).
-Notation "Γ s⊢ₚ[ g ] p : T , i" := (path_typed Γ g p T i).
-Notation "Γ s⊢ₜ[ g ] T1 , i1 <: T2 , i2" := (subtype Γ g T1 i1 T2 i2).

--- a/theories/Dot/typing/typing_stamping.v
+++ b/theories/Dot/typing/typing_stamping.v
@@ -144,11 +144,6 @@ Section syntyping_stamping_lemmas.
       apply (@is_unstamped_ren_ty_1 (length Γ) (shiftN x T)), IHx; eauto.
   Qed.
 
-  Lemma is_unstamped_TLater_n {i n T}:
-    is_unstamped_ty' n T →
-    is_unstamped_ty' n (iterate TLater i T).
-  Proof. elim: i => [|//i IHi]; rewrite ?iterate_0 ?iterate_S //; auto. Qed.
-
   Lemma is_unstamped_tv_inv {n v b}:
     is_unstamped_tm n b (tv v) →
     is_unstamped_vl n b v.

--- a/theories/Dot/typing/typing_stamping.v
+++ b/theories/Dot/typing/typing_stamping.v
@@ -2,7 +2,7 @@
 From D Require Import iris_extra.det_reduction.
 From D.Dot Require Import storeless_typing core_stamping_defs ast_stamping skeleton
   path_repl_lemmas.
-From D.Dot Require old_unstamped_typing.
+From D.Dot Require old_unstamped_typing old_subtyping.
 From D.Dot Require Import unstampedness_binding.
 
 Set Implicit Arguments.
@@ -76,27 +76,29 @@ Section syntyping_stamping_lemmas.
     Γ !! x = Some T → is_unstamped_vl (length Γ) b (var_vl x).
   Proof. constructor; exact: lookup_lt_Some. Qed.
 
+  Lemma unstamped_path_subject Γ p T i:
+    Γ u⊢ₚ p : T, i → is_unstamped_path' (length Γ) p.
+  Proof.
+    induction 1; cbn; intros; try with_is_unstamped inverse;
+      eauto 7 using is_unstamped_vl_lookup.
+  Qed.
+  Local Hint Resolve unstamped_path_subject : core.
+
   Lemma unstamped_mut_subject Γ :
     (∀ e T,   Γ u⊢ₜ e : T → is_unstamped_tm (length Γ) AlsoNonVars e) ∧
     (∀ ds T,  Γ u⊢ds ds : T → is_unstamped_dms (length Γ) AlsoNonVars ds) ∧
-    (∀ l d T, Γ u⊢{ l := d } : T → is_unstamped_dm (length Γ) AlsoNonVars d) ∧
-    (∀ p T i, Γ u⊢ₚ p : T, i → is_unstamped_path' (length Γ) p).
+    (∀ l d T, Γ u⊢{ l := d } : T → is_unstamped_dm (length Γ) AlsoNonVars d).
   Proof.
-    eapply exp_old_unstamped_typing_mut_ind with
+    eapply old_unstamped_typing_mut_ind with
         (P := λ Γ e T _, is_unstamped_tm (length Γ) AlsoNonVars e)
         (P0 := λ Γ ds T _, is_unstamped_dms (length Γ) AlsoNonVars ds)
-        (P1 := λ Γ l d T _, is_unstamped_dm (length Γ) AlsoNonVars d)
-        (P2 := λ Γ p T i _, is_unstamped_path' (length Γ) p); clear Γ;
+        (P1 := λ Γ l d T _, is_unstamped_dm (length Γ) AlsoNonVars d); clear Γ;
         cbn; intros; try (rewrite <-(@ctx_strip_len Γ Γ') in *; last done);
         try by (with_is_unstamped inverse + idtac);
         eauto 7 using is_unstamped_path2tm, is_unstamped_vl_lookup.
-    elim: i {s} => [|i IHi]; rewrite /= ?iterate_0 ?iterate_S //; eauto.
+    - elim: i {s} => [|i IHi]; rewrite /= ?iterate_0 ?iterate_S //; eauto.
+    - constructor; eapply is_unstamped_path2AlsoNonVars; eauto.
   Qed.
-
-  Lemma unstamped_path_subject Γ p T i:
-    Γ u⊢ₚ p : T, i → is_unstamped_path' (length Γ) p.
-  Proof. apply unstamped_mut_subject. Qed.
-  Local Hint Resolve unstamped_path_subject : core.
 
   Section unstamped_syntyping_lemmas.
 
@@ -209,28 +211,52 @@ Section syntyping_stamping_lemmas.
 
   Local Hint Resolve ctx_strip_unstamped ctx_sub_unstamped fmap_TLater_unstamped_inv : core.
 
-  Lemma unstamped_mut_types Γ :
-    (∀ e T, Γ u⊢ₜ e : T → ∀ (Hctx: unstamped_ctx Γ), is_unstamped_ty' (length Γ) T) ∧
-    (∀ ds T, Γ u⊢ds ds : T → ∀ (Hctx: unstamped_ctx Γ), is_unstamped_ty' (length Γ) T) ∧
-    (∀ l d T, Γ u⊢{ l := d } : T → ∀ (Hctx: unstamped_ctx Γ), is_unstamped_ty' (length Γ) T) ∧
+  Lemma subtyping_unstamped_mut_types Γ :
     (∀ p T i, Γ u⊢ₚ p : T , i → ∀ (Hctx: unstamped_ctx Γ), is_unstamped_ty' (length Γ) T) ∧
     (∀ T1 i1 T2 i2, Γ u⊢ₜ T1, i1 <: T2, i2 → ∀ (Hctx: unstamped_ctx Γ),
       is_unstamped_ty' (length Γ) T1 ∧ is_unstamped_ty' (length Γ) T2).
   Proof.
+    eapply old_pure_typing_mut_ind with
+        (P := λ Γ p T i _, ∀ (Hctx: unstamped_ctx Γ), is_unstamped_ty' (length Γ) T)
+        (P0 := λ Γ T1 i1 T2 i2 _, ∀ (Hctx: unstamped_ctx Γ),
+               is_unstamped_ty' (length Γ) T1 ∧ is_unstamped_ty' (length Γ) T2); clear Γ.
+    all: intros; simplify_eq/=; try nosplit inverse Hctx;
+      try (efeed pose proof H ; [by eauto | ev; clear H ]);
+      try (efeed pose proof H0; [by eauto | ev; clear H0]);
+      repeat constructor; eauto 2;
+      inverse_is_unstamped; eauto 4 using unstamped_lookup.
+      exact /is_unstamped_ren_ty.
+  Qed.
+  Lemma unstamped_subtyping_types_1 Γ :
+    ∀ T1 i1 T2 i2, Γ u⊢ₜ T1, i1 <: T2, i2 → ∀ (Hctx: unstamped_ctx Γ),
+      is_unstamped_ty' (length Γ) T1.
+  Proof. apply subtyping_unstamped_mut_types. Qed.
+  Lemma unstamped_subtyping_types_2 Γ :
+    ∀ T1 i1 T2 i2, Γ u⊢ₜ T1, i1 <: T2, i2 → ∀ (Hctx: unstamped_ctx Γ),
+      is_unstamped_ty' (length Γ) T2.
+  Proof. apply subtyping_unstamped_mut_types. Qed.
+  Lemma unstamped_path_types Γ :
+    (∀ p T i, Γ u⊢ₚ p : T , i → ∀ (Hctx: unstamped_ctx Γ), is_unstamped_ty' (length Γ) T).
+  Proof. apply subtyping_unstamped_mut_types. Qed.
+
+  Lemma unstamped_mut_types Γ :
+    (∀ e T, Γ u⊢ₜ e : T → ∀ (Hctx: unstamped_ctx Γ), is_unstamped_ty' (length Γ) T) ∧
+    (∀ ds T, Γ u⊢ds ds : T → ∀ (Hctx: unstamped_ctx Γ), is_unstamped_ty' (length Γ) T) ∧
+    (∀ l d T, Γ u⊢{ l := d } : T → ∀ (Hctx: unstamped_ctx Γ), is_unstamped_ty' (length Γ) T).
+  Proof.
     eapply old_unstamped_typing_mut_ind with
         (P := λ Γ e T _, ∀ (Hctx: unstamped_ctx Γ), is_unstamped_ty' (length Γ) T)
         (P0 := λ Γ ds T _, ∀ (Hctx: unstamped_ctx Γ), is_unstamped_ty' (length Γ) T)
-        (P1 := λ Γ l d T _, ∀ (Hctx: unstamped_ctx Γ), is_unstamped_ty' (length Γ) T)
-        (P2 := λ Γ p T i _, ∀ (Hctx: unstamped_ctx Γ), is_unstamped_ty' (length Γ) T)
-        (P3 := λ Γ T1 i1 T2 i2 _, ∀ (Hctx: unstamped_ctx Γ),
-               is_unstamped_ty' (length Γ) T1 ∧ is_unstamped_ty' (length Γ) T2); clear Γ.
+        (P1 := λ Γ l d T _, ∀ (Hctx: unstamped_ctx Γ), is_unstamped_ty' (length Γ) T); clear Γ.
     all: intros; simplify_eq/=; try nosplit inverse Hctx;
       try (rewrite ->?(@ctx_sub_len Γ Γ'),
         ?(@ctx_strip_len Γ Γ') in * by assumption);
       try (efeed pose proof H ; [by eauto | ev; clear H ]);
       try (efeed pose proof H0; [by eauto | ev; clear H0]);
       repeat constructor; rewrite /= ?fmap_length; eauto 2;
-      inverse_is_unstamped; eauto 4 using unstamped_lookup, is_unstamped_sub_rev_ty.
+      inverse_is_unstamped; eauto 4 using unstamped_lookup,
+        is_unstamped_sub_rev_ty, unstamped_path_types,
+        unstamped_subtyping_types_1, unstamped_subtyping_types_2.
   Qed.
 
   End unstamped_syntyping_lemmas.
@@ -304,17 +330,7 @@ Section syntyping_stamping_lemmas.
 
   (* This allows stamped paths to change; that's not used for paths appearing
   in types, and it helps stamp D-Val/D-Val-New. *)
-  Lemma stamp_obj_ident_typing_mut Γ :
-    (∀ e T, Γ u⊢ₜ e : T →
-      ∀ g, ∃ e' g',
-      Γ s⊢ₜ[ g' ] e' : T ∧ g ⊆ g' ∧ stamps_tm' (length Γ) e g' e') ∧
-    (∀ ds T, Γ u⊢ds ds : T →
-      ∀ g, ∃ ds' g',
-      Γ s⊢ds[ g' ] ds' : T ∧ g ⊆ g' ∧ stamps_dms' (length Γ) ds g' ds') ∧
-    (∀ l d T, Γ u⊢{ l := d } : T →
-      ∀ g, ∃ d' g',
-      Γ s⊢[ g' ]{ l := d' } : T
-        ∧ g ⊆ g' ∧ stamps_dm' (length Γ) d g' d') ∧
+  Lemma stamp_obj_ident_subtyping_mut Γ :
     (∀ p T i, Γ u⊢ₚ p : T, i →
       ∀ g, ∃ g',
       Γ s⊢ₚ[ g' ] p : T, i
@@ -322,20 +338,12 @@ Section syntyping_stamping_lemmas.
     (∀ T1 i1 T2 i2, Γ u⊢ₜ T1, i1 <: T2, i2 →
       ∀ g, ∃ g', Γ s⊢ₜ[ g' ] T1, i1 <: T2, i2 ∧ g ⊆ g').
   Proof.
-    eapply old_unstamped_typing_mut_ind with
-      (P := λ Γ e T _, ∀ g, ∃ e' g',
-        Γ s⊢ₜ[ g' ] e' : T ∧ g ⊆ g' ∧ stamps_tm' (length Γ) e g' e')
-      (P0 := λ Γ ds T _, ∀ g, ∃ ds' g',
-        Γ s⊢ds[ g' ] ds' : T ∧ g ⊆ g' ∧ stamps_dms' (length Γ) ds g' ds')
-      (P1 := λ Γ l d T _, ∀ g, ∃ d' g',
-        Γ s⊢[ g' ]{ l := d' } : T ∧ g ⊆ g' ∧
-        stamps_dm' (length Γ) d g' d')
-      (P2 := λ Γ p T i _, ∀ g, ∃ g',
+    eapply old_pure_typing_mut_ind with
+      (P := λ Γ p T i _, ∀ g, ∃ g',
         Γ s⊢ₚ[ g' ] p : T, i ∧ g ⊆ g')
-      (P3 := λ Γ T1 i1 T2 i2 _, ∀ g, ∃ g',
+      (P0 := λ Γ T1 i1 T2 i2 _, ∀ g, ∃ g',
         Γ s⊢ₜ[ g' ] T1, i1 <: T2, i2 ∧ g ⊆ g');
        clear Γ.
-
     all: try solve [intros * Hu1 IHs1 Hu2 IHs2 g;
     (* Strategy for cases of subtyping with multiple premises:
         - apply the induction hypothesis on the first premise with map [g], and obtain map [g1];
@@ -349,106 +357,6 @@ Section syntyping_stamping_lemmas.
       move: IHs1 => /(.$ g) [g1 [Hts1 Hle1]]; exists g1; split_and!;
       try fast_done; (constructor; eauto 2) || eauto 3].
     all: try solve [intros; exists g; split_and!; try fast_done; constructor; eauto 2].
-
-  (* In hyp names, [Hus] are for [is_unstamped_ty], [Husp] for
-  [is_unstamped_path], [Hu] for unstamped typing, [IHs] for the induction
-  hyps about stamped typing, [Hle] for [g? ⊆ g?], [Hpr] for path replacement. *)
-  - intros * Husp Hu1 IHs1 Hu2 IHs2 g.
-    move: IHs1 => /(.$ g) [e1' [g1 [IHs1 [Hle1 Hse1]]]];
-    move: IHs2 => /(.$ g1) [g2 [IHs2 Hle2]]; lte g g1 g2.
-    have Hse1': unstamp_tm g2 e1' = e1. by eapply stamps_unstamp_mono_tm, Hse1.
-    exists (tapp e1' (path2tm p2)), g2.
-    split_and!; first eapply storeless_typing.iT_All_Ex_p => //; naive_solver eauto 6.
-  - intros * Hu1 IHs1 Hu2 IHs2 g.
-    move: IHs1 => /(.$ g) [e1' [g1 ?]];
-    move: IHs2 => /(.$ g1) [e2' [g2 ?]]; ev; lte g g1 g2.
-    exists (tapp e1' e2'), g2; naive_solver.
-  - intros * Hu1 IHs1 g.
-    move: IHs1 => /(.$ g) [e1' [g1 ?]].
-    exists (tproj e1' l), g1; naive_solver.
-  - intros * Hctxsub Hus1 Hu1 IHs1 g.
-    move: IHs1 => /(.$ g) [e' [g1 ?]].
-    exists (tv (vabs e')), g1.
-    simpl in *. rewrite <-(ctx_strip_len Hctxsub) in *.
-    naive_solver.
-  - intros * Huds1 IHs1 Hus1 g.
-    move: IHs1 => /(.$ g) [ds' [g1 ?]].
-    exists (tv (vobj ds')), g1; naive_solver.
-  - intros * ? IHs1 ? IHs2 g.
-    move: IHs1 => /(.$ g) [g1 [Hts1 Hle1]].
-    move: IHs2 => /(.$ g1) [e' [g2 [Hts2 [Hle2 Hs]]]]; lte g g1 g2.
-    eapply stamps_tm_skip with (i := i) in Hs.
-    exists (iterate tskip i e'), g2; eauto.
-  - intros * Hu1 IHs1 g.
-    move: IHs1 => /(.$ g) /= [g1 ?]; ev.
-    have ? := unstamped_path_subject Hu1.
-    exists (path2tm p), g1; naive_solver.
-  - intros. exists (tv (vint n)), g; split_and?; try typconstructor; naive_solver.
-  - intros. exists (tv (vbool b)), g; split_and?; try typconstructor; naive_solver.
-  - intros * Hprim Hu1 IHs1 g.
-    move: IHs1 => /(.$ g) [e1' [g1 ?]].
-    exists (tun u e1'), g1; naive_solver.
-  - intros * Hprim Hu1 IHs1 Hu2 IHs2 g.
-    move: IHs1 => /(.$ g) [e1' [g1 [Hts1 [Hle1 ?]]]].
-    move: IHs2 => /(.$ g1) [e2' [g2 [Hts2 [Hle2 ?]]]].
-    have ?: unstamp_tm g2 e1' = e1 by exact: stamps_unstamp_mono_tm.
-    (* Must come *after* the assertion. *)
-    lte g g1 g2; ev.
-    exists (tbin b e1' e2'), g2; cbn; split_and!; first econstructor; eauto 3.
-  - intros * Hu1 IHs1 Hu2 IHs2 Hu3 IHs3 g.
-    move: IHs1 => /(.$ g) [e' [g1 [Hts1 [Hle1 ?]]]].
-    move: IHs2 => /(.$ g1) [e1' [g2 [Hts2 [Hle2 ?]]]].
-    move: IHs3 => /(.$ g2) [e2' [g3 [Hts3 [Hle3 ?]]]].
-    lte g g1 g2; lte g1 g2 g3; lte g g1 g3; ev.
-    exists (tif e' e1' e2'), g3; cbn; split_and!; try f_equal; naive_solver.
-  - intros; exists [], g; naive_solver.
-  - intros * Hu1 IHs1 Hu2 IHs2 ? g.
-    move: IHs1 => /(.$ g) [d' [g1 ?]].
-    move: IHs2 => /(.$ g1) [ds' [g2 ?]]; ev; lte g g1 g2.
-    have ?: unstamp_dm g2 d' = d by naive_solver.
-    exists ((l, d') :: ds'), g2; cbn.
-    split_and!; eauto 4 using unstamp_dms_hasnt.
-
-    (* The core and most interesting case! Stamping dtysyn! *)
-  - intros * Hus Hu1 IHs1 Hu2 IHs2 g.
-    move: IHs1 => /(.$ g) [g1 [Hts1 Hle1]];
-    move: IHs2 => /(.$ g1) [g2 [Hts2 Hle2]].
-
-    have Husv: is_unstamped_dm (length Γ) AlsoNonVars (dtysyn T) by eauto.
-    destruct (extract g2 (length Γ) T) as [g3 [s σ]] eqn:Heqo.
-    move: Heqo => [Heqg3 Heqs Heqσ].
-    have {Heqσ} -Heqσ: σ = idsσ (length Γ) by naive_solver.
-    destruct (stamp_dtysyn_spec g2 Husv); destruct_and!.
-    have ?: g2 ⊆ g3 by simplify_eq. lte g g1 g2; lte g g2 g3; lte g1 g2 g3.
-    exists (dtysem σ s), g3; simplify_eq; split_and!;
-      first eapply (storeless_typing.iD_Typ_Abs T); auto 2; [
-        exact: (stamped_obj_ident_subtype_mono _ Hts1)|
-        exact: (stamped_obj_ident_subtype_mono _ Hts2)].
-  - intros * Hu1 IHs1 g.
-    move: IHs1 => /(.$ g) /= [e1' [g1 ?]]; destruct_and!.
-    have [v' ?]: ∃ v', e1' = tv v' by destruct e1'; naive_solver.
-    simplify_eq/=; with_is_stamped inverse; with_is_unstamped inverse.
-    exists (dpt (pv v')), g1; naive_solver.
-  - intros * Hu1 IHs1 g.
-    move: IHs1 => /(.$ g) /= [g1 ?]; destruct_and!.
-    exists (dpt p), g1; split_and!; naive_solver eauto
-      using is_unstamped_path2AlsoNonVars.
-  - intros * Hu1 IHs1 Hus1 g.
-    move: IHs1 => /(.$ g) /= [ds' [g1 ?]]; destruct_and!.
-    exists (dpt (pv (vobj ds'))), g1; split_and!; cbn;
-      try eapply storeless_typing.iD_Val_New; eauto 2;
-      repeat constructor; eauto with f_equal.
-  - intros * Hu1 IHs1 Hu2 IHs2 g.
-    (* Here and for standard subsumption, by stamping the subtyping
-      derivation before typing, we needn't use monotonicity on [Hs],
-      which holds but would require extra boilerplate. *)
-    move: IHs1 => /(.$ g) [g1 [Hts1 Hle1]].
-    move: IHs2 => /(.$ g1) [d' [g2 [Hts2 [Hle2 Hs]]]]; lte g g1 g2.
-    have [p' Heq]: ∃ p', d' = dpt p'. {
-      move: Hs => {Hts2}; destruct d'; rewrite /= /from_option => -[?[??]];
-        try case_match; simplify_eq; eauto 2.
-    }
-    exists d', g2; subst d'; split_and!; ev; eauto 3.
   - intros * Hus1 Hu1 IHs1 g.
     move: IHs1 => /(.$ g) /= [g1 ?]; ev.
     exists g1; split_and! => //; econstructor; naive_solver.
@@ -484,14 +392,156 @@ Section syntyping_stamping_lemmas.
     eauto.
   Qed.
 
+  Lemma stamp_obj_ident_path_typing Γ :
+    (∀ p T i, Γ u⊢ₚ p : T, i →
+      ∀ g, ∃ g', Γ s⊢ₚ[ g' ] p : T, i ∧ g ⊆ g').
+  Proof. apply stamp_obj_ident_subtyping_mut. Qed.
+  Lemma stamp_obj_ident_subtyping Γ :
+    (∀ T1 i1 T2 i2, Γ u⊢ₜ T1, i1 <: T2, i2 →
+      ∀ g, ∃ g', Γ s⊢ₜ[ g' ] T1, i1 <: T2, i2 ∧ g ⊆ g').
+  Proof. apply stamp_obj_ident_subtyping_mut. Qed.
+  Local Hint Resolve stamp_obj_ident_subtyping stamp_obj_ident_path_typing : core.
+
+  Lemma stamp_obj_ident_typing_mut Γ :
+    (∀ e T, Γ u⊢ₜ e : T →
+      ∀ g, ∃ e' g',
+      Γ s⊢ₜ[ g' ] e' : T ∧ g ⊆ g' ∧ stamps_tm' (length Γ) e g' e') ∧
+    (∀ ds T, Γ u⊢ds ds : T →
+      ∀ g, ∃ ds' g',
+      Γ s⊢ds[ g' ] ds' : T ∧ g ⊆ g' ∧ stamps_dms' (length Γ) ds g' ds') ∧
+    (∀ l d T, Γ u⊢{ l := d } : T →
+      ∀ g, ∃ d' g',
+      Γ s⊢[ g' ]{ l := d' } : T
+        ∧ g ⊆ g' ∧ stamps_dm' (length Γ) d g' d').
+  Proof.
+    eapply old_unstamped_typing_mut_ind with
+      (P := λ Γ e T _, ∀ g, ∃ e' g',
+        Γ s⊢ₜ[ g' ] e' : T ∧ g ⊆ g' ∧ stamps_tm' (length Γ) e g' e')
+      (P0 := λ Γ ds T _, ∀ g, ∃ ds' g',
+        Γ s⊢ds[ g' ] ds' : T ∧ g ⊆ g' ∧ stamps_dms' (length Γ) ds g' ds')
+      (P1 := λ Γ l d T _, ∀ g, ∃ d' g',
+        Γ s⊢[ g' ]{ l := d' } : T ∧ g ⊆ g' ∧
+        stamps_dm' (length Γ) d g' d');
+       clear Γ.
+
+    all: try solve [intros * Hu1 IHs1 Hu2 IHs2 g;
+    (* Strategy for cases of subtyping with multiple premises:
+        - apply the induction hypothesis on the first premise with map [g], and obtain map [g1];
+        - apply the induction hypothesis on the second premise with map [g1], and obtain map [g2];
+        - exhibit map [g2]. *)
+    (* Specialize IHs1 (with [/(.$ g]) and split the result. Ditto IHs2. *)
+      move: IHs1 => /(.$ g) [g1 [IHs1 Hle1]];
+      move: IHs2 => /(.$ g1) [g2 [IHs2 Hle2]]; ev; lte g g1 g2;
+      exists g2; split_and!; try fast_done; eauto 3].
+    all: try solve [intros * Hu1 IHs1 **;
+      move: IHs1 => /(.$ g) [g1 [Hts1 Hle1]]; exists g1; split_and!;
+      try fast_done; (constructor; eauto 2) || eauto 3].
+    all: try solve [intros; exists g; split_and!; try fast_done; constructor; eauto 2].
+
+  (* In hyp names, [Hus] are for [is_unstamped_ty], [Husp] for
+  [is_unstamped_path], [Hu] for unstamped typing, [IHs] for the induction
+  hyps about stamped typing, [Hle] for [g? ⊆ g?], [Hpr] for path replacement. *)
+  - intros * Husp Hu1 IHs1 Hu2 g.
+    move: IHs1 => /(.$ g) [e1' [g1 [IHs1 [Hle1 Hse1]]]].
+    move: (stamp_obj_ident_path_typing Hu2) => /(.$ g1) [g2 [IHs2 Hle2]]; lte g g1 g2.
+    have Hse1': unstamp_tm g2 e1' = e1. by eapply stamps_unstamp_mono_tm, Hse1.
+    exists (tapp e1' (path2tm p2)), g2.
+    split_and!; first eapply storeless_typing.iT_All_Ex_p => //; naive_solver eauto 6.
+  - intros * Hu1 IHs1 Hu2 IHs2 g.
+    move: IHs1 => /(.$ g) [e1' [g1 ?]];
+    move: IHs2 => /(.$ g1) [e2' [g2 ?]]; ev; lte g g1 g2.
+    exists (tapp e1' e2'), g2; naive_solver.
+  - intros * Hu1 IHs1 g.
+    move: IHs1 => /(.$ g) [e1' [g1 ?]].
+    exists (tproj e1' l), g1; naive_solver.
+  - intros * Hctxsub Hus1 Hu1 IHs1 g.
+    move: IHs1 => /(.$ g) [e' [g1 ?]].
+    exists (tv (vabs e')), g1.
+    simpl in *. rewrite <-(ctx_strip_len Hctxsub) in *.
+    naive_solver.
+  - intros * Huds1 IHs1 Hus1 g.
+    move: IHs1 => /(.$ g) [ds' [g1 ?]].
+    exists (tv (vobj ds')), g1; naive_solver.
+  - intros * Hu1 ? IHs2 g.
+    move: (stamp_obj_ident_subtyping Hu1) => /(.$ g) [g1 [Hts1 Hle1]].
+    move: IHs2 => /(.$ g1) [e' [g2 [Hts2 [Hle2 Hs]]]]; lte g g1 g2.
+    eapply stamps_tm_skip with (i := i) in Hs.
+    exists (iterate tskip i e'), g2; eauto.
+  - intros * Hu1 g.
+    move: (stamp_obj_ident_path_typing Hu1) => /(.$ g) /= [g1 ?]; ev.
+    have ? := unstamped_path_subject Hu1.
+    exists (path2tm p), g1; naive_solver.
+  - intros. exists (tv (vint n)), g; split_and?; try typconstructor; naive_solver.
+  - intros. exists (tv (vbool b)), g; split_and?; try typconstructor; naive_solver.
+  - intros * Hprim Hu1 IHs1 g.
+    move: IHs1 => /(.$ g) [e1' [g1 ?]].
+    exists (tun u e1'), g1; naive_solver.
+  - intros * Hprim Hu1 IHs1 Hu2 IHs2 g.
+    move: IHs1 => /(.$ g) [e1' [g1 [Hts1 [Hle1 ?]]]].
+    move: IHs2 => /(.$ g1) [e2' [g2 [Hts2 [Hle2 ?]]]].
+    have ?: unstamp_tm g2 e1' = e1 by exact: stamps_unstamp_mono_tm.
+    (* Must come *after* the assertion. *)
+    lte g g1 g2; ev.
+    exists (tbin b e1' e2'), g2; cbn; split_and!; first econstructor; eauto 3.
+  - intros * Hu1 IHs1 Hu2 IHs2 Hu3 IHs3 g.
+    move: IHs1 => /(.$ g) [e' [g1 [Hts1 [Hle1 ?]]]].
+    move: IHs2 => /(.$ g1) [e1' [g2 [Hts2 [Hle2 ?]]]].
+    move: IHs3 => /(.$ g2) [e2' [g3 [Hts3 [Hle3 ?]]]].
+    lte g g1 g2; lte g1 g2 g3; lte g g1 g3; ev.
+    exists (tif e' e1' e2'), g3; cbn; split_and!; try f_equal; naive_solver.
+  - intros; exists [], g; naive_solver.
+  - intros * Hu1 IHs1 Hu2 IHs2 ? g.
+    move: IHs1 => /(.$ g) [d' [g1 ?]].
+    move: IHs2 => /(.$ g1) [ds' [g2 ?]]; ev; lte g g1 g2.
+    have ?: unstamp_dm g2 d' = d by naive_solver.
+    exists ((l, d') :: ds'), g2; cbn.
+    split_and!; eauto 4 using unstamp_dms_hasnt.
+
+    (* The core and most interesting case! Stamping dtysyn! *)
+  - intros * Hus Hu1 Hu2 g.
+    move: (stamp_obj_ident_subtyping Hu1) => /(.$ g) [g1 [Hts1 Hle1]];
+    move: (stamp_obj_ident_subtyping Hu2) => /(.$ g1) [g2 [Hts2 Hle2]].
+
+    have Husv: is_unstamped_dm (length Γ) AlsoNonVars (dtysyn T) by eauto.
+    destruct (extract g2 (length Γ) T) as [g3 [s σ]] eqn:Heqo.
+    move: Heqo => [Heqg3 Heqs Heqσ].
+    have {Heqσ} -Heqσ: σ = idsσ (length Γ) by naive_solver.
+    destruct (stamp_dtysyn_spec g2 Husv); destruct_and!.
+    have ?: g2 ⊆ g3 by simplify_eq. lte g g1 g2; lte g g2 g3; lte g1 g2 g3.
+    exists (dtysem σ s), g3; simplify_eq; split_and!;
+      first eapply (storeless_typing.iD_Typ_Abs T); auto 2; [
+        exact: (stamped_obj_ident_subtype_mono _ Hts1)|
+        exact: (stamped_obj_ident_subtype_mono _ Hts2)].
+  - intros * Hu1 IHs1 g.
+    move: IHs1 => /(.$ g) /= [e1' [g1 ?]]; destruct_and!.
+    have [v' ?]: ∃ v', e1' = tv v' by destruct e1'; naive_solver.
+    simplify_eq/=; with_is_stamped inverse; with_is_unstamped inverse.
+    exists (dpt (pv v')), g1; naive_solver.
+  - intros * Hu1 g.
+    move: (stamp_obj_ident_path_typing Hu1) => /(.$ g) /= [g1 ?]; destruct_and!.
+    exists (dpt p), g1; split_and!; naive_solver eauto
+      using is_unstamped_path2AlsoNonVars.
+  - intros * Hu1 IHs1 Hus1 g.
+    move: IHs1 => /(.$ g) /= [ds' [g1 ?]]; destruct_and!.
+    exists (dpt (pv (vobj ds'))), g1; split_and!; cbn;
+      try eapply storeless_typing.iD_Val_New; eauto 2;
+      repeat constructor; eauto with f_equal.
+  - intros * Hu1 Hu2 IHs2 g.
+    (* Here and for standard subsumption, by stamping the subtyping
+      derivation before typing, we needn't use monotonicity on [Hs],
+      which holds but would require extra boilerplate. *)
+    move: (stamp_obj_ident_subtyping Hu1) => /(.$ g) [g1 [Hts1 Hle1]].
+    move: IHs2 => /(.$ g1) [d' [g2 [Hts2 [Hle2 Hs]]]]; lte g g1 g2.
+    have [p' Heq]: ∃ p', d' = dpt p'. {
+      move: Hs => {Hts2}; destruct d'; rewrite /= /from_option => -[?[??]];
+        try case_match; simplify_eq; eauto 2.
+    }
+    exists d', g2; subst d'; split_and!; ev; eauto 3.
+  Qed.
+
   Lemma stamp_obj_ident_typed g Γ e T: Γ u⊢ₜ e : T →
     ∃ e' g',
     Γ s⊢ₜ[ g' ] e' : T ∧ g ⊆ g' ∧ stamps_tm' (length Γ) e g' e'.
-  Proof. unmut_lemma (stamp_obj_ident_typing_mut Γ). Qed.
-
-  Lemma stamp_obj_ident_path_typed g Γ p T i: Γ u⊢ₚ p : T, i →
-    ∃ g',
-    Γ s⊢ₚ[ g' ] p : T, i ∧ g ⊆ g'.
   Proof. unmut_lemma (stamp_obj_ident_typing_mut Γ). Qed.
 
   (** [stamps_tm'] implies [same_skel_tm], which is a bisimulation, as shown
@@ -510,12 +560,16 @@ Section syntyping_stamping_lemmas.
     exists e', g'; split_and! => //. exact: stamp_bisim_same_skel_tm.
   Qed.
 
+  Lemma stamp_obj_ident_path_typed Γ g p T i: Γ u⊢ₚ p : T, i →
+    ∃ g',
+    Γ s⊢ₚ[ g' ] p : T, i ∧ g ⊆ g'.
+  Proof. unmut_lemma (stamp_obj_ident_subtyping_mut Γ). Qed.
+
   Lemma stamp_path_typed Γ p T g i: Γ u⊢ₚ p : T, i →
     ∃ g',
     Γ v⊢ₚ[ g' ] p : T, i ∧ g ⊆ g'.
   Proof.
-    intros (g' & HobjI' & ?)%
-      (stamp_obj_ident_path_typed g).
+    intros (g' & HobjI' & ?)%(stamp_obj_ident_path_typed g).
     exists g'; split_and! => //.
   Qed.
 End syntyping_stamping_lemmas.

--- a/theories/Dot/typing/typing_stamping.v
+++ b/theories/Dot/typing/typing_stamping.v
@@ -261,16 +261,12 @@ Section syntyping_stamping_lemmas.
   Lemma stamped_obj_ident_typing_mono_mut Γ g :
     (∀ e T, Γ s⊢ₜ[ g ] e : T → ∀ g' (Hle : g ⊆ g'), Γ s⊢ₜ[ g' ] e : T) ∧
     (∀ ds T, Γ s⊢ds[ g ] ds : T → ∀ g' (Hle : g ⊆ g'), Γ s⊢ds[ g' ] ds : T) ∧
-    (∀ l d T, Γ s⊢[ g ]{ l := d } : T → ∀ g' (Hle : g ⊆ g'), Γ s⊢[ g' ]{ l := d } : T) ∧
-    (∀ p T i, Γ s⊢ₚ[ g ] p : T, i → ∀ g' (Hle : g ⊆ g'), Γ s⊢ₚ[ g' ] p : T, i) ∧
-    (∀ T1 i1 T2 i2, Γ s⊢ₜ[ g ] T1, i1 <: T2, i2 → ∀ g' (Hle : g ⊆ g'), Γ s⊢ₜ[ g' ] T1, i1 <: T2, i2).
+    (∀ l d T, Γ s⊢[ g ]{ l := d } : T → ∀ g' (Hle : g ⊆ g'), Γ s⊢[ g' ]{ l := d } : T).
   Proof.
     eapply storeless_typing_mut_ind with
         (P := λ Γ g e T _, ∀ g' (Hle : g ⊆ g'), Γ s⊢ₜ[ g' ] e : T)
         (P0 := λ Γ g ds T _, ∀ g' (Hle : g ⊆ g'), Γ s⊢ds[ g' ] ds : T)
-        (P1 := λ Γ g l d T _, ∀ g' (Hle : g ⊆ g'), Γ s⊢[ g' ]{ l := d } : T)
-        (P2 := λ Γ g p T i _, ∀ g' (Hle : g ⊆ g'), Γ s⊢ₚ[ g' ] p : T, i)
-        (P3 := λ Γ g T1 i1 T2 i2 _, ∀ g' (Hle : g ⊆ g'), Γ s⊢ₜ[ g' ] T1, i1 <: T2, i2);
+        (P1 := λ Γ g l d T _, ∀ g' (Hle : g ⊆ g'), Γ s⊢[ g' ]{ l := d } : T);
     clear Γ g; intros;
       repeat match goal with
       | H : forall g : stys, _ |- _ => specialize (H g' Hle)
@@ -279,25 +275,16 @@ Section syntyping_stamping_lemmas.
   Lemma stamped_obj_ident_typed_mono Γ (g g' : stys) (Hle: g ⊆ g') e T:
     Γ s⊢ₜ[ g ] e : T → Γ s⊢ₜ[ g' ] e : T.
   Proof. unmut_lemma (stamped_obj_ident_typing_mono_mut Γ g). Qed.
-  Lemma stamped_obj_ident_subtype_mono Γ (g g' : stys) (Hle: g ⊆ g') T1 i1 T2 i2:
-    Γ s⊢ₜ[ g ] T1, i1 <: T2, i2 → Γ s⊢ₜ[ g' ] T1, i1 <: T2, i2.
-  Proof. unmut_lemma (stamped_obj_ident_typing_mono_mut Γ g). Qed.
-
   Lemma stamped_obj_ident_dms_typed_mono Γ (g g' : stys) (Hle: g ⊆ g'):
     ∀ ds T, Γ s⊢ds[ g ] ds : T → Γ s⊢ds[ g' ] ds : T.
   Proof. unmut_lemma (stamped_obj_ident_typing_mono_mut Γ g). Qed.
   Lemma stamped_obj_ident_dm_typed_mono Γ (g g' : stys) (Hle: g ⊆ g'):
     ∀ l d T, Γ s⊢[ g ]{ l := d } : T → Γ s⊢[ g' ]{ l := d } : T.
   Proof. unmut_lemma (stamped_obj_ident_typing_mono_mut Γ g). Qed.
-  Lemma stamped_obj_ident_path_typed_mono Γ (g g' : stys) (Hle: g ⊆ g'):
-    ∀ p T i, Γ s⊢ₚ[ g ] p : T, i → Γ s⊢ₚ[ g' ] p : T, i.
-  Proof. unmut_lemma (stamped_obj_ident_typing_mono_mut Γ g). Qed.
 
   Hint Extern 5 => try_once stamped_obj_ident_typed_mono : core.
   Hint Extern 5 => try_once stamped_obj_ident_dms_typed_mono : core.
   Hint Extern 5 => try_once stamped_obj_ident_dm_typed_mono : core.
-  Hint Extern 5 => try_once stamped_obj_ident_path_typed_mono : core.
-  Hint Extern 5 => try_once stamped_obj_ident_subtype_mono : core.
 
   Hint Extern 5 => try_once is_stamped_mono_tm : core.
   Hint Extern 5 => try_once stamps_unstamp_mono_tm : core.
@@ -315,16 +302,17 @@ Section syntyping_stamping_lemmas.
   Hint Resolve psubst_one_implies is_unstamped_ty_subst : core.
   (** These hints slow down proof search. *)
   (** Not directed. *)
-  Remove Hints storeless_typing.iP_Sngl_Trans : core.
+  Remove Hints old_subtyping.iP_Sngl_Trans : core.
   (** These cause cycles. *)
-  Remove Hints storeless_typing.iP_Mu_E : core.
-  Remove Hints storeless_typing.iP_Mu_I : core.
+  Remove Hints old_subtyping.iP_Mu_E : core.
+  Remove Hints old_subtyping.iP_Mu_I : core.
 
   (* To guard against loops. *)
   Tactic Notation "naive_solver" := timeout 1 naive_solver.
 
   (* This allows stamped paths to change; that's not used for paths appearing
   in types, and it helps stamp D-Val/D-Val-New. *)
+  (* XXX drop *)
   Lemma stamp_obj_ident_subtyping_mut Γ :
     (∀ p T i, Γ u⊢ₚ p : T, i →
       ∀ g, ∃ g',
@@ -332,70 +320,17 @@ Section syntyping_stamping_lemmas.
         ∧ g ⊆ g') ∧
     (∀ T1 i1 T2 i2, Γ u⊢ₜ T1, i1 <: T2, i2 →
       ∀ g, ∃ g', Γ s⊢ₜ[ g' ] T1, i1 <: T2, i2 ∧ g ⊆ g').
-  Proof.
-    eapply old_pure_typing_mut_ind with
-      (P := λ Γ p T i _, ∀ g, ∃ g',
-        Γ s⊢ₚ[ g' ] p : T, i ∧ g ⊆ g')
-      (P0 := λ Γ T1 i1 T2 i2 _, ∀ g, ∃ g',
-        Γ s⊢ₜ[ g' ] T1, i1 <: T2, i2 ∧ g ⊆ g');
-       clear Γ.
-    all: try solve [intros * Hu1 IHs1 Hu2 IHs2 g;
-    (* Strategy for cases of subtyping with multiple premises:
-        - apply the induction hypothesis on the first premise with map [g], and obtain map [g1];
-        - apply the induction hypothesis on the second premise with map [g1], and obtain map [g2];
-        - exhibit map [g2]. *)
-    (* Specialize IHs1 (with [/(.$ g]) and split the result. Ditto IHs2. *)
-      move: IHs1 => /(.$ g) [g1 [IHs1 Hle1]];
-      move: IHs2 => /(.$ g1) [g2 [IHs2 Hle2]]; ev; lte g g1 g2;
-      exists g2; split_and!; try fast_done; eauto 3].
-    all: try solve [intros * Hu1 IHs1 **;
-      move: IHs1 => /(.$ g) [g1 [Hts1 Hle1]]; exists g1; split_and!;
-      try fast_done; (constructor; eauto 2) || eauto 3].
-    all: try solve [intros; exists g; split_and!; try fast_done; constructor; eauto 2].
-  - intros * Hus1 Hu1 IHs1 g.
-    move: IHs1 => /(.$ g) /= [g1 ?]; ev.
-    exists g1; split_and! => //; econstructor; naive_solver.
-  - intros * Hus1 Hu1 IHs1 g.
-    move: IHs1 => /(.$ g) /= [g1 ?]; ev.
-    have ?: is_unstamped_path' (length Γ) p. exact: unstamped_path_subject.
-    exists g1; split_and! => //. econstructor; naive_solver.
-  - intros * Hu1 IHs1 Hu2 IHs2 g.
-    move: IHs1 => /(.$ g) [g1 [Hs1 ?]].
-    move: IHs2 => /(.$ g1) [g2 [Hs2 ?]]; ev; lte g g1 g2.
-    exists g2; split_and! => //; eapply storeless_typing.iP_Sngl_Trans => //.
-    naive_solver.
-  - intros * Hu1 IHs1 g.
-    move: IHs1 => /(.$ g) [g1 ?]; ev.
-    exists g1; split_and! => //.
-    exact: storeless_typing.iSel_Sub.
-  - intros * Hu1 IHs1 g.
-    move: IHs1 => /(.$ g) [g1 ?]; ev.
-    exists g1; split_and! => //.
-    exact: storeless_typing.iSub_Sel.
-  - intros * Hpr Hus1 Hus2 Hu1 IHs1 g.
-    move: IHs1 => /(.$ g) [g1 ?]; ev.
-    exists g1; split_and! => //.
-    eapply storeless_typing.iSngl_pq_Sub; eauto 2.
-  - intros * Hu1 IHs1 Hu2 IHs2 Hus1 g.
-    move: IHs1 => /(.$ g) [g1 [Hts1 Hle1]];
-    move: IHs2 => /(.$ g1) [g2 [Hts2 Hle2]]; lte g g1 g2.
-    exists g2; split_and! => //.
-    apply storeless_typing.iAll_Sub_All; eauto 2.
-  - intros * Hus1 Hu1 IHs1 g.
-    move: IHs1 => /(.$ g) [g1 [Hts1 Hle1]].
-    exists g1; split_and! => //.
-    eauto.
-  Qed.
+  Proof. split; eauto. Qed.
 
   Lemma stamp_obj_ident_path_typing Γ :
     (∀ p T i, Γ u⊢ₚ p : T, i →
       ∀ g, ∃ g', Γ s⊢ₚ[ g' ] p : T, i ∧ g ⊆ g').
-  Proof. apply stamp_obj_ident_subtyping_mut. Qed.
+  Proof. eauto. Qed.
   Lemma stamp_obj_ident_subtyping Γ :
     (∀ T1 i1 T2 i2, Γ u⊢ₜ T1, i1 <: T2, i2 →
       ∀ g, ∃ g', Γ s⊢ₜ[ g' ] T1, i1 <: T2, i2 ∧ g ⊆ g').
-  Proof. apply stamp_obj_ident_subtyping_mut. Qed.
-  Local Hint Resolve stamp_obj_ident_subtyping stamp_obj_ident_path_typing : core.
+  Proof. eauto. Qed.
+  (* Local Hint Resolve stamp_obj_ident_subtyping stamp_obj_ident_path_typing : core. *)
 
   Lemma stamp_obj_ident_typing_mut Γ :
     (∀ e T, Γ u⊢ₜ e : T →
@@ -502,9 +437,7 @@ Section syntyping_stamping_lemmas.
     destruct (stamp_dtysyn_spec g2 Husv); destruct_and!.
     have ?: g2 ⊆ g3 by simplify_eq. lte g g1 g2; lte g g2 g3; lte g1 g2 g3.
     exists (dtysem σ s), g3; simplify_eq; split_and!;
-      first eapply (storeless_typing.iD_Typ_Abs T); auto 2; [
-        exact: (stamped_obj_ident_subtype_mono _ Hts1)|
-        exact: (stamped_obj_ident_subtype_mono _ Hts2)].
+      first eapply (storeless_typing.iD_Typ_Abs T); auto 2.
   - intros * Hu1 IHs1 g.
     move: IHs1 => /(.$ g) /= [e1' [g1 ?]]; destruct_and!.
     have [v' ?]: ∃ v', e1' = tv v' by destruct e1'; naive_solver.

--- a/theories/Dot/typing/typing_stamping.v
+++ b/theories/Dot/typing/typing_stamping.v
@@ -471,8 +471,6 @@ Section syntyping_stamping_lemmas.
     move: (stamp_obj_ident_path_typing Hu1) => /(.$ g) /= [g1 ?]; ev.
     have ? := unstamped_path_subject Hu1.
     exists (path2tm p), g1; naive_solver.
-  - intros. exists (tv (vint n)), g; split_and?; try typconstructor; naive_solver.
-  - intros. exists (tv (vbool b)), g; split_and?; try typconstructor; naive_solver.
   - intros * Hprim Hu1 IHs1 g.
     move: IHs1 => /(.$ g) [e1' [g1 ?]].
     exists (tun u e1'), g1; naive_solver.

--- a/theories/Dot/typing/typing_stamping_regularity.v
+++ b/theories/Dot/typing/typing_stamping_regularity.v
@@ -1,8 +1,8 @@
 (** * Show stamped typing only relates stamped syntax.
 Proofs are done on storeless typing. *)
-From D Require Import prelude.
+(* From D Require Import prelude.
 From D.Dot Require Import type_extraction_syn traversals stampedness_binding closed_subst.
-From D.Dot Require Import storeless_typing.
+From D.Dot Require Import storeless_typing typing_stamping.
 From D.Dot Require Import ast_stamping path_repl_lemmas.
 Set Implicit Arguments.
 
@@ -13,16 +13,16 @@ Section storeless_syntyping_lemmas.
   Lemma stamped_mut_subject Γ g :
     (∀ e T, Γ v⊢ₜ[ g ] e : T → is_stamped_tm (length Γ) g e) ∧
     (∀ ds T, Γ v⊢ds[ g ] ds : T → Forall (is_stamped_dm (length Γ) g) (map snd ds)) ∧
-    (∀ l d T, Γ v⊢[ g ]{ l := d } : T → is_stamped_dm (length Γ) g d) ∧
-    (∀ p T i, Γ v⊢ₚ[ g ] p : T, i → is_stamped_path (length Γ) g p).
+    (∀ l d T, Γ v⊢[ g ]{ l := d } : T → is_stamped_dm (length Γ) g d).
   Proof.
     eapply exp_storeless_typing_mut_ind with
         (P := λ Γ g e T _, is_stamped_tm (length Γ) g e)
         (P0 := λ Γ g ds T _, Forall (is_stamped_dm (length Γ) g) (map snd ds))
-        (P1 := λ Γ g l d T _, is_stamped_dm (length Γ) g d)
-        (P2 := λ Γ g p T i _, is_stamped_path (length Γ) g p); clear Γ g;
+        (P1 := λ Γ g l d T _, is_stamped_dm (length Γ) g d);
+        clear Γ g;
         cbn; intros; try (rewrite <-(@ctx_strip_len Γ Γ') in *; last done);
-        try by (with_is_stamped inverse + idtac); eauto using is_stamped_path2tm.
+        try by (with_is_stamped inverse + idtac);
+        eauto using is_unstamped_path2tm, is_stamped_path2tm, is_unstamped_vl_lookup.
     - repeat constructor => //=. by eapply lookup_lt_Some.
     - intros; elim: i {s} => [|i IHi]; rewrite /= ?iterate_0 ?iterate_S //; eauto.
     - move: e => [T' ?]; ev. by apply @Trav1.trav_dtysem with
@@ -172,4 +172,4 @@ Section storeless_syntyping_lemmas.
       by eapply unstamped_stamped_type.
       by eapply unstamped_stamped_type, is_unstamped_ty_subst.
   Qed.
-End storeless_syntyping_lemmas.
+End storeless_syntyping_lemmas. *)

--- a/theories/Dot/typing/typing_stamping_regularity.v
+++ b/theories/Dot/typing/typing_stamping_regularity.v
@@ -15,7 +15,7 @@ Section storeless_syntyping_lemmas.
     (∀ ds T, Γ v⊢ds[ g ] ds : T → Forall (is_stamped_dm (length Γ) g) (map snd ds)) ∧
     (∀ l d T, Γ v⊢[ g ]{ l := d } : T → is_stamped_dm (length Γ) g d).
   Proof.
-    eapply exp_storeless_typing_mut_ind with
+    eapply storeless_typing_mut_ind with
         (P := λ Γ g e T _, is_stamped_tm (length Γ) g e)
         (P0 := λ Γ g ds T _, Forall (is_stamped_dm (length Γ) g) (map snd ds))
         (P1 := λ Γ g l d T _, is_stamped_dm (length Γ) g d);


### PR DESCRIPTION
An obstacle of #258 is that it prevents path typing from depending on expression typing, semantically (see below) — but in our ICFP submission, that's exactly what happens: `Γ ⊢p x : T, 0` requires `Γ ⊢ x : T` (through P-Var) which requires `x ∈ Γ` (through T-Var).

This PR inverts the dependency: now rule P-Var looks up `x` in the context, and `T-Var` can be derived using `T-Path`.

As a consequence of this and other changes, all the current ("old") subtyping and path typing can be disentangled from typing, unified, and can lose their stamps.

To complete the job, this PR also does other changes:
- **Allow singleton types of literal values in unstamped types**. That's used in one of our examples, so we need in storeless path typing, so I just added it to the source language.
- **Clean up storeless typing**: This PR also brings storeless typing closer to the system we present in the paper — which is nice, even tho we only use it as an aid for the "syntactically ill-typed" examples.
- **Drop `T-Mu-I` and `T-Mu-E` from storeless typing**: that's required to show the old P-Var admissible (at least, to do it easily). In the end, I ended up both dropping `T-Mu-[IE]` rule and fixed most examples to avoid using it.
- **Require unstamped types in storeless typing**, in some places. I haven't restricted all side conditions, to avoid the need for further refactorings, but I'm not sure you can use unstamped types.
- **Drop stamped typing**: it was just a bother, and it's disappearing from our story.
- **Drop proofs that unstamped/stamped typing are actually such**: they're not discussed in the paper or used elsewhere (tho I think they've been used, at times); and I hope to drop all that, soon after #258.

### Why expression typing can't depend on path typing
Unstamped semantic expression typing uses an update modality, but semantic path typing doesn't, so the former cannot be eliminated when proving the latter. Potentially, I could have added update modalities for both judgments, but that wasn't the plan.