### PR TITLE
Prepend basic update modality to all judgments

### DIFF
--- a/theories/Dot/examples/sem/ex_iris_utils.v
+++ b/theories/Dot/examples/sem/ex_iris_utils.v
@@ -46,10 +46,10 @@ Section loop_sem.
   Definition cTMemL l L U := cTMem l (oLater L) (oLater U).
   Definition oTMemL l L U := c2o (cTMemL l L U).
 
-  Lemma loopSemT: ⊢ WP hloopTm {{ _, False }}.
+  Lemma loopSemT: ⊢ |==> WP hloopTm {{ _, False }}.
   Proof using Type*.
     iDestruct (fundamental_typed (loopTyp [])) as "#>H".
-    iDestruct "H" as (e_s Hsk1) "H".
+    iDestruct "H" as (e_s Hsk1) ">H"; iModIntro.
     iSpecialize ("H" $! ids with "[//]"); rewrite hsubst_id.
     move E: hloopTm =>e; suff <-: e_s = e by []; subst; clear -Hsk1.
     cbv; repeat constrain_bisimulating.

--- a/theories/Dot/examples/sem/semtyp_lemmas/examples_lr.v
+++ b/theories/Dot/examples/sem/semtyp_lemmas/examples_lr.v
@@ -75,7 +75,7 @@ Section Lemmas.
     (* We're stuck again! *)
     Fail iApply "Hsub".
     Restart. *)
-    iIntros "#Hsub #Hp %ρ %v #Hg Heq".
+    iIntros ">#Hsub >#Hp !> %ρ %v #Hg Heq".
     iSpecialize ("Hp" with "Hg").
     iAssert (▷^i ⟦ T1 ⟧ (v .: ρ) v)%I as "#HT1".
     by iNext i; iDestruct "Heq" as %Heq;
@@ -91,7 +91,7 @@ Section Lemmas.
     Γ ⊨p p : TMu T1, i -∗
     Γ ⊨ TSing p, i <: TMu T2, i.
   Proof.
-    iIntros "#Hsub #Hp %ρ %v #Hg /= Heq"; iSpecialize ("Hp" with "Hg").
+    iIntros ">#Hsub >#Hp !> %ρ %v #Hg /= Heq"; iSpecialize ("Hp" with "Hg").
     iSpecialize ("Hsub" $! ρ v with "[#$Hg] [#]"); iNext i;
       iDestruct "Heq" as %Heq;
       rewrite -(psubst_one_repl Hrepl1, psubst_one_repl Hrepl2) //

--- a/theories/Dot/examples/sem/semtyp_lemmas/sub_lr.v
+++ b/theories/Dot/examples/sem/semtyp_lemmas/sub_lr.v
@@ -10,14 +10,17 @@ Implicit Types (Σ : gFunctors)
          (v w : vl) (e : tm) (d : dm) (ds : dms) (p : path)
          (ρ : env) (l : label).
 
+Notation sstpi' i j Γ τ1 τ2 :=
+  (∀ ρ v,
+    sG⟦Γ⟧*ρ → ▷^i oClose τ1 ρ v → ▷^j oClose τ2 ρ v)%I.
+
 Section defs.
   Context {Σ}.
   Implicit Types (τ : oltyO Σ 0).
 
   (** Legacy: (double)-indexed subtyping. *)
   Definition sstpi `{!dlangG Σ} i j Γ τ1 τ2 : iProp Σ :=
-    ∀ ρ v,
-      sG⟦Γ⟧*ρ → ▷^i oClose τ1 ρ v → ▷^j oClose τ2 ρ v.
+    |==> sstpi' i j Γ τ1 τ2.
   Global Arguments sstpi /.
 
   Definition istpi `{!dlangG Σ} Γ T1 T2 i j := sstpi i j V⟦Γ⟧* V⟦T1⟧ V⟦T2⟧.
@@ -49,11 +52,11 @@ Section judgment_lemmas.
   (** ** Show this typing judgment is equivalent to the more direct definition. *)
   Lemma istpi_eq Γ T1 i T2 j :
     Γ ⊨ T1, i <: T2, j ⊣⊢
-    ∀ ρ v, G⟦Γ⟧ ρ → ▷^i V⟦T1⟧ vnil ρ v → ▷^j V⟦T2⟧ vnil ρ v.
+    |==> ∀ ρ v, G⟦Γ⟧ ρ → ▷^i V⟦T1⟧ vnil ρ v → ▷^j V⟦T2⟧ vnil ρ v.
   Proof. reflexivity. Qed.
 
-  Lemma sstpi_app ρ Γ T1 T2 i j :
-    Γ s⊨ T1, i <: T2, j -∗ sG⟦ Γ ⟧* ρ -∗
+  Lemma sstpi_app ρ Γ (T1 T2 : olty Σ 0) i j :
+    sstpi' i j Γ T1 T2 -∗ sG⟦ Γ ⟧* ρ -∗
     oClose (oLaterN i T1) ρ ⊆ oClose (oLaterN j T2) ρ.
   Proof. iIntros "Hsub Hg %v"; iApply ("Hsub" with "Hg"). Qed.
 
@@ -82,7 +85,7 @@ Section StpLemmas.
     (*───────────────────────────────*)
     Γ s⊨p p : T2, i + j.
   Proof.
-    iIntros "#HpT1 #Hsub %ρ #Hg".
+    iIntros ">#HpT1 >#Hsub !> %ρ #Hg".
     iSpecialize ("HpT1" with "Hg").
     rewrite !path_wp_eq.
     iDestruct "HpT1" as (v) "Hpv"; iExists v.

--- a/theories/Dot/examples/sem/small_sem_ex.v
+++ b/theories/Dot/examples/sem/small_sem_ex.v
@@ -62,7 +62,7 @@ Section small_ex.
       iApply suD_Sing; iApply suD_Val.
       iApply (suT_Sub (T1 := ipos)).
       unstamp_goal_tm.
-      by rewrite setp_value /ipos /pos; iIntros "%ρ _ /= !%"; naive_solver.
+      by rewrite setp_value /ipos /pos; iIntros "!> %ρ _ /= !%"; naive_solver.
       iApply sStp_Trans; first iApply sStp_Add_Later.
       iApply sStp_Trans; first iApply sStp_Add_Later.
       iApply sLater_Stp_Eq.

--- a/theories/Dot/hkdot/hkdot.v
+++ b/theories/Dot/hkdot/hkdot.v
@@ -28,8 +28,11 @@ Module Type HoSemJudgments
   (Import HST : HoSemTypes VS LWP L).
 
 (** Kinded, Indexed SubTyPing *)
+Notation sstpiK' i Γ T1 T2 K :=
+  (∀ ρ, sG⟦Γ⟧*ρ → ▷^i K ρ (envApply T1 ρ) (envApply T2 ρ))%I.
+
 Definition sstpiK `{dlangG Σ} {n} i Γ T1 T2 (K : sf_kind Σ n) : iProp Σ :=
-  ∀ ρ, sG⟦Γ⟧*ρ → ▷^i K ρ (envApply T1 ρ) (envApply T2 ρ).
+  |==> sstpiK' i Γ T1 T2 K.
 Arguments sstpiK : simpl never.
 Instance: Params (@sstpiK) 5 := {}.
 Notation "Γ s⊨ T1 <:[ i  ] T2 ∷ K" := (sstpiK i Γ T1 T2 K)
@@ -44,7 +47,7 @@ Notation "Γ s⊨ T ∷[ i  ] K" := (Γ s⊨ T <:[ i ] T ∷ K)
 
 (* Semantic SubKinding *)
 Definition sSkd `{dlangG Σ} {n} i Γ (K1 K2 : sf_kind Σ n) : iProp Σ :=
-  ∀ ρ, sG⟦Γ⟧*ρ → ∀ (T1 T2 : hoLtyO Σ n), ▷^i (K1 ρ T1 T2 → K2 ρ T1 T2).
+  |==> ∀ ρ, sG⟦Γ⟧*ρ → ∀ (T1 T2 : hoLtyO Σ n), ▷^i (K1 ρ T1 T2 → K2 ρ T1 T2).
 Arguments sSkd : simpl never.
 Instance: Params (@sSkd) 5 := {}.
 Notation "Γ s⊨ K1 <∷[ i  ] K2" := (sSkd i Γ K1 K2)
@@ -74,7 +77,7 @@ Section gen_lemmas.
     Γ s⊨ T1 <:[ i ] T2 ∷ K -∗
     S :: Γ s⊨ oShift T1 <:[ i ] oShift T2 ∷ kShift K.
   Proof.
-    iIntros "#HK %ρ /= #[Hg _]".
+    iIntros ">#HK !> %ρ /= #[Hg _]".
     by iApply (sf_kind_proper with "(HK Hg)").
   Qed.
 
@@ -92,7 +95,7 @@ Section gen_lemmas.
     Γ s⊨ K1 <∷[ i ] K2 -∗
     S :: Γ s⊨ kShift K1 <∷[ i ] kShift K2.
   Proof.
-    iIntros "#HK %ρ /= #[Hg _] *".
+    iIntros ">#HK !> %ρ /= #[Hg _] *".
     iApply ("HK" with "Hg").
   Qed.
 
@@ -101,7 +104,7 @@ Section gen_lemmas.
     S1 :: Γ s⊨ T <:[ i ] U ∷ K -∗
     S2 :: Γ s⊨ T <:[ i ] U ∷ K.
   Proof.
-    iIntros "#HsubS #HJ %ρ /= #[Hg HS]".
+    iIntros ">#HsubS >#HJ !> %ρ /= #[Hg HS]".
     iApply ("HJ" $! ρ with "[$Hg]").
     iApply ("HsubS" $! ρ with "[$Hg $HS] HS").
   Qed.
@@ -125,7 +128,7 @@ Section gen_lemmas.
     S1 :: Γ s⊨ K1 <∷[ i ] K2 -∗
     S2 :: Γ s⊨ K1 <∷[ i ] K2.
   Proof.
-    iIntros "#HsubS #HJ %ρ /= #[Hg HS] *".
+    iIntros ">#HsubS >#HJ !> %ρ /= #[Hg HS] *".
     iApply ("HJ" $! ρ with "[$Hg]").
     iApply ("HsubS" $! ρ with "[$Hg $HS] HS").
   Qed.
