### PR TITLE
Update subtraction for the switch from naturals to integers

### DIFF
--- a/theories/Dot/semtyp_lemmas/prims_lr.v
+++ b/theories/Dot/semtyp_lemmas/prims_lr.v
@@ -16,7 +16,6 @@ Inductive cond_bin_op_syntype : bin_op → ∀ (B1 B2 Br : base_ty),
   (prim_sem B1 → prim_sem B2 → Prop) → Set :=
 | ty_syn b B1 B2 Br : bin_op_syntype b B1 B2 Br →
                       cond_bin_op_syntype b B1 B2 Br (const (const True))
-| ty_bminus         : cond_bin_op_syntype bminus tint  tint  tint  (λ n1 n2, n2 ≤ n1)%Z
 | ty_bdiv           : cond_bin_op_syntype bdiv   tint  tint  tint  (λ _ n, n ≠ 0).
 
 Definition un_op_semtype u B1 Br := ∀ v, pure_interp_prim B1 v →

--- a/theories/Dot/syn/syn.v
+++ b/theories/Dot/syn/syn.v
@@ -416,11 +416,7 @@ Definition bin_op_eval_bool (b : bin_op) (b1 b2 : bool) : option vl :=
 Definition bin_op_eval_int (b : bin_op) (n1 n2 : Z) : option vl :=
   match b with
   | bplus => Some $ vlit $ lint (n1 + n2)
-  | bminus =>
-    if bool_decide (n2 ≤ n1)%Z then
-      Some $ vlit $ lint (n1 - n2)
-    else
-      None
+  | bminus => Some $ vlit $ lint (n1 - n2)
   | btimes => Some $ vlit $ lint (n1 - n2)
   | bdiv =>
     match n2 with

--- a/theories/Dot/typing/typing_aux_defs.v
+++ b/theories/Dot/typing/typing_aux_defs.v
@@ -24,6 +24,7 @@ Inductive bin_op_syntype : bin_op → base_ty → base_ty → base_ty → Set :=
 | ty_blt      : bin_op_syntype blt    tint  tint  tbool
 | ty_ble      : bin_op_syntype ble    tint  tint  tbool
 | ty_bplus    : bin_op_syntype bplus  tint  tint  tint
+| ty_bminus   : bin_op_syntype bminus tint  tint  tint
 | ty_btimes   : bin_op_syntype btimes tint  tint  tint.
 
 (** ** When is a context weaker than another? While we don't give complete


### PR DESCRIPTION
Subtraction was defined to be partial because we initially had naturals as
primitive type; apparently I forgot to fix that when we switched to integers.

Hence, update operational semantics and typing rules.