### PR TITLE
Revert "build(deps): bump tzinfo from 1.2.7 to 2.0.2 in /website"

### DIFF
--- a/website/Gemfile
+++ b/website/Gemfile
@@ -25,7 +25,7 @@ end
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 # and associated library.
 install_if -> { RUBY_PLATFORM =~ %r!mingw|mswin|java! } do
-  gem "tzinfo", "~> 2.0"
+  gem "tzinfo", "~> 1.2"
   gem "tzinfo-data"
 end
 

--- a/website/Gemfile.lock
+++ b/website/Gemfile.lock
@@ -1,9 +1,12 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (3.2.22.5)
-      i18n (~> 0.6, >= 0.6.4)
-      multi_json (~> 1.0)
+    activesupport (6.0.3.2)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+      zeitwerk (~> 2.2, >= 2.2.2)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     coffee-script (2.4.1)
@@ -203,7 +206,7 @@ GEM
       jekyll (>= 3.5, < 5.0)
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
-    multi_json (1.15.0)
+    minitest (5.14.1)
     multipart-post (2.1.1)
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
@@ -234,10 +237,11 @@ GEM
       unf (~> 0.1.4)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
+    thread_safe (0.3.6)
     typhoeus (1.4.0)
       ethon (>= 0.9.0)
-    tzinfo (2.0.2)
-      concurrent-ruby (~> 1.0)
+    tzinfo (1.2.7)
+      thread_safe (~> 0.1)
     tzinfo-data (1.2020.1)
       tzinfo (>= 1.0.0)
     unf (0.1.4)
@@ -245,6 +249,7 @@ GEM
     unf_ext (0.0.7.7)
     unicode-display_width (1.7.0)
     wdm (0.1.1)
+    zeitwerk (2.4.0)
 
 PLATFORMS
   ruby
@@ -253,7 +258,7 @@ DEPENDENCIES
   github-pages
   jekyll-feed (~> 0.6)
   minima (~> 2.0)
-  tzinfo (~> 2.0)
+  tzinfo (~> 1.2)
   tzinfo-data
   wdm (~> 0.1.0)
 


### PR DESCRIPTION
Reverts Blaisorblade/dot-iris#314, because it downgraded activesupport to a version with a CVE.