@@ -143,8 +146,8 @@ Section gen_lemmas.
       iIntros (v); [iIntros "[]" | iIntros "_ //"].
   Qed.
 
-  Lemma ksubtyping_equiv i Γ T1 T2 :
-    Γ s⊨ T1 <:[ i ] T2 ∷ sf_star ⊣⊢
+  Lemma ksubtyping_equiv' i Γ T1 T2 :
+    sstpiK' i Γ T1 T2 sf_star ⊣⊢
     ∀ ρ, sG⟦ Γ ⟧* ρ → ▷^i (oClose T1 ρ ⊆ oClose T2 ρ).
   Proof.
     iSplit.
@@ -155,16 +158,21 @@ Section gen_lemmas.
       iApply ("Hsub" with "Hg").
   Qed.
 
+  Lemma ksubtyping_equiv i Γ T1 T2 :
+    Γ s⊨ T1 <:[ i ] T2 ∷ sf_star ⊣⊢
+    |==> ∀ ρ, sG⟦ Γ ⟧* ρ → ▷^i (oClose T1 ρ ⊆ oClose T2 ρ).
+  Proof. rewrite /sstpiK; f_equiv. apply ksubtyping_equiv'. Qed.
+
   Lemma ksubtyping_spec ρ i Γ T1 T2 :
-    Γ s⊨ T1 <:[ i ] T2 ∷ sf_star -∗
+    sstpiK' i Γ T1 T2 sf_star -∗
     sG⟦ Γ ⟧* ρ -∗
     ▷^i (oClose T1 ρ ⊆ oClose T2 ρ).
   Proof.
-    rewrite ksubtyping_equiv; iIntros "Hsub Hg"; iApply ("Hsub" with "Hg").
+    rewrite ksubtyping_equiv'. iIntros "Hsub Hg"; iApply ("Hsub" with "Hg").
   Qed.
 
   Lemma ksubtyping_intro i Γ (T1 T2 : oltyO Σ 0) :
