### PR TITLE
Prepare for Iris bump

### DIFF
--- a/theories/Dot/hkdot/sem_kind.v
+++ b/theories/Dot/hkdot/sem_kind.v
@@ -33,7 +33,7 @@ Definition hoLty_equiv {Σ n} (T1 T2 : hoLtyO Σ n) : iProp Σ :=
 
 Lemma iff_sym `{PROP : bi} (A B : PROP) :
    (A ↔ B) -∗ (B ↔ A).
-Proof. by rewrite /bi_iff -and_comm. Qed.
+Proof. by rewrite /bi_iff -bi.and_comm. Qed.
 
 (* XXX Unused *)
 Lemma iff_trans `{!BiAffine PROP} (A B C : PROP)

--- a/theories/Dot/lr/sem_unstamped_typing.v
+++ b/theories/Dot/lr/sem_unstamped_typing.v
@@ -7,7 +7,7 @@ From D.Dot Require Import unary_lr.
 From D.Dot Require Import later_sub_sem binding_lr path_repl_lr defs_lr dsub_lr prims_lr.
 From stdpp Require Import relations.
 (* Fix what is in scope. *)
-Import dlang_adequacy D.prelude stdpp.relations stdpp.tactics.
+Import stdpp.relations stdpp.tactics D.prelude dlang_adequacy.
 
 Implicit Types (Σ : gFunctors)
          (v w : vl) (e : tm) (d : dm) (ds : dms) (p : path)

--- a/theories/Dot/syn/skeleton.v
+++ b/theories/Dot/syn/skeleton.v
@@ -66,7 +66,7 @@ with same_skel_path (p1 p2: path): Prop :=
   | _ => False
   end.
 
-Fixpoint same_skel_ectx K K' :=
+Definition same_skel_ectx K K' :=
   match K, K' with
   | AppLCtx e2, AppLCtx e2' => same_skel_tm e2 e2'
   | AppRCtx v1, AppRCtx v1' => same_skel_vl v1 v1'

--- a/theories/Dot/typing/type_eq.v
+++ b/theories/Dot/typing/type_eq.v
@@ -5,7 +5,7 @@ Unset Strict Implicit.
 
 Implicit Types (L T U: ty) (v: vl) (e: tm) (d: dm) (ds: dms) (Γ : ctx).
 
-Reserved Notation "|- T1 == T2" (at level 70, T1 at level 69, only parsing).
+Reserved Notation "|- T1 == T2" (at level 70, T1 at level 69).
 Inductive type_equiv : Equiv ty :=
 | type_equiv_later_and T1 T2 :
   |- TLater (TAnd T1 T2) == TAnd (TLater T1) (TLater T2)

--- a/theories/iris_extra/det_reduction.v
+++ b/theories/iris_extra/det_reduction.v
@@ -29,10 +29,9 @@ Notation InhabitedState Λ := (Inhabited (L.state Λ)).
 Class LangDet (Λ : L.language) `{InhabitedState Λ} := {
   prim_step_PureExec (e1 e2 : L.expr Λ) σ1 κ σ2 efs :
     L.prim_step e1 σ1 κ e2 σ2 efs → PureExec True 1 e1 e2;
-  lang_inh_state : ProofIrrel (L.state Λ)
+  lang_inh_state :> ProofIrrel (L.state Λ)
 }.
 Arguments LangDet Λ {_}.
-Existing Instance lang_inh_state.
 
 Class EctxLangDet (Λ : EL.ectxLanguage) `{InhabitedState Λ} := {
   head_step_PureExec (e1 e2 : L.expr Λ) σ1 κ σ2 efs :
@@ -40,7 +39,6 @@ Class EctxLangDet (Λ : EL.ectxLanguage) `{InhabitedState Λ} := {
   ectx_inh_state :> ProofIrrel (L.state Λ)
 }.
 Arguments EctxLangDet Λ {_}.
-Existing Instance ectx_inh_state.
 
 Notation dummyState := (inhabitant (A := L.state _)).
 

--- a/theories/iris_extra/dlang.v
+++ b/theories/iris_extra/dlang.v
@@ -27,9 +27,8 @@ Module Type LiftWp (Import VS : VlSortsSig).
   Class dlangG Σ `{InhabitedState dlang_lang} := DLangG {
     dlangG_savior :> savedHoSemTypeG Σ;
     dlangG_langdet :> LangDet dlang_lang;
-    dlangG_persistent (P : iProp Σ) : Persistent P;
+    dlangG_persistent (P : iProp Σ) :> Persistent P | 0;
   }.
-  Existing Instance dlangG_persistent | 0.
 
   (** ** Instance of [irisG] enable using the expression weakest precondition; this instance. *)
   Instance dlangG_irisG `{dlangG Σ} : irisG dlang_lang Σ := {


### PR DESCRIPTION
Tested against `coq 8.12.1pre1+flambda-native` and `coq-iris dev.2020-10-15.2.f4060bb5`, still works with the current versions.

The first commit is a general cleanup.