-    (∀ ρ, sG⟦ Γ ⟧* ρ →
+    (|==> ∀ ρ, sG⟦ Γ ⟧* ρ →
     ∀ v, ▷^i (oClose T1 ρ v → oClose T2 ρ v)) -∗
     Γ s⊨ T1 <:[ i ] T2 ∷ sf_star.
   Proof.
@@ -173,20 +181,20 @@ Section gen_lemmas.
   Qed.
 
   Lemma ksubtyping_intro_swap i Γ (T1 T2 : oltyO Σ 0) :
-    (∀ ρ, sG⟦ Γ ⟧* ρ →
+    (|==> ∀ ρ, sG⟦ Γ ⟧* ρ →
     ∀ v, ▷^i oClose T1 ρ v → ▷^i oClose T2 ρ v) -∗
     Γ s⊨ T1 <:[ i ] T2 ∷ sf_star.
   Proof using HswapProp.
-    rewrite -ksubtyping_intro; iIntros "#Hsub %ρ #Hg *".
+    rewrite -ksubtyping_intro; iIntros ">#Hsub !> %ρ #Hg *".
     iApply (impl_laterN with "(Hsub Hg)").
   Qed.
 
   Lemma kinding_intro Γ i (L T U : oltyO Σ 0) :
-    (∀ ρ, sG⟦ Γ ⟧* ρ →
+    (|==> ∀ ρ, sG⟦ Γ ⟧* ρ →
     ▷^i (oClose L ρ ⊆ oClose T ρ ⊆ oClose U ρ)) -∗
     Γ s⊨ T ∷[ i ] sf_kintv L U.
   Proof.
-    iIntros "#Hsub" (ρ); rewrite /= sr_kintv_refl /=. iApply "Hsub".
+    iIntros ">#Hsub !>" (ρ); rewrite /= sr_kintv_refl /=. iApply "Hsub".
   Qed.
 
   (** * Prefixes: K for Kinding, KStp for kinded subtyping, Skd for subkinding. *)
@@ -196,14 +204,14 @@ Section gen_lemmas.
   Lemma sK_Sing Γ (T : oltyO Σ 0) i :
     ⊢ Γ s⊨ T ∷[ i ] sf_sngl T.
   Proof.
-    rewrite -kinding_intro; iIntros "%ρ _". by rewrite -subtype_refl.
+    rewrite -kinding_intro; iIntros "!> %ρ _". by rewrite -subtype_refl.
   Qed.
 
   Lemma sKStp_Intv Γ (T1 T2 L U : oltyO Σ 0) i :
     Γ s⊨ T1 <:[i] T2 ∷ sf_kintv L U -∗
     Γ s⊨ T1 <:[i] T2 ∷ sf_kintv T1 T2.
   Proof.
-    iIntros "#Hs %ρ Hg"; iDestruct ("Hs" with "Hg") as "{Hs} (_ & #H & _)".
+    iIntros ">#Hs !> %ρ Hg"; iDestruct ("Hs" with "Hg") as "{Hs} (_ & #H & _)".
     rewrite /= /sr_kintv; iNext i. iDestruct "H" as "#$ {H}".
     by rewrite -!subtype_refl.
   Qed.
@@ -211,7 +219,7 @@ Section gen_lemmas.
   Lemma sK_Star Γ (T : oltyO Σ 0) i :
     ⊢ Γ s⊨ T ∷[ i ] sf_star.
   Proof.
-    rewrite -kinding_intro; iIntros "%ρ _ !>".
+    rewrite -kinding_intro; iIntros "!> %ρ _ !>".
     by iSplit; iIntros "%v /="; [iIntros "[]"|iIntros "_"].
   Qed.
 
@@ -221,7 +229,7 @@ Section gen_lemmas.
     Γ s⊨ K1 <∷[ i ] K2 -∗
     Γ s⊨ T1 <:[ i ] T2 ∷ K2.
   Proof.
-    iIntros "#H1 #Hsub %ρ #Hg". iApply ("Hsub" with "Hg (H1 Hg)").
+    iIntros ">#H1 >#Hsub !> %ρ #Hg". iApply ("Hsub" with "Hg (H1 Hg)").
   Qed.
 
   (** Kind subsumption (for kinding). *)
@@ -240,7 +248,7 @@ Section gen_lemmas.
     oLaterN i (oShift S) :: Γ s⊨ T1 <:[i] T2 ∷ K -∗
     Γ s⊨ oLam T1 <:[i] oLam T2 ∷ sf_kpi S K.
   Proof using HswapProp.
-    iIntros "#HTK %ρ #Hg * /=" (arg).
+    iIntros ">#HTK !> %ρ #Hg * /=" (arg).
     rewrite -impl_laterN.
     iIntros "Hs".
     iSpecialize ("HTK" $! (arg .: ρ) with "[$Hg $Hs]").
@@ -258,7 +266,7 @@ Section gen_lemmas.
     Γ s⊨ U1 <:[ i ] U2 ∷ sf_star -∗
     Γ s⊨ sf_kintv L1 U1 <∷[ i ] sf_kintv L2 U2.
   Proof.
-    iIntros "#HsubL #HsubU %ρ #Hg /=" (T1 T2).
+    iIntros ">#HsubL >#HsubU !> %ρ #Hg /=" (T1 T2).
     iPoseProof (ksubtyping_spec with "HsubL Hg") as "{HsubL} HsubL".
     iPoseProof (ksubtyping_spec with "HsubU Hg") as "{HsubU Hg} HsubU".
     iNext i; iIntros "#(HsubL1 & $ & HsubU1)"; iSplit.
@@ -271,7 +279,7 @@ Section gen_lemmas.
     oLaterN i (oShift S2) :: Γ s⊨ K1 <∷[ i ] K2 -∗
     Γ s⊨ sf_kpi S1 K1 <∷[ i ] sf_kpi S2 K2.
   Proof using HswapProp.
-    iIntros "#HsubS #HsubK %ρ #Hg /=".
+    iIntros ">#HsubS >#HsubK !> %ρ #Hg /=".
     iPoseProof (ksubtyping_spec with "HsubS Hg") as "{HsubS} HsubS".
     iAssert (∀ arg : vl, let ρ' := arg .: ρ in
             ▷^i (oClose S2 ρ arg → ∀ T1 T2 : hoLtyO Σ n,
@@ -290,14 +298,14 @@ Section gen_lemmas.
   prove them anyway, to show they hold regardless of extensions. *)
   Lemma sSkd_Refl {n} Γ i (K : sf_kind Σ n) :
     ⊢ Γ s⊨ K <∷[ i ] K.
-  Proof. iIntros "%ρ Hg * !> $". Qed.
+  Proof. iIntros "!> %ρ Hg * !> $". Qed.
 
   Lemma sSkd_Trans {n} Γ i (K1 K2 K3 : sf_kind Σ n) :
     Γ s⊨ K1 <∷[ i ] K2 -∗
     Γ s⊨ K2 <∷[ i ] K3 -∗
     Γ s⊨ K1 <∷[ i ] K3.
   Proof.
-    iIntros "#Hs1 #Hs2 %ρ #Hg *".
+    iIntros ">#Hs1 >#Hs2 !> %ρ #Hg *".
     iSpecialize ("Hs1" with "Hg"); iSpecialize ("Hs2" with "Hg"); iNext i.
     iIntros "{Hg} HK1". iApply ("Hs2" with "(Hs1 HK1)").
   Qed.
@@ -329,7 +337,7 @@ Section gen_lemmas.
     Γ s⊨ T2 <:[ i ] T3 ∷ K -∗
     Γ s⊨ T1 <:[ i ] T3 ∷ K.
   Proof.
-    iIntros "#Hs1 #Hs2 %ρ #Hg".
+    iIntros ">#Hs1 >#Hs2 !> %ρ #Hg".
     iApply (sf_kind_sub_trans with "(Hs1 Hg) (Hs2 Hg)").
   Qed.
 
@@ -338,17 +346,17 @@ Section gen_lemmas.
 
   Lemma sKStp_Top Γ (T : oltyO Σ 0) i :
     ⊢ Γ s⊨ T <:[ i ] ⊤ ∷ sf_star.
-  Proof. rewrite -ksubtyping_intro. iIntros "%ρ * _ * !> _ //". Qed.
+  Proof. rewrite -ksubtyping_intro. iIntros "!> %ρ * _ * !> _ //". Qed.
   Lemma sKStp_Bot Γ (T : oltyO Σ 0) i :
     ⊢ Γ s⊨ ⊥ <:[ i ] T ∷ sf_star.
-  Proof. rewrite -ksubtyping_intro; iIntros "%ρ * _ * !> []". Qed.
+  Proof. rewrite -ksubtyping_intro; iIntros "!> %ρ * _ * !> []". Qed.
 
   (* XXX <:-..-U *)
   Lemma sKStp_IntvU {Γ T1 T2 L U i} :
     Γ s⊨ T1 <:[i] T2 ∷ sf_kintv L U -∗
     Γ s⊨ T2 <:[i] U ∷ sf_star.
   Proof.
-    rewrite -ksubtyping_intro; iIntros "#HK * Hg *".
+    rewrite -ksubtyping_intro; iIntros ">#HK !> * Hg *".
     iDestruct ("HK" with "Hg") as "[_ [_ Hsub]]".
     iNext i; iApply "Hsub".
   Qed.
@@ -364,7 +372,7 @@ Section gen_lemmas.
     Γ s⊨ T1 <:[i] T2 ∷ sf_kintv L U -∗
     Γ s⊨ L <:[i] T1 ∷ sf_star.
   Proof.
-    rewrite -ksubtyping_intro; iIntros "#HK * Hg *".
+    rewrite -ksubtyping_intro; iIntros ">#HK !> * Hg *".
     iDestruct ("HK" with "Hg") as "[Hsub _]".
     iNext i; iApply "Hsub".
   Qed.
@@ -411,7 +419,7 @@ Section dot_types.
     oLaterN i T :: Γ s⊨p p : U, i -∗
     Γ s⊨p p.|[v/] : U.|[v/], i.
   Proof.
-    iIntros "#Hrepl #H" (ρ) "#Hg /=".
+    iIntros ">#Hrepl >#H !>" (ρ) "#Hg /=".
     iSpecialize ("Hrepl" with "Hg"); rewrite path_wp_pv_eq.
     rewrite hsubst_comp -subst_swap_base.
     iSpecialize ("H" $! (v.[ρ] .: ρ) with "[$Hg $Hrepl]").
@@ -426,7 +434,7 @@ Section dot_types.
     oLaterN i V :: Γ s⊨ T1 <:[ i ] T2 ∷ K -∗
     Γ s⊨ T1.|[v/] <:[ i ] T2.|[v/] ∷ K.|[v/].
   Proof.
-    iIntros "#Hrepl #H" (ρ) "#Hg /=".
+    iIntros ">#Hrepl >#H !>" (ρ) "#Hg /=".
     iSpecialize ("Hrepl" with "Hg"); rewrite path_wp_pv_eq -subst_swap_base.
     iSpecialize ("H" $! (v.[ρ] .: ρ) with "[$Hg $Hrepl]").
     iApply (sf_kind_proper with "H") => args w /=;
@@ -438,7 +446,7 @@ Section dot_types.
     Γ s⊨p p : S, i -∗
     Γ s⊨ oTApp T1 p <:[i] oTApp T2 p ∷ kpSubstOne p K.
   Proof.
-    iIntros "#HTK #Hp %ρ #Hg".
+    iIntros ">#HTK >#Hp !> %ρ #Hg".
     iApply (strong_path_wp_wand with "(Hp Hg)").
     iIntros (v Hal%alias_paths_pv_eq_1) "{Hp} #Hv".
     iApply (sf_kind_proper with "(HTK Hg Hv)") => args w /=;
@@ -457,8 +465,10 @@ Section dot_types.
     Γ s⊨p pv v : S, i -∗
     Γ s⊨ oTAppV T1 v <:[i] oTAppV T2 v ∷ K.|[v/].
   Proof.
-    rewrite -!oTApp_pv. iIntros "#HTK #Hv %ρ #Hg"; rewrite kpSubstOne_eq.
-    iApply (sKStp_App with "HTK Hv Hg").
+    rewrite -!oTApp_pv; iIntros "#HTK #Hv".
+    iPoseProof (sKStp_App with "HTK Hv") as ">Happ".
+    iIntros "!> %ρ #Hg"; rewrite kpSubstOne_eq.
+    iApply ("Happ" with "Hg").
   Qed.
 
   Lemma sK_AppV Γ {n} (K : sf_kind Σ n) {S T i v} :
@@ -496,7 +506,7 @@ Section dot_types.
   Lemma sstpiK_star_to_sstp Γ i T1 T2 :
     Γ s⊨ T1 <:[ i ] T2 ∷ sf_star ⊢ Γ s⊨ T1 , i <: T2 , i.
   Proof.
-    iIntros "#Hsub %ρ %v #Hg".
+    iIntros ">#Hsub !> %ρ %v #Hg".
     iDestruct (ksubtyping_spec with "Hsub Hg") as "{Hsub Hg} Hsub".
     rewrite -laterN_impl. iNext i. iApply ("Hsub" $! v).
   Qed.
@@ -505,7 +515,7 @@ Section dot_types.
     Γ s⊨ T1 <:[ i ] T2 ∷ sf_star ⊣⊢ Γ s⊨ T1 , i <: T2 , i.
   Proof using HswapProp.
     iSplit; first iApply sstpiK_star_to_sstp.
-    rewrite -ksubtyping_intro_swap /=. iIntros "#Hsub %ρ Hg *".
+    rewrite -ksubtyping_intro_swap /=. iIntros ">#Hsub !> %ρ Hg *".
     iApply ("Hsub" with "Hg").
   Qed.
 
@@ -518,7 +528,7 @@ Section dot_types.
     Γ s⊨ K1 <∷[ i ] K2 -∗
     Γ s⊨ oTMemK l K1 <:[ i ] oTMemK l K2 ∷ sf_star.
   Proof.
-    rewrite -ksubtyping_intro; iIntros "#HK %ρ Hg *".
+    rewrite -ksubtyping_intro; iIntros ">#HK !> %ρ Hg *".
     iSpecialize ("HK" with "Hg"); iNext i.
     iDestruct 1 as (d Hld) "Hφ"; iExists d; iFrame (Hld).
     iDestruct "Hφ" as (φ) "[Hlφ #HK1]"; iExists φ; iFrame "Hlφ".
@@ -528,7 +538,7 @@ Section dot_types.
   Lemma sKStp_TMem_AnyKind {n} Γ l (K : sf_kind Σ n) i :
     ⊢ Γ s⊨ oTMemK l K <:[ i ] oTMemAnyKind l ∷ sf_star.
   Proof.
-    rewrite -ksubtyping_intro; iIntros "%ρ #Hg * !>".
+    rewrite -ksubtyping_intro; iIntros "!> %ρ #Hg * !>".
     iDestruct 1 as (d Hl φ) "[Hl _]".
     iExists d; iFrame (Hl); iExists n, φ; iFrame "Hl".
   Qed.
@@ -549,8 +559,8 @@ Section dot_types.
     s ↝[ σ ] T -∗
     Γ s⊨ { l := dtysem σ s } : cTMemK l K.
   Proof.
-    rewrite sdtp_eq'; iIntros "#HTK"; iDestruct 1 as (φ Hγφ) "#Hγ".
-    iIntros (ρ Hpid) "Hg"; iExists (hoEnvD_inst (σ.|[ρ]) φ); iSplit.
+    rewrite sdtp_eq'; iIntros ">#HTK"; iDestruct 1 as (φ Hγφ) "#Hγ".
+    iIntros "!>" (ρ Hpid) "Hg"; iExists (hoEnvD_inst (σ.|[ρ]) φ); iSplit.
     by iApply (dm_to_type_intro with "Hγ").
     iApply (sf_kind_proper' with "(HTK Hg)") => args v /=.
     by rewrite -(Hγφ args ρ v).
@@ -560,7 +570,7 @@ Section dot_types.
     Γ s⊨p p : oTMemK l K, i -∗
     Γ s⊨ oSelN n p l ∷[i] K.
   Proof.
-    iIntros "#Hp %ρ Hg"; iSpecialize ("Hp" with "Hg"); iNext i.
+    iIntros ">#Hp !> %ρ Hg"; iSpecialize ("Hp" with "Hg"); iNext i.
     rewrite path_wp_eq.
     iDestruct "Hp" as (v Hal%alias_paths_pv_eq_1 d1 Hl1 ψ1) "[#Hl1 HK]".
     iApply (sfkind_respects with "[] HK"); iIntros (args w).
@@ -577,7 +587,7 @@ Section dot_types.
     Γ s⊨ T1 ∷[i] K -∗
     Γ s⊨ T1 <:[i] T2 ∷ K.
   Proof.
-    iIntros "#Hrepl #Hal #HK %ρ #Hg".
+    iIntros ">#Hrepl >#Hal >#HK !> %ρ #Hg".
     iSpecialize ("Hal" with "Hg"); iSpecialize ("HK" with "Hg"); iNext i.
     iDestruct "Hal" as %Hal%alias_paths_simpl.
     iApply (sf_kind_sub_internal_proper with "[] [] HK").
@@ -594,7 +604,7 @@ Section dot_types.
     Γ s⊨ T1 <:[i] T2 ∷ K1 -∗
     Γ s⊨ T1 <:[i] T2 ∷ K2.
   Proof.
-    iIntros "#Hal #HK %ρ #Hg".
+    iIntros ">#Hal >#HK !> %ρ #Hg".
     iSpecialize ("Hal" with "Hg"); iSpecialize ("HK" with "Hg"). iNext i.
     iDestruct "Hal" as %Hal%alias_paths_simpl.
     by iApply (Hrepl with "HK").
@@ -869,7 +879,7 @@ Section dot_experimental_kinds.
     that is, [oLam (oSing (pv (ids 0)))]. *)
   Proof.
     rewrite /sstpiK.
-    iIntros "/= #HT [#Hsub1 #Hsub2] %ρ #Hg"; iSpecialize ("HT" with "Hg");
+    iIntros "/= >#HT [>#Hsub1 >#Hsub2] !> %ρ #Hg"; iSpecialize ("HT" with "Hg");
       iSpecialize ("Hsub1" with "Hg"); iSpecialize ("Hsub2" with "Hg");
       iNext i.
     rewrite /sr_kintv/=.

--- a/theories/Dot/lr/sem_unstamped_typing.v
+++ b/theories/Dot/lr/sem_unstamped_typing.v
@@ -83,7 +83,7 @@ Proof.
   apply (soundness (M := iResUR Σ) _ n).
   apply (bupd_plain_soundness _).
   iDestruct (Hwp HdlangG HswapProp) as "#>Hwp".
-  iDestruct "Hwp" as (e_s Hsim) "#Hwp".
+  iDestruct "Hwp" as (e_s Hsim) ">#Hwp".
   iSpecialize ("Hwp" $! ids with "[//]").
   rewrite hsubst_id /= (wptp_safe_n n).
   iIntros "!>!>"; iDestruct "Hwp" as %Hsafe; iIntros "!%".

--- a/theories/Dot/lr/unary_lr.v
+++ b/theories/Dot/lr/unary_lr.v
@@ -43,18 +43,18 @@ Section judgments.
 
   (** Expression typing *)
   Definition setp `{!dlangG Σ} e Γ τ : iProp Σ :=
-    ∀ ρ, sG⟦Γ⟧* ρ → sE⟦ τ ⟧ ρ (e.|[ρ]).
+    |==> ∀ ρ, sG⟦Γ⟧* ρ → sE⟦ τ ⟧ ρ (e.|[ρ]).
   Global Arguments setp : simpl never.
 
   (** Delayed subtyping. *)
   Definition sstpd `{!dlangG Σ} i Γ τ1 τ2 : iProp Σ :=
-    ∀ ρ,
+    |==> ∀ ρ,
       sG⟦Γ⟧*ρ → ▷^i (oClose τ1 ρ ⊆ oClose τ2 ρ).
   Global Arguments sstpd : simpl never.
 
   (** Multi-definition typing *)
   Definition sdstp `{!dlangG Σ} ds Γ (T : clty Σ) : iProp Σ :=
-    ⌜wf_ds ds⌝ ∧ ∀ ρ, ⌜path_includes (pv (ids 0)) ρ ds ⌝ → sG⟦Γ⟧* ρ → T ρ ds.|[ρ].
+    |==> ⌜wf_ds ds⌝ ∧ ∀ ρ, ⌜path_includes (pv (ids 0)) ρ ds ⌝ → sG⟦Γ⟧* ρ → T ρ ds.|[ρ].
   Global Arguments sdstp : simpl never.
 
   (** Definition typing *)
@@ -63,7 +63,7 @@ Section judgments.
 
   (** Path typing *)
   Definition sptp `{!dlangG Σ} p i Γ (T : oltyO Σ 0): iProp Σ :=
-    ∀ ρ, sG⟦Γ⟧* ρ →
+    |==> ∀ ρ, sG⟦Γ⟧* ρ →
       ▷^i path_wp p.|[ρ] (oClose T ρ).
   Global Arguments sptp : simpl never.
 End judgments.
@@ -84,15 +84,15 @@ Section JudgEqs.
 
   Lemma sstpd_eq_1 Γ T1 i T2 :
     Γ s⊨ T1 <:[i] T2 ⊣⊢
-    ∀ ρ, sG⟦Γ⟧* ρ → ∀ v, ▷^i (T1 vnil ρ v → T2 vnil ρ v).
+    |==> ∀ ρ, sG⟦Γ⟧* ρ → ∀ v, ▷^i (T1 vnil ρ v → T2 vnil ρ v).
   Proof.
-    rewrite /sstpd /subtype_lty; f_equiv => ρ.
+    rewrite /sstpd /subtype_lty; f_equiv; f_equiv => ρ.
     by rewrite laterN_forall.
   Qed.
 
   Lemma sstpd_eq Γ T1 i T2 :
     Γ s⊨ T1 <:[i] T2 ⊣⊢
-    ∀ ρ v, sG⟦Γ⟧* ρ → ▷^i (T1 vnil ρ v → T2 vnil ρ v).
+    |==> ∀ ρ v, sG⟦Γ⟧* ρ → ▷^i (T1 vnil ρ v → T2 vnil ρ v).
   Proof. rewrite sstpd_eq_1; properness. apply: forall_swap_impl. Qed.
 End JudgEqs.
 
@@ -130,7 +130,7 @@ Notation "T .sTp[ p /]" := (opSubst p T) (at level 65).
 
 (** Semantic definition of path replacement. *)
 Definition sem_ty_path_replI {Σ n} p q (T1 T2 : olty Σ n) : iProp Σ :=
-  ∀ args ρ v (H : alias_paths p.|[ρ] q.|[ρ]), T1 args ρ v ≡ T2 args ρ v.
+  |==> ∀ args ρ v (H : alias_paths p.|[ρ] q.|[ρ]), T1 args ρ v ≡ T2 args ρ v.
 Notation "T1 ~sTpI[ p := q  ]* T2" :=
   (sem_ty_path_replI p q T1 T2) (at level 70).
 
@@ -155,7 +155,7 @@ Section path_repl.
 
   Lemma sem_ty_path_repl_eq {n} {p q} {T1 T2 : olty Σ n} :
     T1 ~sTpP[ p := q ]* T2 → ⊢ T1 ~sTpI[ p := q ]* T2.
-  Proof. iIntros "%Heq !%". apply: Heq. Qed.
+  Proof. iIntros "%Heq !% /=". apply: Heq. Qed.
   (* The reverse does not hold. *)
 End path_repl.
 
@@ -317,21 +317,21 @@ Section judgment_definitions.
   Proof. by rewrite /path_includes path_wp_pure_pv_eq. Qed.
 
   Lemma idstp_eq Γ T ds : Γ ⊨ds ds : T ⊣⊢
-    ⌜wf_ds ds⌝ ∧ ∀ ρ, ⌜path_includes (pv (ids 0)) ρ ds ⌝ → G⟦Γ⟧ ρ → Ds⟦T⟧ ρ ds.|[ρ].
+    |==> ⌜wf_ds ds⌝ ∧ ∀ ρ, ⌜path_includes (pv (ids 0)) ρ ds ⌝ → G⟦Γ⟧ ρ → Ds⟦T⟧ ρ ds.|[ρ].
   Proof. reflexivity. Qed.
 
   Lemma ietp_eq Γ e T :
-    Γ ⊨ e : T ⊣⊢ ∀ ρ, G⟦Γ⟧ ρ → E⟦T⟧ ρ (e.|[ρ]).
+    Γ ⊨ e : T ⊣⊢ |==> ∀ ρ, G⟦Γ⟧ ρ → E⟦T⟧ ρ (e.|[ρ]).
   Proof. reflexivity. Qed.
 
   Lemma istpd_eq Γ T1 i T2 :
     Γ ⊨ T1 <:[i] T2 ⊣⊢
-    ∀ ρ v, G⟦Γ⟧ ρ → ▷^i (V⟦T1⟧ vnil ρ v → V⟦T2⟧ vnil ρ v).
+    |==> ∀ ρ v, G⟦Γ⟧ ρ → ▷^i (V⟦T1⟧ vnil ρ v → V⟦T2⟧ vnil ρ v).
   Proof. apply sstpd_eq. Qed.
 
   Lemma iptp_eq Γ p T i :
     Γ ⊨p p : T , i ⊣⊢
-    ∀ ρ, G⟦Γ⟧ ρ →
+    |==> ∀ ρ, G⟦Γ⟧ ρ →
       ▷^i path_wp (p.|[ρ]) (λ v, V⟦T⟧ vnil ρ v).
   Proof. reflexivity. Qed.
 End judgment_definitions.
@@ -437,7 +437,7 @@ Section misc_lemmas.
 
   Lemma sdtp_eq (Γ : sCtx Σ) (T : clty Σ) l d:
     Γ s⊨ { l := d } : T ⊣⊢
-      ∀ ρ, ⌜path_includes (pv (ids 0)) ρ [(l, d)]⌝ → sG⟦Γ⟧* ρ → T ρ [(l, d.|[ρ])].
+      |==> ∀ ρ, ⌜path_includes (pv (ids 0)) ρ [(l, d)]⌝ → sG⟦Γ⟧* ρ → T ρ [(l, d.|[ρ])].
   Proof.
     rewrite /sdtp /sdstp pure_True ?(left_id _ bi_and);
       by [> | exact: NoDup_singleton].
@@ -445,13 +445,13 @@ Section misc_lemmas.
 
   Lemma sdtp_eq' (Γ : sCtx Σ) (T : dlty Σ) l d:
     Γ s⊨ { l := d } : dty2clty l T ⊣⊢
-      ∀ ρ, ⌜path_includes (pv (ids 0)) ρ [(l, d)]⌝ → sG⟦Γ⟧* ρ → T ρ d.|[ρ].
+      |==> ∀ ρ, ⌜path_includes (pv (ids 0)) ρ [(l, d)]⌝ → sG⟦Γ⟧* ρ → T ρ d.|[ρ].
   Proof. by rewrite sdtp_eq; properness; last apply dty2clty_singleton. Qed.
 
   Lemma ipwp_terminates {p T i}:
     [] s⊨p p : T , i ⊢ ▷^i ⌜ terminates (path2tm p) ⌝.
   Proof.
-    iIntros "#H".
+    iIntros ">#H".
     iSpecialize ("H" $! ids with "[//]"); rewrite hsubst_id.
     iApply (path_wp_terminates with "H").
   Qed.
@@ -460,7 +460,7 @@ Section misc_lemmas.
   Lemma sT_Path {Γ τ p} :
     Γ s⊨p p : τ, 0 -∗ Γ s⊨ path2tm p : τ.
   Proof.
-    iIntros "#Hep %ρ #Hg /="; rewrite path2tm_subst.
+    iIntros ">#Hep !> %ρ #Hg /="; rewrite path2tm_subst.
     by iApply (path_wp_to_wp with "(Hep Hg)").
   Qed.
 End misc_lemmas.

--- a/theories/Dot/semtyp_lemmas/binding_lr.v
+++ b/theories/Dot/semtyp_lemmas/binding_lr.v
@@ -20,7 +20,7 @@ Section LambdaIntros.
     (*─────────────────────────*)
     Γ s⊨ tv (vabs e) : oAll T1 T2.
   Proof.
-    rewrite Hctx; iIntros "HeT %ρ Hg /=".
+    rewrite Hctx; iIntros ">HeT !> %ρ Hg /=".
     rewrite -wp_value'. iExists _; iSplit; first done.
     iIntros (v) "Hv"; rewrite up_sub_compose.
     (* Factor ▷ out of [sG⟦ Γ ⟧* ρ] before [iNext]. *)
@@ -57,7 +57,7 @@ Section Sec.
     (*──────────────────────*)
     ⊢ Γ s⊨p pv (ids x) : shiftN x τ, 0.
   Proof.
-    iIntros "/= %ρ #Hg"; rewrite path_wp_pv_eq.
+    iIntros "/= !> %ρ #Hg"; rewrite path_wp_pv_eq.
     by rewrite s_interp_env_lookup // id_subst.
   Qed.
 
@@ -74,7 +74,7 @@ Section Sec.
     Γ s⊨ e : oLaterN i T -∗
     Γ s⊨ iterate tskip i e : T.
   Proof.
-    iIntros "#He %ρ #Hg"; rewrite tskip_subst; iApply wp_bind.
+    iIntros ">#He !> %ρ #Hg"; rewrite tskip_subst; iApply wp_bind.
     wp_wapply "(He Hg)"; iIntros "{He} /= %v Hv".
     by wp_pure.
   Qed.
@@ -89,7 +89,7 @@ Section Sec.
     (*───────────────────────────────*)
     Γ s⊨ e : T2.
   Proof.
-    iIntros "HeT1 Hsub %ρ #Hg".
+    iIntros ">HeT1 >Hsub !> %ρ #Hg".
     wp_wapply "(HeT1 Hg)".
     iIntros (v) "HvT1 /=".
     iApply ("Hsub" with "Hg HvT1").
@@ -102,7 +102,7 @@ Section Sec.
    *)
   Lemma sTMu_equiv {Γ T v} : (Γ s⊨ tv v : oMu T) ≡ (Γ s⊨ tv v : T.|[v/]).
   Proof.
-    iSplit; iIntros "#Htp %ρ #Hg /=";
+    iSplit; iIntros ">#Htp !> %ρ #Hg /=";
     iDestruct (wp_value_inv' with "(Htp Hg)") as "{Htp} Hgoal";
     by rewrite -wp_value /= hoEnvD_subst_one.
   Qed.
@@ -113,7 +113,7 @@ Section Sec.
     (*────────────────────────────────────────────────────────────*)
     Γ s⊨ tapp e1 (tv v2) : T2.|[v2/].
   Proof.
-    iIntros "He1 Hv2Arg %ρ #Hg".
+    iIntros ">He1 >Hv2Arg !> %ρ #Hg".
     iSpecialize ("Hv2Arg" with "Hg"); rewrite /= wp_value_inv'.
     wp_wapply "(He1 Hg)"; iIntros "{Hg} %v /=".
     iDestruct 1 as (t ->) "HvFun"; iSpecialize ("HvFun" with "Hv2Arg").
@@ -131,7 +131,7 @@ Section Sec.
     (*────────────────────────────────────────────────────────────*)
     Γ s⊨ tapp e1 e2 : T2.
   Proof.
-    iIntros "/= He1 He2 %ρ #Hg".
+    iIntros "/= >He1 >He2 !> %ρ #Hg".
     wp_wapply "(He1 Hg)"; iIntros "%v"; iDestruct 1 as (t ->) "Hv /=".
     wp_wapply "(He2 Hg)"; iIntros "{Hg} %w Hw /=".
     iSpecialize ("Hv" with "Hw"). wp_pure. wp_wapply "Hv".
@@ -147,7 +147,7 @@ Section Sec.
     (*─────────────────────────*)
     Γ s⊨ tproj e l : T.
   Proof.
-    iIntros "He %ρ Hg".
+    iIntros ">He !> %ρ Hg".
     wp_wapply "(He Hg)"; iIntros "%v /=".
     iDestruct 1 as (? Hl pmem ->) "Hv /=".
     wp_pure. by rewrite -path_wp_to_wp.

--- a/theories/Dot/semtyp_lemmas/defs_lr.v
+++ b/theories/Dot/semtyp_lemmas/defs_lr.v
@@ -15,7 +15,7 @@ Section Sec.
     Γ s⊨p p : T, 0 -∗
     Γ s⊨ { l := dpt p } : cVMem l T.
   Proof.
-    rewrite sdtp_eq'; iIntros "#Hv" (ρ Hpid) "#Hg".
+    rewrite sdtp_eq'; iIntros ">#Hv !>" (ρ Hpid) "#Hg".
     rewrite oDVMem_eq; iApply ("Hv" with "Hg").
   Qed.
 
@@ -26,7 +26,7 @@ Section Sec.
     Γ s⊨ tv v : T -∗
     Γ s⊨p pv v : T, 0.
   Proof.
-    iIntros "/= #Hp %ρ Hg". rewrite path_wp_pv_eq -wp_value_inv'.
+    iIntros "/= >#Hp !> %ρ Hg". rewrite path_wp_pv_eq -wp_value_inv'.
     iApply ("Hp" with "Hg").
   Qed.
 
@@ -40,8 +40,8 @@ Section Sec.
     oAnd (oLater (c2o T)) (oSing (pself (pv (ids 1)) l)) :: Γ s⊨ds ds : T -∗
     Γ s⊨ { l := dpt (pv (vobj ds)) } : cVMem l (oMu (c2o T)).
   Proof.
-    rewrite sdtp_eq'; iDestruct 1 as (Hwf) "#Hds";
-      iIntros (ρ Hpid%path_includes_field_aliases) "#Hg".
+    rewrite sdtp_eq'; iMod 1 as (Hwf) "#Hds";
+      iIntros "!>" (ρ Hpid%path_includes_field_aliases) "#Hg".
     rewrite oDVMem_eq path_wp_pv_eq /=. iLöb as "IH".
     iEval rewrite -clty_commute norm_selfSubst.
     iApply ("Hds" $! (vobj _ .: ρ) with "[%] [$IH $Hg //]").
@@ -53,7 +53,7 @@ Section Sec.
     Γ s⊨ { l := dpt p } : cVMem l T1 -∗
     Γ s⊨ { l := dpt p } : cVMem l T2.
   Proof.
-    rewrite !sdtp_eq'; iIntros "#Hsub #Hd" (ρ Hpid) "#Hg".
+    rewrite !sdtp_eq'; iIntros ">#Hsub >#Hd !>" (ρ Hpid) "#Hg".
     iSpecialize ("Hd" $! ρ Hpid with "Hg").
     iApply (oDVMem_respects_sub with "(Hsub Hg) Hd").
   Qed.
@@ -64,7 +64,7 @@ Section Sec.
     Γ s⊨ { l := d } : cTMem l L1 U1 -∗
     Γ s⊨ { l := d } : cTMem l L2 U2.
   Proof.
-    rewrite !sdtp_eq'; iIntros "#HL #HU #Hd" (ρ Hpid) "#Hg".
+    rewrite !sdtp_eq'; iIntros ">#HL >#HU >#Hd !>" (ρ Hpid) "#Hg".
     iSpecialize ("Hd" $! ρ Hpid with "Hg").
     iApply (oDTMem_respects_sub with "(HL Hg) (HU Hg) Hd").
   Qed.
@@ -74,7 +74,7 @@ Section Sec.
     Γ s⊨ { l := dtysem σ s } : cTMem l (oLater T) (oLater T).
   Proof.
     rewrite !sdtp_eq'; iDestruct 1 as (φ Hγφ) "#Hγ".
-    iIntros (ρ Hpid) "#Hg"; iExists (hoEnvD_inst (σ.|[ρ]) φ); iSplit.
+    iIntros "!>" (ρ Hpid) "#Hg"; iExists (hoEnvD_inst (σ.|[ρ]) φ); iSplit.
     by iApply (dm_to_type_intro with "Hγ").
     by iSplit; iIntros (v) "#H"; iNext; rewrite /= (Hγφ _ _).
   Qed.
@@ -96,7 +96,7 @@ Section Sec.
     oLater (c2o T) :: Γ s⊨ds ds : T -∗
     Γ s⊨p pv (vobj ds) : oMu (c2o T), 0.
   Proof.
-    iDestruct 1 as (Hwf) "#Hds". iIntros "%ρ #Hg /=".
+    iMod 1 as (Hwf) "#Hds". iIntros "!> %ρ #Hg /=".
     rewrite path_wp_pv_eq /=. iLöb as "IH".
     iApply clty_commute. rewrite norm_selfSubst.
     iApply ("Hds" $! (vobj _ .: ρ) with "[%] [$IH $Hg]").
@@ -109,14 +109,14 @@ Section Sec.
   Proof. by rewrite sP_Obj_I sT_Path. Qed.
 
   Lemma sD_Nil Γ : ⊢ Γ s⊨ds [] : cTop.
-  Proof. by iSplit; last iIntros "**". Qed.
+  Proof. by iModIntro; iSplit; last iIntros "**". Qed.
 
   Lemma sD_Cons Γ d ds l (T1 T2 : cltyO Σ):
     dms_hasnt ds l →
     Γ s⊨ { l := d } : T1 -∗ Γ s⊨ds ds : T2 -∗
     Γ s⊨ds (l, d) :: ds : cAnd T1 T2.
   Proof.
-    rewrite !sdtp_eq; iIntros (Hlds) "#HT1 [% #HT2]"; iSplit.
+    rewrite !sdtp_eq; iIntros (Hlds) ">#HT1 >[% #HT2] !>"; iSplit.
     by iIntros "!%"; cbn; constructor => //; by rewrite -dms_hasnt_notin_eq.
     iIntros (ρ [Hpid Hpids]%path_includes_split) "#Hg".
     iSpecialize ("HT1" $! _  Hpid with "Hg").

--- a/theories/Dot/semtyp_lemmas/dsub_lr.v
+++ b/theories/Dot/semtyp_lemmas/dsub_lr.v
@@ -35,52 +35,52 @@ Section DStpLemmas.
 
 
   Lemma sStp_Refl {Γ} T i : ⊢ Γ s⊨ T <:[i] T.
-  Proof. iIntros "%ρ _ !>"; by rewrite -subtype_refl. Qed.
+  Proof. iIntros "!> %ρ _ !>"; by rewrite -subtype_refl. Qed.
 
   Lemma sStp_Trans {Γ T1 T2 T3 i} :
     Γ s⊨ T1 <:[i] T2 -∗ Γ s⊨ T2 <:[i] T3 -∗ Γ s⊨ T1 <:[i] T3.
   Proof.
-    iIntros "#Hsub1 #Hsub2 %ρ #Hg *".
+    iIntros ">#Hsub1 >#Hsub2 !> %ρ #Hg *".
     iApply (subtype_trans with "(Hsub1 Hg) (Hsub2 Hg)").
   Qed.
 
   Lemma sStp_Top Γ T i:
     ⊢ Γ s⊨ T <:[i] oTop.
-  Proof. rewrite sstpd_eq_1. by iIntros "** !> ** /=". Qed.
+  Proof. rewrite sstpd_eq_1. by iIntros "!> ** !> **". Qed.
 
   Lemma sBot_Stp Γ T i:
     ⊢ Γ s⊨ oBot <:[i] T.
-  Proof. rewrite sstpd_eq_1. by iIntros "/= ** !> []". Qed.
+  Proof. rewrite sstpd_eq_1. by iIntros "!> /= ** !> []". Qed.
 
   Lemma sAnd1_Stp Γ T1 T2 i :
     ⊢ Γ s⊨ oAnd T1 T2 <:[i] T1.
-  Proof. rewrite sstpd_eq. by iIntros "/= %ρ %v _ !> [$ _]". Qed.
+  Proof. rewrite sstpd_eq. by iIntros "!> /= %ρ %v _ !> [$ _]". Qed.
   Lemma sAnd2_Stp Γ T1 T2 i :
     ⊢ Γ s⊨ oAnd T1 T2 <:[i] T2.
-  Proof. rewrite sstpd_eq. by iIntros "/= %ρ %v _ !> [_ $]". Qed.
+  Proof. rewrite sstpd_eq. by iIntros "!> /= %ρ %v _ !> [_ $]". Qed.
 
   Lemma sStp_And Γ T U1 U2 i:
     Γ s⊨ T <:[i] U1 -∗
     Γ s⊨ T <:[i] U2 -∗
     Γ s⊨ T <:[i] oAnd U1 U2.
   Proof.
-    rewrite !sstpd_eq; iIntros "#H1 #H2 %ρ %v #Hg".
+    rewrite !sstpd_eq; iIntros ">#H1 >#H2 !> %ρ %v #Hg".
     iSpecialize ("H1" $! ρ v with "Hg"); iSpecialize ("H2" $! ρ v with "Hg").
     iNext i; iIntros "#H".
     iSplit; [iApply "H1" | iApply "H2"]; iApply "H".
   Qed.
 
   Lemma sStp_Or1 Γ T1 T2 i: ⊢ Γ s⊨ T1 <:[i] oOr T1 T2.
-  Proof. rewrite sstpd_eq. by iIntros "/= %ρ %v _ !>"; eauto. Qed.
+  Proof. rewrite sstpd_eq. by iIntros "!> /= %ρ %v _ !>"; eauto. Qed.
   Lemma sStp_Or2 Γ T1 T2 i: ⊢ Γ s⊨ T2 <:[i] oOr T1 T2.
-  Proof. rewrite sstpd_eq. by iIntros "/= %ρ %v _ !>"; eauto. Qed.
+  Proof. rewrite sstpd_eq. by iIntros "!> /= %ρ %v _ !>"; eauto. Qed.
 
   Lemma sOr_Stp Γ T1 T2 U i:
     Γ s⊨ T1 <:[i] U -∗
     Γ s⊨ T2 <:[i] U -∗
     Γ s⊨ oOr T1 T2 <:[i] U.
   Proof.
-    rewrite !sstpd_eq; iIntros "/= #H1 #H2 * #Hg".
+    rewrite !sstpd_eq; iIntros ">#H1 >#H2 !> * #Hg".
     iSpecialize ("H1" $! ρ v with "Hg"); iSpecialize ("H2" $! ρ v with "Hg").
     iNext i; iIntros "#[HT | HT]"; [iApply "H1" | iApply "H2"]; iApply "HT".
   Qed.
@@ -88,7 +88,7 @@ Section DStpLemmas.
   Lemma sDistr_And_Or_Stp Γ {S T U i} : ⊢ Γ s⊨ oAnd (oOr S T) U <:[i] oOr (oAnd S U) (oAnd T U).
   Proof.
     rewrite sstpd_eq.
-    by iIntros "%ρ %v #Hg !> [[HS|HT] Hu] /="; [iLeft|iRight]; iFrame.
+    by iIntros "!> %ρ %v #Hg !> [[HS|HT] Hu] /="; [iLeft|iRight]; iFrame.
   Qed.
 
   (* XXX must we state the two separate halves? *)
@@ -99,7 +99,7 @@ Section DStpLemmas.
 
   Lemma sStp_Add_LaterN {Γ T i j}:
     ⊢ Γ s⊨ T <:[i] oLaterN j T.
-  Proof. rewrite sstpd_eq; iIntros "** !> $".  Qed.
+  Proof. rewrite sstpd_eq; iIntros "!> ** !> $".  Qed.
   Lemma sStp_Add_Later {Γ T i}:
     ⊢ Γ s⊨ T <:[i] oLater T.
   Proof. apply sStp_Add_LaterN. Qed.
@@ -108,7 +108,7 @@ Section DStpLemmas.
     Γ s⊨p p : oTMem l L U, i -∗
     Γ s⊨ L <:[i] oSel p l.
   Proof.
-    rewrite sstpd_eq; iIntros "#Hp %ρ %v Hg".
+    rewrite sstpd_eq; iIntros ">#Hp !> %ρ %v Hg".
     iSpecialize ("Hp" with "Hg"); iNext i; iIntros "#HL".
     iApply (path_wp_wand with "Hp"); iIntros (w).
     iApply (vl_sel_lb with "HL").
@@ -118,7 +118,7 @@ Section DStpLemmas.
     Γ s⊨p p : oTMem l L U, i -∗
     Γ s⊨ oSel p l <:[i] U.
   Proof.
-    rewrite sstpd_eq; iIntros "#Hp %ρ %v Hg".
+    rewrite sstpd_eq; iIntros ">#Hp !> %ρ %v Hg".
     iSpecialize ("Hp" with "Hg"); iNext i; iIntros "Hφ".
     iDestruct (path_wp_agree with "Hp Hφ") as (w Hw) "[Hp Hφ]".
     iApply (vl_sel_ub with "Hφ Hp").
@@ -133,7 +133,7 @@ Section DStpLemmas.
     oLaterN i T1 :: Γ s⊨ T1 <:[i] T2 -∗
     Γ s⊨ oMu T1 <:[i] oMu T2.
   Proof.
-    rewrite !sstpd_eq; iIntros "/= #Hstp %ρ %v Hg".
+    rewrite !sstpd_eq; iIntros ">#Hstp !> %ρ %v Hg".
     iApply mlaterN_impl; iIntros "#HT1".
     iApply ("Hstp" $! (v .: ρ) v with "[$Hg $HT1] [$HT1]").
   Qed.
@@ -177,7 +177,7 @@ Section DStpLemmas.
     Γ s⊨ T1 <:[i] T2 -∗
     Γ s⊨ oVMem l T1 <:[i] oVMem l T2.
   Proof.
-    iIntros "#Hsub %ρ Hg"; iSpecialize ("Hsub" with "Hg"); iNext i.
+    iIntros ">#Hsub !> %ρ Hg"; iSpecialize ("Hsub" with "Hg"); iNext i.
     iApply (oVMem_respects_sub with "Hsub").
   Qed.
 
@@ -186,7 +186,7 @@ Section DStpLemmas.
     Γ s⊨ U1 <:[i] U2 -∗
     Γ s⊨ oTMem l L1 U1 <:[i] oTMem l L2 U2.
   Proof.
-    iIntros "#HsubL #HsubU %ρ #Hg".
+    iIntros ">#HsubL >#HsubU !> %ρ #Hg".
     iSpecialize ("HsubL" with "Hg"); iSpecialize ("HsubU" with "Hg"); iNext i.
     iApply (oTMem_respects_sub with "HsubL HsubU").
   Qed.
@@ -196,7 +196,7 @@ Section DStpLemmas.
     oLaterN (i.+1) (oShift T2) :: Γ s⊨ oLater U1 <:[i] oLater U2 -∗
     Γ s⊨ oAll T1 U1 <:[i] oAll T2 U2.
   Proof.
-    rewrite !sstpd_delay_oLaterN_plus; iIntros "#HsubT #HsubU %ρ #Hg %v".
+    rewrite !sstpd_delay_oLaterN_plus; iIntros ">#HsubT >#HsubU !> %ρ #Hg %v".
     rewrite -!mlaterN_impl.
     iDestruct 1 as (t) "#[Heq #HT1]"; iExists t; iFrame "Heq".
     iIntros (w); iSpecialize ("HT1" $! w).
@@ -227,7 +227,7 @@ Section DStpLemmas.
     (*───────────────────────────────*)
     Γ s⊨ T1 <:[i] oLaterN j T2.
   Proof.
-    rewrite -sstpd_delay_oLaterN; iIntros "#Htyp %ρ Hg %v HvT1".
+    rewrite -sstpd_delay_oLaterN; iIntros ">#Htyp !> %ρ Hg %v HvT1".
     iEval rewrite /= -(path_wp_pv_eq _ (T2 _ _)) -laterN_plus.
     iApply ("Htyp" $! (v .: ρ) with "[$Hg $HvT1]").
   Qed.
@@ -249,7 +249,7 @@ Section DStpLemmas.
   Lemma sAnd_All_Stp_Distr Γ T U1 U2 i:
     ⊢ Γ s⊨ oAnd (oAll T U1) (oAll T U2) <:[i] oAll T (oAnd U1 U2).
   Proof.
-    iIntros "%ρ _ !> %v [#H1 #H2]".
+    iIntros "!> %ρ _ !> %v [#H1 #H2]".
     iDestruct "H1" as (t ?) "#H1"; iDestruct "H2" as (t' ->) "#H2"; simplify_eq.
     iExists t; iSplit; first done.
     iIntros (w) "#HT".
@@ -261,7 +261,7 @@ Section DStpLemmas.
   Lemma sAnd_Fld_Stp_Distr Γ l T1 T2 i:
     ⊢ Γ s⊨ oAnd (oVMem l T1) (oVMem l T2) <:[i] oVMem l (oAnd T1 T2).
   Proof.
-    iIntros "%ρ _ !> %v [#H1 H2]"; rewrite !oVMem_eq.
+    iIntros "!> %ρ _ !> %v [#H1 H2]"; rewrite !oVMem_eq.
     iDestruct "H1" as (pmem Hl) "#H1"; iDestruct "H2" as (pmem' Hl') "#H2".
     objLookupDet. iExists pmem; iFrame (Hl).
     by iApply (path_wp_and' with "H1 H2").
@@ -270,7 +270,7 @@ Section DStpLemmas.
   Lemma sAnd_Typ_Stp_Distr Γ l L U1 U2 i:
     ⊢ Γ s⊨ oAnd (oTMem l L U1) (oTMem l L U2) <:[i] oTMem l L (oAnd U1 U2).
   Proof.
-    iIntros "%ρ _ !> %v [H1 H2]"; rewrite !oTMem_eq /dot_intv_type_pred.
+    iIntros "!> %ρ _ !> %v [H1 H2]"; rewrite !oTMem_eq /dot_intv_type_pred.
     iDestruct "H1" as (ψ d Hl) "[Hdψ1 [HLψ1 HψU1]]".
     iDestruct "H2" as (ψ' d' Hl') "[Hdψ2 [_ HψU2]]". objLookupDet.
     iExists ψ, d. iFrame (Hl) "HLψ1". iSplit; first done.
@@ -283,7 +283,7 @@ Section DStpLemmas.
   Lemma sOr_Fld_Stp_Distr Γ l T1 T2 i:
     ⊢ Γ s⊨ oVMem l (oOr T1 T2) <:[i] oOr (oVMem l T1) (oVMem l T2).
   Proof.
-    iIntros "%ρ _ !> %v". rewrite !oVMem_eq.
+    iIntros "!> %ρ _ !> %v". rewrite !oVMem_eq.
     iDestruct 1 as (pmem Hl) "Hp". rewrite path_wp_eq.
     iDestruct "Hp" as (w Hpw) "[H|H]"; [iLeft|iRight].
     all: by rewrite oVMem_eq; iExists (pmem); iFrame (Hl);
@@ -295,7 +295,7 @@ Section DStpLemmas.
     Γ s⊨p p : oLater T, i -∗
     Γ s⊨p p : T, i.+1.
   Proof.
-    iIntros "#HpT %ρ #Hg"; rewrite -later_laterN laterN_later.
+    iIntros ">#HpT !> %ρ #Hg"; rewrite -later_laterN laterN_later.
     iSpecialize ("HpT" with "Hg"); iNext i.
     iApply (path_wp_later_swap with "HpT").
   Qed.

--- a/theories/Dot/semtyp_lemmas/path_repl_lr.v
+++ b/theories/Dot/semtyp_lemmas/path_repl_lr.v
@@ -21,7 +21,7 @@ Section semantic_lemmas.
     Γ s⊨p p : τ, i -∗
     Γ s⊨p p : oSing p, i.
   Proof.
-    iIntros "#Hep %ρ Hg"; iApply (strong_path_wp_wand with "(Hep Hg)").
+    iIntros ">#Hep !> %ρ Hg"; iApply (strong_path_wp_wand with "(Hep Hg)").
     iIntros "%v %Hpv _ !%"; apply alias_paths_pv_eq_1, Hpv.
   Qed.
 
@@ -29,7 +29,7 @@ Section semantic_lemmas.
     Γ s⊨p p : T, i -∗
     Γ s⊨ oSing p <:[i] T.
   Proof.
-    rewrite sstpd_eq; iIntros "#Hp %ρ %v Hg".
+    rewrite sstpd_eq; iIntros ">#Hp !> %ρ %v Hg".
     iSpecialize ("Hp" with "Hg"); iNext i.
     iDestruct 1 as %->%(alias_paths_elim_eq (T _ ρ)).
     by rewrite path_wp_pv_eq.
@@ -40,7 +40,7 @@ Section semantic_lemmas.
     Γ s⊨ oSing p <:[i] oSing q -∗
     Γ s⊨ oSing q <:[i] oSing p.
   Proof.
-    rewrite !sstpd_eq; iIntros "#Hp #Hps %ρ %v #Hg".
+    rewrite !sstpd_eq; iIntros ">#Hp >#Hps !> %ρ %v #Hg".
     iDestruct (path_wp_eq with "(Hp Hg)") as (w) "[Hpw _] {Hp}".
     rewrite -alias_paths_pv_eq_1; iSpecialize ("Hps" $! _ w with "Hg Hpw");
       iNext i; rewrite /= !alias_paths_pv_eq_1.
@@ -52,7 +52,7 @@ Section semantic_lemmas.
     Γ s⊨p p : oSing q, i -∗
     Γ s⊨p q : oTop, i.
   Proof.
-    iIntros "#Hpq %ρ Hg /="; iSpecialize ("Hpq" with "Hg"); iNext i.
+    iIntros ">#Hpq !> %ρ Hg /="; iSpecialize ("Hpq" with "Hg"); iNext i.
     iDestruct "Hpq" as %(v & _ & Hqv)%alias_paths_simpl%alias_paths_sameres.
     iIntros "!%". exact: (path_wp_pure_wand Hqv).
   Qed.
@@ -64,7 +64,7 @@ Section semantic_lemmas.
     Γ s⊨p p : oSing q, i -∗
     Γ s⊨ T1 <:[i] T2.
   Proof.
-    rewrite sstpd_eq; iIntros "#Hrepl #Hal %ρ %v #Hg".
+    rewrite sstpd_eq; iIntros ">#Hrepl >#Hal !> %ρ %v #Hg".
     iSpecialize ("Hal" with "Hg"); iNext i.
     iDestruct "Hal" as %Hal%alias_paths_simpl.
     iRewrite ("Hrepl" $! vnil ρ v Hal); iIntros "$".
@@ -81,7 +81,7 @@ Section semantic_lemmas.
   Lemma sP_Mu_E {Γ T p i} :
     Γ s⊨p p : oMu T, i -∗ Γ s⊨p p : T .sTp[ p /], i.
   Proof.
-    iIntros "#Hp %ρ Hg /=".
+    iIntros ">#Hp !> %ρ Hg /=".
     iApply (strong_path_wp_wand with "(Hp Hg)"); iIntros "**".
     by rewrite oMu_eq sem_psubst_one_repl ?alias_paths_pv_eq_1.
   Qed.
@@ -89,7 +89,7 @@ Section semantic_lemmas.
   Lemma sP_Mu_I {Γ T p i} :
     Γ s⊨p p : T .sTp[ p /], i -∗ Γ s⊨p p : oMu T, i.
   Proof.
-    iIntros "#Hp %ρ Hg /=".
+    iIntros ">#Hp !> %ρ Hg /=".
     iApply (strong_path_wp_wand with "(Hp Hg)"); iIntros "**".
     by rewrite oMu_eq sem_psubst_one_repl ?alias_paths_pv_eq_1.
   Qed.
@@ -100,7 +100,7 @@ Section semantic_lemmas.
   Lemma P_Mu_E {Γ T T' p i} (Hrepl : T .Tp[ p /]~ T') :
     Γ ⊨p p : TMu T, i -∗ Γ ⊨p p : T', i.
   Proof.
-    rewrite /iptp sP_Mu_E; iIntros "#Hp %ρ Hg /=".
+    rewrite /iptp sP_Mu_E; iIntros ">#Hp !> %ρ Hg /=".
     iApply (strong_path_wp_wand with "(Hp Hg)"); iIntros "**".
     by rewrite (sem_psubst_one_eq Hrepl) ?alias_paths_pv_eq_1.
   Qed.
@@ -108,7 +108,7 @@ Section semantic_lemmas.
   Lemma P_Mu_I {Γ T T' p i} (Hrepl : T .Tp[ p /]~ T') :
     Γ ⊨p p : T', i -∗ Γ ⊨p p : TMu T, i.
   Proof.
-    rewrite /iptp -sP_Mu_I; iIntros "#Hp %ρ Hg /=".
+    rewrite /iptp -sP_Mu_I; iIntros ">#Hp !> %ρ Hg /=".
     iApply (strong_path_wp_wand with "(Hp Hg)"); iIntros "**".
     by rewrite (sem_psubst_one_eq Hrepl) ?alias_paths_pv_eq_1.
   Qed.
@@ -118,7 +118,7 @@ Section semantic_lemmas.
   Lemma P_Mu_E' {Γ T T' p i} (Hrepl : T .Tp[ p /]~ T') :
     Γ ⊨p p : TMu T, i -∗ Γ ⊨p p : T', i.
   Proof.
-    iIntros "#Hp %ρ Hg /=".
+    iIntros ">#Hp !> %ρ Hg /=".
     iApply (strong_path_wp_wand with "(Hp Hg)"); iIntros "**".
     by rewrite oMu_eq -(psubst_one_repl Hrepl) ?alias_paths_pv_eq_1.
   Qed.
@@ -126,7 +126,7 @@ Section semantic_lemmas.
   Lemma P_Mu_I' {Γ T T' p i} (Hrepl : T .Tp[ p /]~ T') :
     Γ ⊨p p : T', i -∗ Γ ⊨p p : TMu T, i.
   Proof.
-    iIntros "#Hp %ρ Hg /=".
+    iIntros ">#Hp !> %ρ Hg /=".
     iApply (strong_path_wp_wand with "(Hp Hg)"); iIntros "**".
     by rewrite oMu_eq -(psubst_one_repl Hrepl) ?alias_paths_pv_eq_1.
   Qed.
@@ -137,7 +137,7 @@ Section semantic_lemmas.
     (*────────────────────────────────────────────────────────────*)
     Γ s⊨ tapp e1 (path2tm p2) : T2 .sTp[ p2 /].
   Proof.
-    iIntros "He1 Hp2 %ρ #Hg /="; iSpecialize ("Hp2" with "Hg").
+    iIntros ">He1 >Hp2 !> %ρ #Hg /="; iSpecialize ("Hp2" with "Hg").
     wp_wapply "(He1 Hg)"; iIntros "{Hg} %v".
     iDestruct 1 as (t ->) "HvFun". rewrite path_wp_eq path2tm_subst /=.
     iDestruct "Hp2" as (pw Hpwpp) "Hpw"; iSpecialize ("HvFun" with "Hpw").
@@ -153,10 +153,10 @@ Section semantic_lemmas.
     (*────────────────────────────────────────────────────────────*)
     Γ ⊨ tapp e1 (path2tm p2) : T2'.
   Proof.
-    iIntros "He1 #Hp2 %ρ #Hg".
-    iDestruct (path_wp_eq with "(Hp2 Hg)") as (pw Hal%alias_paths_pv_eq_1) "_".
-    iDestruct (sT_All_E_p with "He1 Hp2") as "{Hp2} Hep".
-    iApply (wp_wand with "(Hep Hg)"). iIntros "{Hg} %v #Hv".
+    iIntros ">He1 >#Hp2".
+    iDestruct (sT_All_E_p with "He1 Hp2") as ">Hep"; iIntros "!> %ρ #Hg".
+    iDestruct (path_wp_eq with "(Hp2 Hg)") as (pw Hal%alias_paths_pv_eq_1) "_ /=".
+    iApply (wp_wand with "(Hep Hg)"); iIntros "{Hg} %v #Hv".
     iApply (sem_psubst_one_eq Hrepl Hal with "Hv").
   Qed.
 
@@ -166,7 +166,7 @@ Section semantic_lemmas.
     (*─────────────────────────*)
     Γ s⊨p p : oVMem l T, i.
   Proof.
-    iIntros "Hp /= %ρ Hg"; iSpecialize ("Hp" with "Hg"); iNext i.
+    iIntros ">Hp /= !> %ρ Hg"; iSpecialize ("Hp" with "Hg"); iNext i.
     rewrite path_wp_pself_eq; iDestruct "Hp" as (v q Hlook) "[Hpv #Htw]".
     iApply (path_wp_wand with "Hpv"). iIntros "/= % <-"; eauto.
   Qed.
@@ -186,7 +186,7 @@ Section semantic_lemmas.
     (*─────────────────────────*)
     Γ s⊨p pself p l : T, i.
   Proof.
-    iIntros "Hp %ρ Hg /="; iSpecialize ("Hp" with "Hg"); iNext i.
+    iIntros ">Hp !> %ρ Hg /="; iSpecialize ("Hp" with "Hg"); iNext i.
     rewrite path_wp_pself_eq path_wp_eq.
     iDestruct "Hp" as (vp Hpv d Hlook pmem ->) "H".
     iExists vp, pmem. eauto.
@@ -199,7 +199,7 @@ Section semantic_lemmas.
     Γ s⊨p q : T, i -∗
     Γ s⊨p p : T, i.
   Proof.
-    iIntros "Hep Heq %ρ #Hg"; iSpecialize ("Heq" with "Hg").
+    iIntros ">Hep >Heq !> %ρ #Hg"; iSpecialize ("Heq" with "Hg").
     iSpecialize ("Hep" with "Hg"); iNext i.
     by iDestruct "Hep" as %->%alias_paths_simpl%(alias_paths_elim_eq (T _ _)).
   Qed.
@@ -209,7 +209,7 @@ Section semantic_lemmas.
     Γ s⊨p pself q l : τ, i -∗
     Γ s⊨p pself p l : oSing (pself q l), i.
   Proof.
-    iIntros "Hpq HqlT %ρ #Hg"; iSpecialize ("HqlT" with "Hg");
+    iIntros ">Hpq >HqlT !> %ρ #Hg"; iSpecialize ("HqlT" with "Hg");
     iSpecialize ("Hpq" with "Hg"); iNext i; iClear "Hg".
     iDestruct "Hpq" as %Hal%alias_paths_simpl.
     rewrite !path_wp_eq; iDestruct "HqlT" as (vql Hql) "_".
@@ -223,7 +223,7 @@ Section semantic_lemmas.
     (*───────────────────────────────*)
     Γ s⊨p p : T2, i.
   Proof.
-    iIntros "HpT1 Hsub %ρ #Hg".
+    iIntros ">HpT1 >Hsub !> %ρ #Hg".
     iSpecialize ("Hsub" with "Hg"); iSpecialize ("HpT1" with "Hg"); iNext i.
     iApply (path_wp_wand with "HpT1"); iIntros "%w HvT1 {Hg}".
     iApply ("Hsub" with "HvT1").

--- a/theories/Dot/semtyp_lemmas/prims_lr.v
+++ b/theories/Dot/semtyp_lemmas/prims_lr.v
@@ -50,13 +50,13 @@ Section Sec.
   Import path_wp.
   Lemma sP_Nat_I Γ n: ⊢ Γ s⊨p pv (vint n): oInt, 0.
   Proof.
-    iIntros "%ρ * _ /=";
+    iIntros "!> %ρ * _ /=";
       rewrite path_wp_pv_eq /= /pure_interp_prim /prim_evals_to; naive_solver.
   Qed.
 
   Lemma sP_Bool_I Γ b: ⊢ Γ s⊨p pv (vbool b): oBool, 0.
   Proof.
-    iIntros "%ρ _ /=";
+    iIntros "!> %ρ _ /=";
       rewrite path_wp_pv_eq /= /pure_interp_prim /prim_evals_to; naive_solver.
   Qed.
 
@@ -73,7 +73,7 @@ Section Sec.
     Γ s⊨ e1 : oPrim B1 -∗
     Γ s⊨ tun u e1 : oPrim Br.
   Proof.
-    iIntros "He1 %ρ Hg /=".
+    iIntros ">He1 !> %ρ Hg /=".
     wp_bind (UnCtx _); wp_wapply "(He1 Hg)"; iIntros "%v1 %Ha1 /=".
     by iApply wp_wand; [iApply wp_un|iIntros (? [??])].
   Qed.
@@ -98,7 +98,7 @@ Section Sec.
     Γ s⊨ e2 : oPrim B2 -∗
     Γ s⊨ tbin b e1 e2 : oPrim Br.
   Proof.
-    iIntros "He1 He2 /= %ρ #Hg".
+    iIntros ">He1 >He2 !> /= %ρ #Hg".
     wp_bind (BinLCtx _ _); wp_wapply "(He1 Hg)"; iIntros "%v1 %Ha1 /=".
     wp_bind (BinRCtx _ _); wp_wapply "(He2 Hg)"; iIntros "{Hg} %v2 %Ha2 /=".
     unfold pure_interp_prim in *; ev.
@@ -121,7 +121,7 @@ Section Sec.
     Γ s⊨ e : oBool -∗ Γ s⊨ e1 : T -∗ Γ s⊨ e2 : T -∗
     Γ s⊨ tif e e1 e2 : T.
   Proof.
-    iIntros "He He1 He2 /= %ρ #Hg".
+    iIntros ">He >He1 >He2 !> /= %ρ #Hg".
     wp_bind (IfCtx _ _); wp_wapply "(He Hg)".
     rewrite /=/pure_interp_prim/=; iIntros (v (b & ->)).
     case: b; wp_pure; [iApply ("He1" with "Hg") | iApply ("He2" with "Hg")].

--- a/theories/Dot/semtyp_lemmas/tproj_lr.v
+++ b/theories/Dot/semtyp_lemmas/tproj_lr.v
@@ -49,7 +49,7 @@ Section existentials.
     oLaterN i (oShift S) :: Γ s⊨ T <:[i] oShift U -∗
     Γ s⊨ oExists S T <:[i] U.
   Proof.
-    iIntros "/= #Hstp %ρ Hg %v"; iApply impl_laterN.
+    iIntros "/= >#Hstp !> %ρ Hg %v"; iApply impl_laterN.
     iDestruct 1 as (w) "[HS HT]".
     iApply ("Hstp" $! (w .: ρ) with "[$Hg $HS] HT").
   Qed.
@@ -60,7 +60,7 @@ Section existentials.
     Γ s⊨ T <:[i] opSubst p U -∗
     Γ s⊨ T <:[i] oExists S U.
   Proof.
-    iIntros "/= #HpS #Hstp %ρ #Hg".
+    iIntros "/= >#HpS >#Hstp !> %ρ #Hg".
     iSpecialize ("HpS" with "Hg"); iSpecialize ("Hstp" with "Hg"); iNext i.
     iApply (subtype_trans with "Hstp"); iIntros "%v HvUp".
     iDestruct (path_wp_agree with "HpS HvUp") as (w ?) "Hgoal".
@@ -164,7 +164,7 @@ Section type_proj.
     Γ s⊨ T <:[i] U -∗
     Γ s⊨ oProj A T <:[i] oProj A U.
   Proof.
-    iIntros "#Hsub %ρ Hg %v"; iSpecialize ("Hsub" with "Hg"); iNext i.
+    iIntros ">#Hsub !> %ρ Hg %v"; iSpecialize ("Hsub" with "Hg"); iNext i.
     (**
       From [T <: U] we must show [T#A <: U#A], that is, that any [v] in [T#A]
       is in [U#A]. Recall the definition of [T#A]:
@@ -189,7 +189,7 @@ Section type_proj.
   Lemma sProj_Stp_U A Γ L U i :
     ⊢ Γ s⊨ oProj A (oTMem A L U) <:[i] U.
   Proof.
-    iIntros "%ρ Hg %v"; iNext i.
+    iIntros "!> %ρ Hg %v"; iNext i.
     rewrite oProjN_eq; iDestruct 1 as (w) "(HTw & HselV)".
     (*
       After unfolding definitions, we must show that [v] is in [U],


### PR DESCRIPTION
This enables supporting properly type projections out of equal bounds, turning incomplete PR #255 into PR #304.