### PR TITLE
Drop dependent typing for predicates, try 3

### DIFF
--- a/tests/test_shadow.ref
+++ b/tests/test_shadow.ref
@@ -1,4 +1,7 @@
-Notation anil := @vnil
-Expands to: Notation D.iris_extra.saved_interp_dep.anil
+anil : astream
+
+anil is not universe polymorphic
+anil is transparent
+Expands to: Constant D.Dot.lr.dlang_inst.anil
 Notation shift chi := (shift chi)
 Expands to: Notation D.prelude.shift

--- a/theories/DSub/lr/ds_ty_interp_subst_lemmas.v
+++ b/theories/DSub/lr/ds_ty_interp_subst_lemmas.v
@@ -1,5 +1,5 @@
 (** * Binding lemmas about DSub* logical relations. *)
-From D Require Import prelude iris_prelude asubst_base saved_interp_dep.
+From D Require Import prelude iris_prelude asubst_base saved_interp_n.
 
 Set Suggest Proof Using.
 Set Default Proof Using "Type*".

--- a/theories/DSub/lr/ds_unary_lr.v
+++ b/theories/DSub/lr/ds_unary_lr.v
@@ -1,4 +1,4 @@
-From D Require Export iris_prelude saved_interp_dep.
+From D Require Export iris_prelude saved_interp_n.
 From D Require Import persistence.
 From D.DSub Require Import ds_syn.
 From D.DSub Require Import ds_ty_interp_subst_lemmas.

--- a/theories/Dot/examples/old_fundamental.v
+++ b/theories/Dot/examples/old_fundamental.v
@@ -78,7 +78,7 @@ Section storeless_unstamped_lemmas.
     Γ u⊨ { l := dtysyn T } : TTMem l L U.
   Proof. have := !!(nclosed_syn_coveringσ HclT); apply suD_Typ_Abs_I. Qed.
 
-  Lemma suD_Typ_dtysem {Γ l σ s fakeσ} {T : olty Σ 0} (HclT : coveringσ σ T):
+  Lemma suD_Typ_dtysem {Γ l σ s fakeσ} {T : olty Σ} (HclT : coveringσ σ T):
     ⊢ Γ su⊨ { l := dtysem fakeσ s } : cTMem l (oLater T) (oLater T).
   Proof.
     by iApply sudtp_respects_skel_sym; last iApply (suD_Typ (fakeT := TTop)).

--- a/theories/Dot/examples/sem/no_russell_paradox.v
+++ b/theories/Dot/examples/sem/no_russell_paradox.v
@@ -52,7 +52,7 @@ Section Russell.
     iEval (rewrite uAu_unfold) in "HuauV'".
     iDestruct "HuauV'" as (d ψ Hl) "[Hs1 Hvav]".
     have Hdeq: d = dtysem [] s. by move: Hl => /= [ds [[<- /=] ?]]; simplify_eq.
-    iAssert (d ↗n[ 0 ] aopen (russell_p ids)) as "#Hs2". by iApply (dm_to_type_intro with "Hs").
+    iAssert (d ↗n aopen (russell_p ids)) as "#Hs2". by iApply (dm_to_type_intro with "Hs").
     iPoseProof (dm_to_type_agree anil v with "Hs1 Hs2") as "#Hag".
     (* without lock, iNext would strip a later in [HuauV]. *)
     rewrite [uAu]lock; iNext; unlock.

--- a/theories/Dot/examples/sem/positive_div.v
+++ b/theories/Dot/examples/sem/positive_div.v
@@ -67,13 +67,13 @@ Section helpers.
   Lemma wp_nge m n (Hnge : ¬ m > n) : ⊢ WP m > n {{ w, w ≡ false }}.
   Proof. wp_bin. ev; simplify_eq/=. case_decide; by [|lia]. Qed.
 
-  Lemma setp_value Γ (T : olty Σ 0) v: Γ s⊨ v : T ⊣⊢ |==> ∀ ρ, sG⟦ Γ ⟧* ρ → T anil ρ v.[ρ].
+  Lemma setp_value Γ (T : olty Σ) v: Γ s⊨ v : T ⊣⊢ |==> ∀ ρ, sG⟦ Γ ⟧* ρ → T anil ρ v.[ρ].
   Proof.
     rewrite /setp/=; properness => //; iSplit;
       [rewrite wp_value_inv|rewrite -wp_value]; iIntros "#$".
   Qed.
 
-  Lemma setp_value_eq (T : olty Σ 0) v: (|==> ∀ ρ, T anil ρ v.[ρ]) ⊣⊢ [] s⊨ v : T.
+  Lemma setp_value_eq (T : olty Σ) v: (|==> ∀ ρ, T anil ρ v.[ρ]) ⊣⊢ [] s⊨ v : T.
   Proof.
     iSplit.
     - iIntros ">#H !>" (? _).
@@ -85,9 +85,9 @@ Section helpers.
 End helpers.
 
 Definition pos v := ∃ n, v = vint n ∧ n > 0.
-Definition ipos {Σ}: oltyO Σ 0 := olty0 (λI ρ v, ⌜ pos v ⌝).
+Definition ipos {Σ}: oltyO Σ := olty0 (λI ρ v, ⌜ pos v ⌝).
 
-Definition s_is_pos `{!dlangG Σ} s : iProp Σ := s ↝n[ 0 ] ipos.
+Definition s_is_pos `{!dlangG Σ} s : iProp Σ := s ↝n ipos.
 
 Section div_example.
   Context `{HdlangG: !dlangG Σ} `{SwapPropI Σ}.

--- a/theories/Dot/examples/sem/semtyp_lemmas/sub_lr.v
+++ b/theories/Dot/examples/sem/semtyp_lemmas/sub_lr.v
@@ -16,7 +16,7 @@ Notation sstpi' i j Γ τ1 τ2 :=
 
 Section defs.
   Context {Σ}.
-  Implicit Types (τ : oltyO Σ 0).
+  Implicit Types (τ : oltyO Σ).
 
   (** Legacy: (double)-indexed subtyping. *)
   Definition sstpi `{!dlangG Σ} i j Γ τ1 τ2 : iProp Σ :=
@@ -32,7 +32,7 @@ Notation "Γ ⊨ T1 , i <: T2 , j" := (istpi Γ T1 T2 i j) (at level 74, T1, T2,
 (** * Proper instances. *)
 Section Propers.
   Context `{HdotG: !dlangG Σ}.
-  Implicit Types (τ L T U : olty Σ 0).
+  Implicit Types (τ L T U : olty Σ).
 
   #[global] Instance sstpi_proper i j : Proper ((≡) ==> (≡) ==> (≡) ==> (≡)) (sstpi i j).
   Proof.
@@ -55,7 +55,7 @@ Section judgment_lemmas.
     |==> ∀ ρ v, G⟦Γ⟧ ρ → ▷^i V⟦T1⟧ anil ρ v → ▷^j V⟦T2⟧ anil ρ v.
   Proof. reflexivity. Qed.
 
-  Lemma sstpi_app ρ Γ (T1 T2 : olty Σ 0) i j :
+  Lemma sstpi_app ρ Γ (T1 T2 : olty Σ) i j :
     sstpi' i j Γ T1 T2 -∗ sG⟦ Γ ⟧* ρ -∗
     oClose (oLaterN i T1) ρ ⊆ oClose (oLaterN j T2) ρ.
   Proof. iIntros "Hsub Hg %v"; iApply ("Hsub" with "Hg"). Qed.

--- a/theories/Dot/examples/sem/small_sem_ex.v
+++ b/theories/Dot/examples/sem/small_sem_ex.v
@@ -37,7 +37,7 @@ Section small_ex.
   }.
   Definition miniVT2 := μ miniVT2Body.
 
-  Definition sminiVT2Body : oltyO Σ 0 :=
+  Definition sminiVT2Body : oltyO Σ :=
     oAnd (oTMemL "A" oBot (oPrim tint))
       (oAnd (oVMem "n" (oLater (oSel x0 "A")))
       oTop).

--- a/theories/Dot/hkdot/hkdot.v
+++ b/theories/Dot/hkdot/hkdot.v
@@ -5,7 +5,7 @@ From iris.proofmode Require Import tactics.
 From iris.base_logic Require Import lib.saved_prop.
 From D Require Import iris_prelude.
 From D Require Export succ_notation.
-From D Require Import saved_interp_dep asubst_intf asubst_base dlang lty.
+From D Require Import saved_interp_n asubst_intf asubst_base dlang lty.
 From D Require Import swap_later_impl.
 From D.Dot Require dot_lty unary_lr.
 From D.Dot Require defs_lr binding_lr dsub_lr sub_lr examples_lr.
@@ -32,10 +32,10 @@ Notation sstpiK_env i T1 T2 K ρ := (▷^i K ρ (envApply T1 ρ) (envApply T2 ρ
 
 Notation sstpiK' i Γ T1 T2 K := (∀ ρ, sG⟦Γ⟧*ρ → sstpiK_env i T1 T2 K ρ)%I.
 
-Definition sstpiK `{dlangG Σ} {n} i Γ T1 T2 (K : sf_kind Σ n) : iProp Σ :=
+Definition sstpiK `{dlangG Σ} i Γ T1 T2 (K : sf_kind Σ) : iProp Σ :=
   |==> sstpiK' i Γ T1 T2 K.
 Arguments sstpiK : simpl never.
-Instance: Params (@sstpiK) 5 := {}.
+Instance: Params (@sstpiK) 4 := {}.
 Notation "Γ s⊨ T1 <:[ i  ] T2 ∷ K" := (sstpiK i Γ T1 T2 K)
   (at level 74, i, T1, T2, K at next level).
 
@@ -47,18 +47,18 @@ Notation "Γ s⊨ T ∷[ i  ] K" := (Γ s⊨ T <:[ i ] T ∷ K)
   (at level 74, T, K at next level).
 
 (* Semantic SubKinding *)
-Definition sSkd `{dlangG Σ} {n} i Γ (K1 K2 : sf_kind Σ n) : iProp Σ :=
-  |==> ∀ ρ, sG⟦Γ⟧*ρ → ∀ (T1 T2 : hoLtyO Σ n), ▷^i (K1 ρ T1 T2 → K2 ρ T1 T2).
+Definition sSkd `{dlangG Σ} i Γ (K1 K2 : sf_kind Σ) : iProp Σ :=
+  |==> ∀ ρ, sG⟦Γ⟧*ρ → ∀ (T1 T2 : hoLtyO Σ), ▷^i (K1 ρ T1 T2 → K2 ρ T1 T2).
 Arguments sSkd : simpl never.
-Instance: Params (@sSkd) 5 := {}.
+Instance: Params (@sSkd) 4 := {}.
 Notation "Γ s⊨ K1 <∷[ i  ] K2" := (sSkd i Γ K1 K2)
   (at level 74, K1, K2 at next level).
 
 Section gen_lemmas.
   Context `{Hdlang : dlangG Σ} `{HswapProp: SwapPropI Σ}.
 
-  #[global] Instance sstpiK_proper n i :
-    Proper ((≡) ==> (≡) ==> (≡) ==> (≡) ==> (≡)) (sstpiK (Σ := Σ) (n := n) i).
+  #[global] Instance sstpiK_proper i :
+    Proper ((≡) ==> (≡) ==> (≡) ==> (≡) ==> (≡)) (sstpiK (Σ := Σ) i).
   Proof.
     rewrite /sstpiK=> Γ1 Γ2 HΓ T1 T2 HT U1 U2 HU K1 K2 HK.
     properness; rewrite (HΓ, HK); first done.
@@ -67,19 +67,19 @@ Section gen_lemmas.
     by apply sf_kind_proper; f_equiv.
   Qed.
 
-  Lemma sstpiK_mono_ctx i n Γ {T1 U1 T2 U2: olty Σ n} (K1 K2 : sf_kind Σ n)
+  Lemma sstpiK_mono_ctx i Γ {T1 U1 T2 U2: olty Σ} (K1 K2 : sf_kind Σ)
     (Hsub : ⊢ ∀ ρ, sG⟦Γ⟧*ρ → sstpiK_env i T1 U1 K1 ρ -∗ sstpiK_env i T2 U2 K2 ρ) :
     Γ s⊨ T1 <:[ i ] U1 ∷ K1 ⊢ Γ s⊨ T2 <:[ i ] U2 ∷ K2.
   Proof. iIntros ">#HT !>" (ρ) "#Hg /=". iApply (Hsub with "Hg (HT Hg)"). Qed.
 
-  #[global] Instance sSkd_proper n i :
-    Proper ((≡) ==> (≡) ==> (≡) ==> (≡)) (sSkd (Σ := Σ) (n := n) i).
+  #[global] Instance sSkd_proper i :
+    Proper ((≡) ==> (≡) ==> (≡) ==> (≡)) (sSkd (Σ := Σ) i).
   Proof.
     rewrite /sSkd => Γ1 Γ2 HΓ K1 K2 HK1 K3 K4 HK2.
     by properness; rewrite (HΓ, HK1, HK2).
   Qed.
 
-  Lemma shift_sstpiK S Γ {n i} (T1 T2 : olty Σ n) K :
+  Lemma shift_sstpiK S Γ {i} (T1 T2 : olty Σ) K :
     Γ s⊨ T1 <:[ i ] T2 ∷ K -∗
     S :: Γ s⊨ oShift T1 <:[ i ] oShift T2 ∷ kShift K.
   Proof.
@@ -87,17 +87,17 @@ Section gen_lemmas.
     by iApply (sf_kind_proper with "(HK Hg)").
   Qed.
 
-  Lemma shift_sKEq S Γ {n i} (T1 T2 : olty Σ n) K :
+  Lemma shift_sKEq S Γ {i} (T1 T2 : olty Σ) K :
     Γ s⊨ T1 =[ i ] T2 ∷ K -∗
     S :: Γ s⊨ oShift T1 =[ i ] oShift T2 ∷ kShift K.
   Proof. by rewrite -!shift_sstpiK. Qed.
 
-  Lemma shift_stpkD S Γ {n i} (T : olty Σ n) K :
+  Lemma shift_stpkD S Γ {i} (T : olty Σ) K :
     Γ s⊨ T ∷[ i ] K -∗
     S :: Γ s⊨ oShift T ∷[ i ] kShift K.
   Proof. apply shift_sstpiK. Qed.
 
-  Lemma shift_sSkd S Γ {n i} (K1 K2 : sf_kind Σ n) :
+  Lemma shift_sSkd S Γ {i} (K1 K2 : sf_kind Σ) :
     Γ s⊨ K1 <∷[ i ] K2 -∗
     S :: Γ s⊨ kShift K1 <∷[ i ] kShift K2.
   Proof.
@@ -105,7 +105,7 @@ Section gen_lemmas.
     iApply ("HK" with "Hg").
   Qed.
 
-  Lemma narrow_sstpiK {n} Γ S1 S2 T U (K : sf_kind Σ n) i :
+  Lemma narrow_sstpiK Γ S1 S2 T U (K : sf_kind Σ) i :
     S2 :: Γ s⊨ S2 <:[ 0 ] S1 ∷ sf_star -∗
     S1 :: Γ s⊨ T <:[ i ] U ∷ K -∗
     S2 :: Γ s⊨ T <:[ i ] U ∷ K.
@@ -115,13 +115,13 @@ Section gen_lemmas.
     iApply ("HsubS" $! ρ with "[$Hg $HS] HS").
   Qed.
 
-  Lemma narrow_stpkD {n} Γ S1 S2 T (K : sf_kind Σ n) i :
+  Lemma narrow_stpkD Γ S1 S2 T (K : sf_kind Σ) i :
     S2 :: Γ s⊨ S2 <:[ 0 ] S1 ∷ sf_star -∗
     S1 :: Γ s⊨ T ∷[ i ] K -∗
     S2 :: Γ s⊨ T ∷[ i ] K.
   Proof. apply narrow_sstpiK. Qed.
 
-  Lemma narrow_sKEq {n} Γ S1 S2 T U (K : sf_kind Σ n) i :
+  Lemma narrow_sKEq Γ S1 S2 T U (K : sf_kind Σ) i :
     S2 :: Γ s⊨ S2 <:[ 0 ] S1 ∷ sf_star -∗
     S1 :: Γ s⊨ T =[ i ] U ∷ K -∗
     S2 :: Γ s⊨ T =[ i ] U ∷ K.
@@ -129,7 +129,7 @@ Section gen_lemmas.
     by iIntros "#HsubS #[HJ1 HJ2]"; iSplit; iApply (narrow_sstpiK with "HsubS").
   Qed.
 
-  Lemma narrow_sSkd Γ S1 S2 {n i} (K1 K2 : sf_kind Σ n) :
+  Lemma narrow_sSkd Γ S1 S2 {i} (K1 K2 : sf_kind Σ) :
     S2 :: Γ s⊨ S2 <:[ 0 ] S1 ∷ sf_star -∗
     S1 :: Γ s⊨ K1 <∷[ i ] K2 -∗
     S2 :: Γ s⊨ K1 <∷[ i ] K2.
@@ -139,7 +139,7 @@ Section gen_lemmas.
     iApply ("HsubS" $! ρ with "[$Hg $HS] HS").
   Qed.
 
-  Lemma sKEq_Symm Γ {n} (K : sf_kind Σ n) T1 T2 i :
+  Lemma sKEq_Symm Γ (K : sf_kind Σ) T1 T2 i :
     Γ s⊨ T1 =[ i ] T2 ∷ K -∗
     Γ s⊨ T2 =[ i ] T1 ∷ K.
   Proof. iIntros "[$ $]". Qed.
@@ -177,7 +177,7 @@ Section gen_lemmas.
     rewrite ksubtyping_equiv'. iIntros "Hsub Hg"; iApply ("Hsub" with "Hg").
   Qed.
 
-  Lemma ksubtyping_intro i Γ (T1 T2 : oltyO Σ 0) :
+  Lemma ksubtyping_intro i Γ (T1 T2 : oltyO Σ) :
     (|==> ∀ ρ, sG⟦ Γ ⟧* ρ →
     ∀ v, ▷^i (oClose T1 ρ v → oClose T2 ρ v)) -∗
     Γ s⊨ T1 <:[ i ] T2 ∷ sf_star.
@@ -186,7 +186,7 @@ Section gen_lemmas.
     by rewrite -laterN_forall.
   Qed.
 
-  Lemma ksubtyping_intro_swap i Γ (T1 T2 : oltyO Σ 0) :
+  Lemma ksubtyping_intro_swap i Γ (T1 T2 : oltyO Σ) :
     (|==> ∀ ρ, sG⟦ Γ ⟧* ρ →
     ∀ v, ▷^i oClose T1 ρ v → ▷^i oClose T2 ρ v) -∗
     Γ s⊨ T1 <:[ i ] T2 ∷ sf_star.
@@ -195,7 +195,7 @@ Section gen_lemmas.
     iApply (impl_laterN with "(Hsub Hg)").
   Qed.
 
-  Lemma kinding_intro Γ i (L T U : oltyO Σ 0) :
+  Lemma kinding_intro Γ i (L T U : oltyO Σ) :
     (|==> ∀ ρ, sG⟦ Γ ⟧* ρ →
     ▷^i (oClose L ρ ⊆ oClose T ρ ⊆ oClose U ρ)) -∗
     Γ s⊨ T ∷[ i ] sf_kintv L U.
@@ -205,15 +205,15 @@ Section gen_lemmas.
 
   (** * Prefixes: K for Kinding, KStp for kinded subtyping, Skd for subkinding. *)
 
-  Definition sf_sngl (T : oltyO Σ 0) : sf_kind Σ 0 := sf_kintv T T.
+  Definition sf_sngl (T : oltyO Σ) : sf_kind Σ := sf_kintv T T.
 
-  Lemma sK_Sing Γ (T : oltyO Σ 0) i :
+  Lemma sK_Sing Γ (T : oltyO Σ) i :
     ⊢ Γ s⊨ T ∷[ i ] sf_sngl T.
   Proof.
     rewrite -kinding_intro; iIntros "!> %ρ _". by rewrite -subtype_refl.
   Qed.
 
-  Lemma sKStp_Intv Γ (T1 T2 L U : oltyO Σ 0) i :
+  Lemma sKStp_Intv Γ (T1 T2 L U : oltyO Σ) i :
     Γ s⊨ T1 <:[i] T2 ∷ sf_kintv L U -∗
     Γ s⊨ T1 <:[i] T2 ∷ sf_kintv T1 T2.
   Proof.
@@ -222,7 +222,7 @@ Section gen_lemmas.
     by rewrite -!subtype_refl.
   Qed.
 
-  Lemma sK_Star Γ (T : oltyO Σ 0) i :
+  Lemma sK_Star Γ (T : oltyO Σ) i :
     ⊢ Γ s⊨ T ∷[ i ] sf_star.
   Proof.
     rewrite -kinding_intro; iIntros "!> %ρ _ !>".
@@ -230,7 +230,7 @@ Section gen_lemmas.
   Qed.
 
   (** Kind subsumption (for kinded subtyping). *)
-  Lemma sKStp_Sub Γ {n} (T1 T2 : oltyO Σ n) (K1 K2 : sf_kind Σ n) i :
+  Lemma sKStp_Sub Γ (T1 T2 : oltyO Σ) (K1 K2 : sf_kind Σ) i :
     Γ s⊨ T1 <:[ i ] T2 ∷ K1 -∗
     Γ s⊨ K1 <∷[ i ] K2 -∗
     Γ s⊨ T1 <:[ i ] T2 ∷ K2.
@@ -239,18 +239,18 @@ Section gen_lemmas.
   Qed.
 
   (** Kind subsumption (for kinding). *)
-  Lemma sK_Sub Γ {n} (T : oltyO Σ n) (K1 K2 : sf_kind Σ n) i :
+  Lemma sK_Sub Γ (T : oltyO Σ) (K1 K2 : sf_kind Σ) i :
     Γ s⊨ T ∷[ i ] K1 -∗
     Γ s⊨ K1 <∷[ i ] K2 -∗
     Γ s⊨ T ∷[ i ] K2.
   Proof. apply sKStp_Sub. Qed.
 
-  Lemma sK_Sing_deriv Γ (T : oltyO Σ 0) i :
+  Lemma sK_Sing_deriv Γ (T : oltyO Σ) i :
     ⊢ Γ s⊨ T ∷[ i ] sf_sngl T.
   Proof. rewrite -sKStp_Intv. apply sK_Star. Qed.
 
 
-  Lemma sKStp_Lam Γ {n} (K : sf_kind Σ n) S T1 T2 i :
+  Lemma sKStp_Lam Γ (K : sf_kind Σ) S T1 T2 i :
     oLaterN i (oShift S) :: Γ s⊨ T1 <:[i] T2 ∷ K -∗
     Γ s⊨ oLam T1 <:[i] oLam T2 ∷ sf_kpi S K.
   Proof using HswapProp.
@@ -261,13 +261,13 @@ Section gen_lemmas.
     by iApply (sf_kind_proper with "HTK").
   Qed.
 
-  Lemma sK_Lam Γ {n} (K : sf_kind Σ n) S T i :
+  Lemma sK_Lam Γ (K : sf_kind Σ) S T i :
     oLaterN i (oShift S) :: Γ s⊨ T ∷[i] K -∗
     Γ s⊨ oLam T ∷[i] sf_kpi S K.
   Proof using HswapProp. apply sKStp_Lam. Qed.
 
   (** * Subkinding *)
-  Lemma sSkd_Intv (L1 L2 U1 U2 : oltyO Σ 0) Γ i :
+  Lemma sSkd_Intv (L1 L2 U1 U2 : oltyO Σ) Γ i :
     Γ s⊨ L2 <:[ i ] L1 ∷ sf_star -∗
     Γ s⊨ U1 <:[ i ] U2 ∷ sf_star -∗
     Γ s⊨ sf_kintv L1 U1 <∷[ i ] sf_kintv L2 U2.
@@ -280,7 +280,7 @@ Section gen_lemmas.
     iApply (subtype_trans with "HsubU1 HsubU").
   Qed.
 
-  Lemma sSkd_Pi {n} (S1 S2 : oltyO Σ 0) (K1 K2 : sf_kind Σ n) Γ i :
+  Lemma sSkd_Pi (S1 S2 : oltyO Σ) (K1 K2 : sf_kind Σ) Γ i :
     Γ s⊨ S2 <:[ i ] S1 ∷ sf_star -∗
     oLaterN i (oShift S2) :: Γ s⊨ K1 <∷[ i ] K2 -∗
     Γ s⊨ sf_kpi S1 K1 <∷[ i ] sf_kpi S2 K2.
@@ -288,7 +288,7 @@ Section gen_lemmas.
     iIntros ">#HsubS >#HsubK !> %ρ #Hg /=".
     iPoseProof (ksubtyping_spec with "HsubS Hg") as "{HsubS} HsubS".
     iAssert (∀ arg : vl, let ρ' := arg .: ρ in
-            ▷^i (oClose S2 ρ arg → ∀ T1 T2 : hoLtyO Σ n,
+            ▷^i (oClose S2 ρ arg → ∀ T1 T2 : hoLtyO Σ,
             K1 ρ' T1 T2 → K2 ρ' T1 T2))%I as
             "{HsubK} #HsubK". {
       iIntros "%arg"; rewrite -mlaterN_impl.
@@ -302,11 +302,11 @@ Section gen_lemmas.
 
   (** Reflexivity and transitivity of subkinding seem admissible, but let's
   prove them anyway, to show they hold regardless of extensions. *)
-  Lemma sSkd_Refl {n} Γ i (K : sf_kind Σ n) :
+  Lemma sSkd_Refl Γ i (K : sf_kind Σ) :
     ⊢ Γ s⊨ K <∷[ i ] K.
   Proof. iIntros "!> %ρ Hg * !> $". Qed.
 
-  Lemma sSkd_Trans {n} Γ i (K1 K2 K3 : sf_kind Σ n) :
+  Lemma sSkd_Trans Γ i (K1 K2 K3 : sf_kind Σ) :
     Γ s⊨ K1 <∷[ i ] K2 -∗
     Γ s⊨ K2 <∷[ i ] K3 -∗
     Γ s⊨ K1 <∷[ i ] K3.
@@ -318,22 +318,22 @@ Section gen_lemmas.
 
   (** * Kinded subtyping. *)
 
-  Lemma sKStp_Refl Γ {n} T (K : sf_kind Σ n) i :
+  Lemma sKStp_Refl Γ T (K : sf_kind Σ) i :
     Γ s⊨ T ∷[ i ] K -∗
     Γ s⊨ T <:[ i ] T ∷ K.
   Proof. done. Qed.
 
-  Lemma sKEq_Refl {n} Γ T1 T2 (K : sf_kind Σ n) i :
+  Lemma sKEq_Refl Γ T1 T2 (K : sf_kind Σ) i :
     T1 ≡ T2 →
     Γ s⊨ T1 ∷[i] K -∗
     Γ s⊨ T1 =[i] T2 ∷ K.
   Proof. iIntros (Heq) "#H"; by iSplit; iApply (sstpiK_proper with "H"). Qed.
 
-  Lemma sTEq_Eta_acons {n} (T : oltyO Σ n.+1) arg args :
+  Lemma sTEq_Eta_acons (T : oltyO Σ) arg args :
     oLam (oTAppV (oShift T) (ids 0)) (acons arg args) ≡ T (acons arg args).
   Proof. move=>?? /=. autosubst. Qed.
 
-  Lemma sstpiK_mono_kpi i n Γ {T1 U1 T2 U2: olty Σ n.+1} S (K : sf_kind Σ n)
+  Lemma sstpiK_mono_kpi i Γ {T1 U1 T2 U2: olty Σ} S (K : sf_kind Σ)
     (HT : ∀ arg args ρ, envApply T2 ρ (acons arg args) ≡ envApply T1 ρ (acons arg args))
     (HU : ∀ arg args ρ, envApply U2 ρ (acons arg args) ≡ envApply U1 ρ (acons arg args)) :
     Γ s⊨ T1 <:[ i ] U1 ∷ sf_kpi S K ⊢ Γ s⊨ T2 <:[ i ] U2 ∷ sf_kpi S K.
@@ -342,22 +342,22 @@ Section gen_lemmas.
     by iApply (sf_kind_proper with "(HK HS)") => args; rewrite /acurry.
   Qed.
 
-  Lemma sKStp_EtaRed {n} Γ (K : sf_kind Σ n) S T1 T2 i :
+  Lemma sKStp_EtaRed Γ (K : sf_kind Σ) S T1 T2 i :
     Γ s⊨ oLam (oTAppV (oShift T1) (ids 0)) <:[ i ] oLam (oTAppV (oShift T2) (ids 0)) ∷ sf_kpi S K -∗
     Γ s⊨ T1 <:[ i ] T2 ∷ sf_kpi S K.
   Proof. apply sstpiK_mono_kpi; intros; apply symmetry, sTEq_Eta_acons. Qed.
 
-  Lemma sKStp_Eta_1 {n} Γ S T (K : sf_kind Σ n) i :
+  Lemma sKStp_Eta_1 Γ S T (K : sf_kind Σ) i :
     Γ s⊨ T ∷[i] sf_kpi S K -∗
     Γ s⊨ T <:[i] oLam (oTAppV (oShift T) (ids 0)) ∷ sf_kpi S K.
   Proof. apply sstpiK_mono_kpi; intros => //. exact: (sTEq_Eta_acons _ arg args). Qed.
 
-  Lemma sKStp_Eta_2 {n} Γ S T (K : sf_kind Σ n) i :
+  Lemma sKStp_Eta_2 Γ S T (K : sf_kind Σ) i :
     Γ s⊨ T ∷[i] sf_kpi S K -∗
     Γ s⊨ oLam (oTAppV (oShift T) (ids 0)) <:[i] T ∷ sf_kpi S K.
   Proof. apply sstpiK_mono_kpi; intros => //. exact: (sTEq_Eta_acons _ arg args). Qed.
 
-  Lemma sKEq_Eta {n} Γ S T (K : sf_kind Σ n) i :
+  Lemma sKEq_Eta Γ S T (K : sf_kind Σ) i :
     Γ s⊨ T ∷[i] sf_kpi S K -∗
     Γ s⊨ T =[i] oLam (oTAppV (oShift T) (ids 0)) ∷ sf_kpi S K.
   Proof. by iIntros "HT"; iSplit; [iApply sKStp_Eta_1|iApply sKStp_Eta_2]. Qed.
@@ -365,26 +365,26 @@ Section gen_lemmas.
   (** This lemma is a stronger version of [sTEq_Eta_acons]; it is
   controversial, and fails when [astream := list vl], but it enables simpler
   proofs of [sKStp_EtaRed] and [sKEq_Eta], without needing [sstpiK_mono_kpi]. *)
-  Lemma sTEq_Eta {n} (T : oltyO Σ n.+1) :
+  Lemma sTEq_Eta (T : oltyO Σ) :
     T ≡ oLam (oTAppV (oShift T) (ids 0)).
   Proof. Abort.
 
   Section with_sTEq_Eta.
-  Context (sTEq_Eta : ∀ n (T : oltyO Σ n.+1), T ≡ oLam (oTAppV (oShift T) (ids 0))).
+  Context (sTEq_Eta : ∀ (T : oltyO Σ), T ≡ oLam (oTAppV (oShift T) (ids 0))).
   Local Set Default Proof Using "sTEq_Eta".
 
-  Lemma sKStp_EtaRed_simpler {n} Γ (K : sf_kind Σ n) S T1 T2 i :
+  Lemma sKStp_EtaRed_simpler Γ (K : sf_kind Σ) S T1 T2 i :
     Γ s⊨ oLam (oTAppV (oShift T1) (ids 0)) <:[ i ] oLam (oTAppV (oShift T2) (ids 0)) ∷ sf_kpi S K -∗
     Γ s⊨ T1 <:[ i ] T2 ∷ sf_kpi S K.
   Proof. by rewrite -!sTEq_Eta. Qed.
 
-  Lemma sKEq_Eta_simpler {n} Γ S T (K : sf_kind Σ n) i :
+  Lemma sKEq_Eta_simpler Γ S T (K : sf_kind Σ) i :
     Γ s⊨ T ∷[i] sf_kpi S K -∗
     Γ s⊨ T =[i] oLam (oTAppV (oShift T) (ids 0)) ∷ sf_kpi S K.
   Proof. iApply sKEq_Refl. apply sTEq_Eta. Qed.
   End with_sTEq_Eta.
 
-  Lemma sKStp_Trans Γ {n} T1 T2 T3 (K : sf_kind Σ n) i :
+  Lemma sKStp_Trans Γ T1 T2 T3 (K : sf_kind Σ) i :
     Γ s⊨ T1 <:[ i ] T2 ∷ K -∗
     Γ s⊨ T2 <:[ i ] T3 ∷ K -∗
     Γ s⊨ T1 <:[ i ] T3 ∷ K.
@@ -396,10 +396,10 @@ Section gen_lemmas.
   (* Notation "" := sf_star. *)
   (* Notation "L  U" := (sf_kintv L U) (at level 70). *)
 
-  Lemma sKStp_Top Γ (T : oltyO Σ 0) i :
+  Lemma sKStp_Top Γ (T : oltyO Σ) i :
     ⊢ Γ s⊨ T <:[ i ] ⊤ ∷ sf_star.
   Proof. rewrite -ksubtyping_intro. iIntros "!> %ρ * _ * !> _ //". Qed.
-  Lemma sKStp_Bot Γ (T : oltyO Σ 0) i :
+  Lemma sKStp_Bot Γ (T : oltyO Σ) i :
     ⊢ Γ s⊨ ⊥ <:[ i ] T ∷ sf_star.
   Proof. rewrite -ksubtyping_intro; iIntros "!> %ρ * _ * !> []". Qed.
 
@@ -481,7 +481,7 @@ Section dot_types.
 
   (* Add a lemma like [sptp_subst_oMu], used below. *)
   (* We need a semantic substitution lemma?!? More importantly... one with mu types!?!? Oh dear. *)
-  Lemma sstpiK_subst_oMu {n} (K : sf_kind Σ n){Γ V T1 T2 v i}  :
+  Lemma sstpiK_subst_oMu (K : sf_kind Σ) {Γ V T1 T2 v i}  :
     Γ s⊨p pv v : oMu V, i -∗
     oLaterN i V :: Γ s⊨ T1 <:[ i ] T2 ∷ K -∗
     Γ s⊨ T1.|[v/] <:[ i ] T2.|[v/] ∷ K.|[v/].
@@ -493,7 +493,7 @@ Section dot_types.
       by rewrite hoEnvD_subst_one.
   Qed.
 
-  Lemma sKStp_App Γ {n} (K : sf_kind Σ n) S T1 T2 i p :
+  Lemma sKStp_App Γ (K : sf_kind Σ) S T1 T2 i p :
     Γ s⊨ T1 <:[i] T2 ∷ sf_kpi S K -∗
     Γ s⊨p p : S, i -∗
     Γ s⊨ oTApp T1 p <:[i] oTApp T2 p ∷ kpSubstOne p K.
@@ -505,14 +505,14 @@ Section dot_types.
       by rewrite (alias_paths_elim_eq _ Hal) path_wp_pv_eq.
   Qed.
 
-  Lemma sK_App Γ {n} (K : sf_kind Σ n) S T i p :
+  Lemma sK_App Γ (K : sf_kind Σ) S T i p :
     Γ s⊨ T ∷[i] sf_kpi S K -∗
     Γ s⊨p p : S, i -∗
     Γ s⊨ oTApp T p ∷[i] kpSubstOne p K.
   Proof. apply sKStp_App. Qed.
 
   (* Maybe not interesting *)
-  Lemma sKStp_AppV Γ {n} (K : sf_kind Σ n) {S T1 T2 i v} :
+  Lemma sKStp_AppV Γ (K : sf_kind Σ) {S T1 T2 i v} :
     Γ s⊨ T1 <:[i] T2 ∷ sf_kpi S K -∗
     Γ s⊨p pv v : S, i -∗
     Γ s⊨ oTAppV T1 v <:[i] oTAppV T2 v ∷ K.|[v/].
@@ -523,7 +523,7 @@ Section dot_types.
     iApply ("Happ" with "Hg").
   Qed.
 
-  Lemma sK_AppV Γ {n} (K : sf_kind Σ n) {S T i v} :
+  Lemma sK_AppV Γ (K : sf_kind Σ) {S T i v} :
     Γ s⊨ T ∷[i] sf_kpi S K -∗
     Γ s⊨p pv v : S, i -∗
     Γ s⊨ oTAppV T v ∷[i] K.|[v/].
@@ -533,7 +533,7 @@ Section dot_types.
   (* XXX Those two semantic types are definitionally equal; show that opSubst
   agrees with syntactic path substitution for gDOT.
   The closest thing we can state is [sem_psubst_one_eq]. *)
-  Lemma sKEq_Beta {n} Γ S T (K : sf_kind Σ n) i p :
+  Lemma sKEq_Beta Γ S T (K : sf_kind Σ) i p :
     Γ s⊨p p : S, i -∗
     oLaterN i (oShift S) :: Γ s⊨ T ∷[i] K -∗
     Γ s⊨ oTApp (oLam T) p =[i] T .sTp[ p /] ∷ kpSubstOne p K.
@@ -542,7 +542,7 @@ Section dot_types.
     rewrite sK_Lam. iApply (sK_App with "HK Hp").
   Qed.
 
-  Lemma sKEq_BetaV {n} Γ S T (K : sf_kind Σ n) i v :
+  Lemma sKEq_BetaV Γ S T (K : sf_kind Σ) i v :
     Γ s⊨p pv v : S, i -∗
     oLaterN i (oShift S) :: Γ s⊨ T ∷[i] K -∗
     Γ s⊨ oTAppV (oLam T) v =[i] T.|[v/] ∷ K.|[v/].
@@ -576,7 +576,7 @@ Section dot_types.
   Proof. apply ksubtyping_equiv. Qed.
 
 
-  Lemma sKStp_TMem {n} Γ l (K1 K2 : sf_kind Σ n) i :
+  Lemma sKStp_TMem Γ l (K1 K2 : sf_kind Σ) i :
     Γ s⊨ K1 <∷[ i ] K2 -∗
     Γ s⊨ oTMemK l K1 <:[ i ] oTMemK l K2 ∷ sf_star.
   Proof.
@@ -587,16 +587,16 @@ Section dot_types.
     iApply ("HK" with "HK1").
   Qed.
 
-  Lemma sKStp_TMem_AnyKind {n} Γ l (K : sf_kind Σ n) i :
+  Lemma sKStp_TMem_AnyKind Γ l (K : sf_kind Σ) i :
     ⊢ Γ s⊨ oTMemK l K <:[ i ] oTMemAnyKind l ∷ sf_star.
   Proof.
     rewrite -ksubtyping_intro; iIntros "!> %ρ #Hg * !>".
     iDestruct 1 as (d Hl φ) "[Hl _]".
-    iExists d; iFrame (Hl); iExists n, φ; iFrame "Hl".
+    iExists d; iFrame (Hl); iExists φ; iFrame "Hl".
   Qed.
 
   (** * Kinding *)
-  Lemma sK_Star_deriv Γ (T : oltyO Σ 0) i :
+  Lemma sK_Star_deriv Γ (T : oltyO Σ) i :
     ⊢ Γ s⊨ T ∷[ i ] sf_star.
   Proof.
     iApply sK_Sub. iApply sK_Sing.
@@ -606,7 +606,7 @@ Section dot_types.
   Qed.
 
   (** Generalization of [sD_Typ_Abs]. *)
-  Lemma sD_TypK_Abs {Γ n} T (K : sf_kind Σ n) s σ l:
+  Lemma sD_TypK_Abs {Γ} T (K : sf_kind Σ) s σ l:
     Γ s⊨ oLater T ∷[ 0 ] K -∗
     s ↝[ σ ] T -∗
     Γ s⊨ { l := dtysem σ s } : cTMemK l K.
@@ -618,9 +618,9 @@ Section dot_types.
     by rewrite -(Hγφ args ρ v).
   Qed.
 
-  Lemma sK_Sel {Γ n} l (K : sf_kind Σ n) p i :
+  Lemma sK_Sel {Γ} l (K : sf_kind Σ) p i :
     Γ s⊨p p : oTMemK l K, i -∗
-    Γ s⊨ oSelN n p l ∷[i] K.
+    Γ s⊨ oSel p l ∷[i] K.
   Proof.
     iIntros ">#Hp !> %ρ Hg"; iSpecialize ("Hp" with "Hg"); iNext i.
     rewrite path_wp_eq.
@@ -633,7 +633,7 @@ Section dot_types.
     iNext. by iRewrite "Hag".
   Qed.
 
-  Lemma sSngl_pq_KStp {Γ i p q n T1 T2} {K : sf_kind Σ n} :
+  Lemma sSngl_pq_KStp {Γ i p q T1 T2} {K : sf_kind Σ} :
     T1 ~sTpI[ p := q ]* T2 -∗
     Γ s⊨p p : oSing q, i -∗
     Γ s⊨ T1 ∷[i] K -∗
@@ -649,7 +649,7 @@ Section dot_types.
   Qed.
 
   (* This is the easy part :-) *)
-  Lemma sSngl_pq_KStp' {Γ i p q n T1 T2} {K1 K2 : sf_kind Σ n}
+  Lemma sSngl_pq_KStp' {Γ i p q T1 T2} {K1 K2 : sf_kind Σ}
     (* XXX we should use an internal version of this premise, as done for [sSngl_pq_KStp]. *)
     (Hrepl : K1 ~sKd[ p := q ]* K2) :
     Γ s⊨p p : oSing q, i -∗
@@ -678,7 +678,7 @@ Section s_kind_ofe.
   Proof. by apply (iso_ofe_mixin s_kind_to_sf_kind). Qed.
   Canonical Structure s_kindO := OfeT tpred s_kind_ofe_mixin.
 
-  Lemma s_kind_equiv_intro (K1 K2 : sf_kind Σ n) : K1 ≡@{sf_kind _ _} K2 → K1 ≡ K2.
+  Lemma s_kind_equiv_intro (K1 K2 : sf_kind Σ) : K1 ≡@{sf_kind _ _} K2 → K1 ≡ K2.
   Proof. apply. Qed.
 End s_kind_ofe.
 #[global] Arguments s_kindO : clear implicits. *)
@@ -689,7 +689,7 @@ Section derived.
   Context `{Hdlang : !dlangG Σ} `{HswapProp : SwapPropI Σ}.
   Opaque sSkd sstpiK sptp sstpi.
 
-  Lemma sT_New n Γ l σ s (K : sf_kind Σ n) T :
+  Lemma sT_New Γ l σ s (K : sf_kind Σ) T :
     oLater (oTMemK l K) :: Γ s⊨ oLater T ∷[ 0 ] K -∗
     s ↝[ σ ] T -∗
     Γ s⊨ vobj [ (l, dtysem σ s) ] : oMu (oTMemK l K).
@@ -744,7 +744,7 @@ Section derived.
   Qed.
 
   Lemma ho_sing_idemp {n} (K : s_kind Σ n) T :
-    s_to_sf (ho_sing (ho_sing K T) T) ≡@{sf_kind _ _}
+    s_to_sf (ho_sing (ho_sing K T) T) ≡@{sf_kind _}
     s_to_sf (ho_sing K T).
   Proof. elim: K T => [//|{}n S K +] T /=. by move->. Qed.
 
@@ -809,7 +809,7 @@ Section derived.
     iApply IHK; iApply (sK_Eta_Apply with "HK").
   Qed.
 
-  Lemma sT_New_Singl n Γ l σ s (K : s_kind Σ n) (T : olty Σ n) :
+  Lemma sT_New_Singl n Γ l σ s (K : s_kind Σ n) (T : olty Σ) :
     oLater (oTMemK l (s_to_sf (ho_sing K (oLater T)))) :: Γ s⊨ oLater T ∷[ 0 ] s_to_sf K -∗
     s ↝[ σ ] T -∗
     Γ s⊨ vobj [ (l, dtysem σ s) ] : oMu (oTMemK l (s_to_sf K)).
@@ -829,7 +829,7 @@ Section derived.
   (* #[global] Instance : Params (@bi_wand b) 1 := {}. *)
 
   (** Kind subsumption (for kinded subtyping). *)
-  Lemma sKEq_Sub Γ {n} (T1 T2 : oltyO Σ n) (K1 K2 : sf_kind Σ n) i :
+  Lemma sKEq_Sub Γ (T1 T2 : oltyO Σ) (K1 K2 : sf_kind Σ) i :
     Γ s⊨ T1 =[ i ] T2 ∷ K1 -∗
     Γ s⊨ K1 <∷[ i ] K2 -∗
     Γ s⊨ T1 =[ i ] T2 ∷ K2.
@@ -837,8 +837,8 @@ Section derived.
     iIntros "#(Hs1 & Hs2) #HKs"; iSplit; by iApply (sKStp_Sub with "[] HKs").
   Qed.
 (* Inductive s_kind {Σ} : nat → Type :=
-  | s_kintv : olty Σ 0 → olty Σ 0 → s_kind 0
-  | s_kpi n : olty Σ 0 → s_kind n → s_kind n.+1. *)
+  | s_kintv : olty Σ → olty Σ → s_kind 0
+  | s_kpi n : olty Σ → s_kind n → s_kind n.+1. *)
 
   (* XXX: Substituting [vPack] in types doesn't work robustly, so we should use an
   object-level [let] instead, or just assumptions on the typing context. *)
@@ -848,7 +848,7 @@ Section derived.
     let vPack := vobj [ (l, dtysem σ s) ] in
     oLater (oTMemK l (s_to_sf (ho_sing K (oLater T)))) :: Γ s⊨ oLater T ∷[ 0 ] s_to_sf K -∗
     s ↝[ σ ] T -∗
-      Γ s⊨ oSelN n (pv vPack) l =[0] oLater T .sTp[ vPack /] ∷ s_to_sf K.|[ vPack /].
+      Γ s⊨ oSel (pv vPack) l =[0] oLater T .sTp[ vPack /] ∷ s_to_sf K.|[ vPack /].
   Proof using HswapProp.
     iIntros (vPack) "#HK #Hs".
     iPoseProof (sK_HoSing with "HK") as "HK1".
@@ -878,7 +878,7 @@ Section derived.
   the system in his thesis. *)
   Lemma sK_Sel_Red {n} Γ p l (K : s_kind Σ n) i :
     Γ s⊨p p : oTMemK l (s_to_sf K), i -∗
-    Γ s⊨ oSelN n p l ∷[i] s_to_sf (ho_sing K (oSelN n p l)).
+    Γ s⊨ oSel p l ∷[i] s_to_sf (ho_sing K (oSel p l)).
   Proof using HswapProp. rewrite sK_Sel. apply sK_HoSing. Qed.
 
 End derived.
@@ -920,7 +920,7 @@ Section dot_experimental_kinds.
     by iApply (sKStp_Trans with "Hs1 HU").
   Qed.
 
-  Lemma failed_path_equality n Γ T l L U i (K : sf_kind Σ n) v w :
+  Lemma failed_path_equality Γ T l L U i (K : sf_kind Σ) v w :
     Γ s⊨ T ∷[i] sf_kpi (oTMemK l (sf_kintv L U)) K -∗
     Γ s⊨ oSel v l =[i] oSel w l ∷ sf_kintv L U -∗
     Γ s⊨ oTAppV T v <:[i] oTAppV T w ∷ K.|[v/].
@@ -964,7 +964,7 @@ Section dot_experimental_kinds.
     by rewrite !alias_paths_pv_eq_1 (alias_paths_elim_eq_pure _ Hal).
   Qed. *)
 
-  Program Definition kAnd (K1 K2 : sf_kind Σ 0) : sf_kind Σ 0 :=
+  Program Definition kAnd (K1 K2 : sf_kind Σ) : sf_kind Σ :=
     SfKind (λI ρ T1 T2, K1 ρ T1 T2 ∧ K2 ρ T1 T2).
   Next Obligation.
     move=> K1 K2 ρ n T1 T2 HT U1 U2 HU /=. f_equiv; exact: sf_kind_sub_ne_2.
@@ -999,7 +999,7 @@ Section dot_experimental_kinds.
    *)
   Definition isSing (T : lty Σ) := (∀ v1 v2, T v1 → T v2 → ⌜ v1 = v2 ⌝)%I.
 
-  Lemma isSing_respects_hoLty_equiv {n} {T1 T2 : hoLtyO Σ n} args:
+  Lemma isSing_respects_hoLty_equiv {T1 T2 : hoLtyO Σ} args:
     hoLty_equiv T1 T2 -∗ isSing (T1 args) -∗ isSing (T2 args).
   Proof using Type*.
     rewrite /isSing /=.
@@ -1008,7 +1008,7 @@ Section dot_experimental_kinds.
   Qed.
 
   (* Uh. Not actually checking subtyping, but passes requirements. [kSing] also checks requirements. *)
-  Program Definition kSing' : sf_kind Σ 0 :=
+  Program Definition kSing' : sf_kind Σ :=
     SfKind (λI ρ T1 T2, isSing (oClose T1) ∧ isSing (oClose T2)).
   Next Obligation. rewrite /isSing/=. solve_proper_ho. Qed.
 
@@ -1021,7 +1021,7 @@ Section dot_experimental_kinds.
   Next Obligation. iIntros "/= _" (T1 T2) "[$ _]". Qed.
   Next Obligation. iIntros "/= _" (T1 T2) "[_ $]". Qed.
 
-  Definition kSing (K : sf_kind Σ 0) : sf_kind Σ 0 := kAnd sf_star kSing'.
+  Definition kSing (K : sf_kind Σ) : sf_kind Σ := kAnd sf_star kSing'.
     (* SfKind (SrKind (λI ρ T1 T2, oClose T1 ⊆ oClose T2 ∧ ∀ v1 v2, oClose T2 v1 → oClose T2 v2 → ⌜ v1 = v2 ⌝)) _ _ _ _ _. *)
 End dot_experimental_kinds.
 End HkDot.

--- a/theories/Dot/hkdot/hkdot.v
+++ b/theories/Dot/hkdot/hkdot.v
@@ -367,7 +367,7 @@ Section gen_lemmas.
   proofs of [sKStp_EtaRed] and [sKEq_Eta], without needing [sstpiK_mono_kpi]. *)
   Lemma sTEq_Eta (T : oltyO Σ) :
     T ≡ oLam (oTAppV (oShift T) (ids 0)).
-  Proof. Abort.
+  Proof. move => [|x xs] ρ v; asimpl => //=. Abort.
 
   Section with_sTEq_Eta.
   Context (sTEq_Eta : ∀ (T : oltyO Σ), T ≡ oLam (oTAppV (oShift T) (ids 0))).

--- a/theories/Dot/hkdot/hkdot.v
+++ b/theories/Dot/hkdot/hkdot.v
@@ -367,7 +367,11 @@ Section gen_lemmas.
   proofs of [sKStp_EtaRed] and [sKEq_Eta], without needing [sstpiK_mono_kpi]. *)
   Lemma sTEq_Eta {n} (T : oltyO Σ n.+1) :
     T ≡ oLam (oTAppV (oShift T) (ids 0)).
-  Proof. move => + ρ v. apply: vec_S_inv => w args. autosubst. Qed.
+  Proof. Abort.
+
+  Section with_sTEq_Eta.
+  Context (sTEq_Eta : ∀ n (T : oltyO Σ n.+1), T ≡ oLam (oTAppV (oShift T) (ids 0))).
+  Local Set Default Proof Using "sTEq_Eta".
 
   Lemma sKStp_EtaRed_simpler {n} Γ (K : sf_kind Σ n) S T1 T2 i :
     Γ s⊨ oLam (oTAppV (oShift T1) (ids 0)) <:[ i ] oLam (oTAppV (oShift T2) (ids 0)) ∷ sf_kpi S K -∗
@@ -378,6 +382,7 @@ Section gen_lemmas.
     Γ s⊨ T ∷[i] sf_kpi S K -∗
     Γ s⊨ T =[i] oLam (oTAppV (oShift T) (ids 0)) ∷ sf_kpi S K.
   Proof. iApply sKEq_Refl. apply sTEq_Eta. Qed.
+  End with_sTEq_Eta.
 
   Lemma sKStp_Trans Γ {n} T1 T2 T3 (K : sf_kind Σ n) i :
     Γ s⊨ T1 <:[ i ] T2 ∷ K -∗

--- a/theories/Dot/hkdot/sem_kind.v
+++ b/theories/Dot/hkdot/sem_kind.v
@@ -1,7 +1,7 @@
 From Coq Require FunctionalExtensionality.
 From D Require Import iris_prelude proper proofmode_extra.
 From D Require Export succ_notation.
-From D Require Import saved_interp_dep asubst_intf dlang lty.
+From D Require Import saved_interp_n asubst_intf dlang lty.
 From D Require Import swap_later_impl.
 From D.Dot Require dot_lty unary_lr.
 
@@ -19,10 +19,10 @@ Module Type HoSemTypes
 
 (** A semantic kind of arity [n] induces an partial order representing
 subtyping on types of arity [n], indexed by environments. *)
-Notation sr_kind Σ n := (env → hoLtyO Σ n → hoLtyO Σ n → iPropO Σ).
-Notation sr_kindO Σ n := (env -d> hoLtyO Σ n -d> hoLtyO Σ n -d> iPropO Σ).
+Notation sr_kind Σ := (env → hoLtyO Σ → hoLtyO Σ → iPropO Σ).
+Notation sr_kindO Σ := (env -d> hoLtyO Σ -d> hoLtyO Σ -d> iPropO Σ).
 
-Definition hoLty_equiv {Σ n} (T1 T2 : hoLtyO Σ n) : iProp Σ :=
+Definition hoLty_equiv {Σ} (T1 T2 : hoLtyO Σ) : iProp Σ :=
   ∀ args v, T1 args v ↔ T2 args v.
 
 Lemma iff_sym `{PROP : bi} (A B : PROP) :
@@ -39,24 +39,24 @@ Proof.
   iApply ("H1" with "(H2 H)").
 Qed.
 
-Lemma hoLty_equiv_refl {Σ n} (T : hoLtyO Σ n) :
+Lemma hoLty_equiv_refl {Σ} (T : hoLtyO Σ) :
   ⊢ hoLty_equiv T T.
 Proof. iIntros "%args %v". by rewrite -equiv_iff. Qed.
 
-Lemma hoLty_equiv_sym {Σ n} (T1 T2 : hoLtyO Σ n) :
+Lemma hoLty_equiv_sym {Σ} (T1 T2 : hoLtyO Σ) :
   hoLty_equiv T1 T2 -∗ hoLty_equiv T2 T1.
 Proof. iIntros "H %args %v"; iApply (iff_sym with "H"). Qed.
 
-Lemma hoLty_equiv_split `{dlangG Σ} {n} args (T1 T2 : hoLtyO Σ n) :
+Lemma hoLty_equiv_split `{dlangG Σ} args (T1 T2 : hoLtyO Σ) :
   hoLty_equiv T1 T2 -∗ (T1 args ⊆ T2 args ⊆ T1 args).
 Proof. iIntros "Heq"; iSplit; iIntros "%v H"; iApply ("Heq" with "H"). Qed.
 
 
 (** * Semantic Full Kind. *)
-Record sf_kind {Σ n} := _SfKind {
-  sf_kind_sub :> sr_kind Σ n;
+Record sf_kind {Σ} := _SfKind {
+  sf_kind_sub :> sr_kind Σ;
   sf_kind_sub_ne_2 ρ : NonExpansive2 (sf_kind_sub ρ);
-  sf_kind_sub_internal_proper (T1 T2 U1 U2 : hoLtyO Σ n) ρ:
+  sf_kind_sub_internal_proper (T1 T2 U1 U2 : hoLtyO Σ) ρ:
     hoLty_equiv T1 T2 -∗
     hoLty_equiv U1 U2 -∗
     sf_kind_sub ρ T1 U1 -∗ sf_kind_sub ρ T2 U2;
@@ -74,18 +74,18 @@ Record sf_kind {Σ n} := _SfKind {
 Add Printing Constructor sf_kind.
 (* Existing Instance sf_kind_sub_ne. Using :> would create an ambiguous coercion to Funclass. *)
 #[global] Arguments sf_kind : clear implicits.
-#[global] Arguments sf_kind_sub {_ _} !_.
-#[global] Arguments _SfKind {_ _} _.
+#[global] Arguments sf_kind_sub {_} !_.
+#[global] Arguments _SfKind {_} _.
 Notation SfKind F := (_SfKind F notc_hole _ _ _ _).
 
 Declare Scope sf_kind_scope.
 Bind Scope sf_kind_scope with sf_kind.
 Delimit Scope sf_kind_scope with K.
-Notation kApp := (sf_kind_sub : sf_kind _ _ → sr_kindO _ _).
+Notation kApp := (sf_kind_sub : sf_kind _ → sr_kindO _).
 
 Section sf_kind_ofe.
-  Context {Σ} {n : nat}.
-  Notation tpred := (sf_kind Σ n).
+  Context {Σ}.
+  Notation tpred := (sf_kind Σ).
   (* Forces inserting coercions to -d>. *)
 
   Instance sf_kind_equiv : Equiv tpred := λ A B, kApp A ≡ B.
@@ -94,23 +94,23 @@ Section sf_kind_ofe.
   Proof. by apply (iso_ofe_mixin kApp). Qed.
   Canonical Structure sf_kindO := OfeT tpred sf_kind_ofe_mixin.
 
-  Lemma sf_kind_equiv_intro (K1 K2 : sf_kind Σ n) : kApp K1 ≡ kApp K2 → K1 ≡ K2.
+  Lemma sf_kind_equiv_intro (K1 K2 : sf_kind Σ) : kApp K1 ≡ kApp K2 → K1 ≡ K2.
   Proof. apply. Qed.
 End sf_kind_ofe.
 #[global] Arguments sf_kindO : clear implicits.
 
 
-Program Definition kSub {Σ n} (f : env → env) (K : sf_kind Σ n) : sf_kind Σ n :=
+Program Definition kSub {Σ} (f : env → env) (K : sf_kind Σ) : sf_kind Σ :=
   SfKind (λI ρ, K (f ρ)).
 Next Obligation.
-  move=> n f K ρ m T1 T2 HT U1 U2 HU /=; exact: sf_kind_sub_ne_2.
+  move=> Σ f K ρ n T1 T2 HT U1 U2 HU /=; exact: sf_kind_sub_ne_2.
 Qed.
 Next Obligation. intros; simpl; exact: sf_kind_sub_internal_proper. Qed.
 Next Obligation. intros; simpl; exact: sf_kind_sub_trans. Qed.
 Next Obligation. intros; simpl; exact: sf_kind_sub_quasi_refl_1. Qed.
 Next Obligation. intros; simpl; exact: sf_kind_sub_quasi_refl_2. Qed.
 
-#[global] Program Instance inhabited_sf_kind {Σ n}: Inhabited (sf_kind Σ n) :=
+#[global] Program Instance inhabited_sf_kind {Σ}: Inhabited (sf_kind Σ) :=
   populate $ SfKind (λI _ _ _, False).
 Next Obligation. done. Qed.
 Next Obligation. cbn; eauto. Qed.
@@ -118,21 +118,21 @@ Next Obligation. cbn; eauto. Qed.
 Next Obligation. cbn; eauto. Qed.
 Next Obligation. cbn; eauto. Qed.
 
-#[global] Instance ids_sf_kind {Σ n}: Ids (sf_kind Σ n) := λ _, inhabitant.
+#[global] Instance ids_sf_kind {Σ} : Ids (sf_kind Σ) := λ _, inhabitant.
 
-#[global] Instance hsubst_sf_kind {Σ n}: HSubst vl (sf_kind Σ n) :=
+#[global] Instance hsubst_sf_kind {Σ} : HSubst vl (sf_kind Σ) :=
   λ σ K, kSub (λ ρ, (σ >> ρ)) K.
 
 
-#[global] Instance sf_kind_sub_ne {Σ n m} :
-  Proper (dist m ==> (=) ==> dist m ==> dist m ==> dist m) (@sf_kind_sub Σ n).
+#[global] Instance sf_kind_sub_ne {Σ n} :
+  Proper (dist n ==> (=) ==> dist n ==> dist n ==> dist n) (@sf_kind_sub Σ).
 Proof.
   intros K1 K2 HK ρ ? <- T1 T2 HT U1 U2 HU.
   etrans; last exact: HK. by apply sf_kind_sub_ne_2.
   (* have ? := sf_kind_sub_ne_2 K1; rewrite HT HU. apply HK. *)
 Qed.
-#[global] Instance sf_kind_sub_proper {Σ n} :
-  Proper ((≡) ==> (=) ==> (≡) ==> (≡) ==> (≡)) (@sf_kind_sub Σ n).
+#[global] Instance sf_kind_sub_proper {Σ} :
+  Proper ((≡) ==> (=) ==> (≡) ==> (≡) ==> (≡)) (@sf_kind_sub Σ).
 Proof.
   intros K1 K2 HK ρ ? <- T1 T2 HT U1 U2 HU. etrans; last exact: HK.
   by apply ne_proper_2; [exact: sf_kind_sub_ne_2|..].
@@ -140,13 +140,13 @@ Proof.
   (* have Hp := !! (ne_proper_2 (K1 ρ)). *)
   (* rewrite HT HU; exact: HK. *)
 Qed.
-#[global] Instance: Params (@sf_kind_sub) 2 := {}.
+#[global] Instance: Params (@sf_kind_sub) 1 := {}.
 
-Lemma sf_kind_equivI {Σ n} (K1 K2 : sf_kindO Σ n):
+Lemma sf_kind_equivI {Σ} (K1 K2 : sf_kindO Σ):
   (∀ ρ T1 T2, K1 ρ T1 T2 ≡ K2 ρ T1 T2) ⊣⊢@{iPropI Σ} (K1 ≡ K2).
 Proof. by uPred.unseal. Qed.
 
-Lemma sf_kind_eq {Σ n} (K1 K2 : sf_kind Σ n) : sf_kind_sub K1 = sf_kind_sub K2 → K1 = K2.
+Lemma sf_kind_eq {Σ} (K1 K2 : sf_kind Σ) : sf_kind_sub K1 = sf_kind_sub K2 → K1 = K2.
 Proof.
   destruct K1, K2; cbn.
   intros ->. f_equal; exact: ProofIrrelevance.proof_irrelevance.
@@ -154,14 +154,14 @@ Qed.
 
 (* This is really properness of sf_kind_sub; but it's also proper over the
 first argument K. Maybe that's worth a wrapper with swapped arguments. *)
-Lemma sf_kind_proper {Σ n} (K : sf_kind Σ n) ρ :
+Lemma sf_kind_proper {Σ} (K : sf_kind Σ) ρ :
   Proper ((≡) ==> (≡) ==> (≡)) (K ρ).
 Proof. move=> T1 T2 HT U1 U2 HU. exact: sf_kind_sub_proper. Qed.
-Lemma sf_kind_proper' {Σ n} (K : sf_kind Σ n) ρ T1 T2 :
+Lemma sf_kind_proper' {Σ} (K : sf_kind Σ) ρ T1 T2 :
   T1 ≡ T2 → K ρ T1 T1 ≡ K ρ T2 T2.
 Proof. intros Heq. exact: sf_kind_proper. Qed.
 
-Lemma sfkind_respects `{dlangG Σ} {n} (K : sf_kind Σ n) ρ T1 T2 :
+Lemma sfkind_respects `{dlangG Σ} (K : sf_kind Σ) ρ T1 T2 :
   hoLty_equiv T1 T2 -∗ K ρ T1 T1 -∗ K ρ T2 T2.
 Proof. iIntros "#H". iApply (sf_kind_sub_internal_proper with "H H"). Qed.
 
@@ -173,51 +173,51 @@ Section sf_kind_subst.
   and only finally lift that over sf_kind. *)
   (* XXX Name. *)
 
-  #[global] Instance hsubst_sf_kind_lemmas {n} : HSubstLemmas vl (sf_kind Σ n).
+  #[global] Instance hsubst_sf_kind_lemmas : HSubstLemmas vl (sf_kind Σ).
   Proof.
     split; intros; apply sf_kind_eq; rewrite /hsubst_sf_kind/kSub/=; [|done|];
       f_ext => ρ; autosubst.
   Qed.
-  #[global] Instance rename_sf_kind n : Rename (sf_kind Σ n) := λ r K, K.|[ren r].
-  #[global] Instance sort_sf_kind n : Sort (sf_kind Σ n) := {}.
-  #[global] Instance hsubst_sf_kind_ne ρ n:
-    NonExpansive (hsubst (outer := sf_kind Σ n) ρ).
+  #[global] Instance rename_sf_kind : Rename (sf_kind Σ) := λ r K, K.|[ren r].
+  #[global] Instance sort_sf_kind : Sort (sf_kind Σ) := {}.
+  #[global] Instance hsubst_sf_kind_ne ρ :
+    NonExpansive (hsubst (outer := sf_kind Σ) ρ).
   Proof. solve_proper_ho. Qed.
 
-  #[global] Instance hsubst_sf_kind_proper ρ n:
-    Proper ((≡) ==> (≡)) (hsubst (outer := sf_kind Σ n) ρ) := ne_proper _.
+  #[global] Instance hsubst_sf_kind_proper ρ :
+    Proper ((≡) ==> (≡)) (hsubst (outer := sf_kind Σ) ρ) := ne_proper _.
 
-  Definition kSubstOne {Σ n} v (K : sf_kind Σ n) : sf_kind Σ n :=
+  Definition kSubstOne {Σ} v (K : sf_kind Σ) : sf_kind Σ :=
     kSub (λ ρ, v.[ρ] .: ρ) K.
-  Lemma kSubstOne_eq {n} (K : sf_kind Σ n) v ρ : sf_kind_sub K.|[v/] ρ = kSubstOne v K ρ.
+  Lemma kSubstOne_eq (K : sf_kind Σ) v ρ : sf_kind_sub K.|[v/] ρ = kSubstOne v K ρ.
   Proof. by rewrite /= subst_swap_base. Qed.
 
-  Definition kShift {Σ n} (K : sf_kind Σ n) : sf_kind Σ n :=
+  Definition kShift {Σ} (K : sf_kind Σ) : sf_kind Σ :=
     kSub (λ ρ, stail ρ) K.
 
   (** Analogue of [hoEnvD_subst_compose_ind]; the lemma setup here is however slightly
       simplified. *)
-  Lemma sf_kind_subst_compose {n} (K : sf_kind Σ n) ρ1 ρ2 T1 T2 :
+  Lemma sf_kind_subst_compose (K : sf_kind Σ) ρ1 ρ2 T1 T2 :
     K.|[ρ1] ρ2 T1 T2 ⊣⊢ K (ρ1 >> ρ2) T1 T2.
   Proof. done. Qed.
 
-  Lemma kShift_eq {n} (K : sf_kind Σ n) :
+  Lemma kShift_eq (K : sf_kind Σ) :
     kShift K ≡ shift K.
   Proof. intros ρ T1 T2. rewrite sf_kind_subst_compose. autosubst. Qed.
 
-  Lemma kShift_cancel {n} (K : sf_kind Σ n) v :
+  Lemma kShift_cancel (K : sf_kind Σ) v :
     (kShift K).|[v/] ≡ K.
   Proof. by rewrite kShift_eq shift_sub. Qed.
 
-  Lemma kShift_cancel' {n} (K : sf_kind Σ n) :
+  Lemma kShift_cancel' (K : sf_kind Σ) :
     K.|[up (ren (+1))].|[ids 0/] ≡ K.
   Proof. move=> ρ /=; f_equiv; autosubst. Qed.
 
-  Definition oLam {n} (τ : oltyO Σ n) : oltyO Σ n.+1 :=
+  Definition oLam (τ : oltyO Σ) : oltyO Σ :=
     Olty (λI args ρ, τ (atail args) (ahead args .: ρ)).
     (* auncurry (λ v, Olty (λ args ρ, τ args (v .: ρ))). *)
 
-  Definition _oTAppV {n} w (T : oltyO Σ n.+1) : oltyO Σ n :=
+  Definition _oTAppV w (T : oltyO Σ) : oltyO Σ :=
     Olty (λI args ρ, T (acons w.[ρ] args) ρ).
 
 End sf_kind_subst.
@@ -228,29 +228,29 @@ Notation oTAppV T w := (_oTAppV w T).
 Section utils.
   Context `{dlangG Σ}.
 
-  #[global] Instance _oTAppV_ne n v: NonExpansive (_oTAppV (Σ := Σ) (n := n) v).
+  #[global] Instance _oTAppV_ne v: NonExpansive (_oTAppV (Σ := Σ) v).
   Proof. solve_proper_ho. Qed.
-  #[global] Instance _oTAppV_proper n v:
-    Proper ((≡) ==> (≡)) (_oTAppV (Σ := Σ) (n := n) v) := ne_proper _.
+  #[global] Instance _oTAppV_proper v:
+    Proper ((≡) ==> (≡)) (_oTAppV (Σ := Σ) v) := ne_proper _.
 
-  #[global] Instance oLam_ne n : NonExpansive (oLam (Σ := Σ) (n := n)).
+  #[global] Instance oLam_ne : NonExpansive (oLam (Σ := Σ)).
   Proof. solve_proper_ho. Qed.
 
-  #[global] Instance oLam_proper n :
-    Proper ((≡) ==> (≡)) (oLam (Σ := Σ) (n := n)) := ne_proper _.
+  #[global] Instance oLam_proper :
+    Proper ((≡) ==> (≡)) (oLam (Σ := Σ)) := ne_proper _.
 
-  Lemma oTAppV_subst {n} (T : olty Σ n.+1) v ρ :
+  Lemma oTAppV_subst (T : olty Σ) v ρ :
     (oTAppV T v).|[ρ] ≡ oTAppV T.|[ρ] v.[ρ].
   Proof.
     move=> ???/=.
     by rewrite /hsubst /hsubst_hoEnvD subst_comp.
   Qed.
 
-  Lemma envApply_oTAppV_eq n (T : olty Σ n.+1) v ρ :
+  Lemma envApply_oTAppV_eq (T : olty Σ) v ρ :
     envApply (oTAppV T v) ρ ≡ acurry (envApply T ρ) v.[ρ].
   Proof. done. Qed.
 
-  Definition sr_kintv (L U : oltyO Σ 0) : sr_kind Σ 0 := λI ρ φ1 φ2,
+  Definition sr_kintv (L U : oltyO Σ) : sr_kind Σ := λI ρ φ1 φ2,
     oClose L ρ ⊆ oClose φ1 ⊆ oClose φ2 ⊆ oClose U ρ.
 
   Lemma sr_kintv_refl L U ρ φ :
@@ -259,7 +259,7 @@ Section utils.
     by rewrite /sr_kintv (bi_emp_valid_True subtype_refl) (left_id True)%I.
   Qed.
 
-  Lemma sr_kintv_respects_hoLty_equiv_1 {T1 T2} (L U : olty Σ 0) U1 ρ :
+  Lemma sr_kintv_respects_hoLty_equiv_1 {T1 T2} (L U : olty Σ) U1 ρ :
     hoLty_equiv T1 T2 -∗ sr_kintv L U ρ T1 U1 -∗ sr_kintv L U ρ T2 U1.
   Proof.
     rewrite !(hoLty_equiv_split anil).
@@ -268,7 +268,7 @@ Section utils.
     by iApply (subtype_trans with "HT2 HM").
   Qed.
 
-  Lemma sr_kintv_respects_hoLty_equiv_2 {U1 U2} (L U : olty Σ 0) T1 ρ :
+  Lemma sr_kintv_respects_hoLty_equiv_2 {U1 U2} (L U : olty Σ) T1 ρ :
     hoLty_equiv U1 U2 -∗ sr_kintv L U ρ T1 U1 -∗ sr_kintv L U ρ T1 U2.
   Proof.
     rewrite !(hoLty_equiv_split anil).
@@ -278,7 +278,7 @@ Section utils.
   Qed.
 End utils.
 
-Program Definition sf_kintv `{dlangG Σ} (L U : oltyO Σ 0) : sf_kind Σ 0 :=
+Program Definition sf_kintv `{dlangG Σ} (L U : oltyO Σ) : sf_kind Σ :=
   SfKind (sr_kintv L U).
 Next Obligation. cbn; solve_proper_ho. Qed.
 Next Obligation.
@@ -300,17 +300,17 @@ Qed.
 
 Notation sf_star := (sf_kintv oBot oTop).
 
-Lemma acurry_respects_hoLty_equiv {Σ n} {T1 T2 : hoLty Σ n.+1} arg :
+Lemma acurry_respects_hoLty_equiv {Σ} {T1 T2 : hoLty Σ} arg :
   hoLty_equiv T1 T2 -∗ hoLty_equiv (acurry T1 arg) (acurry T2 arg).
 Proof. by iIntros "H %%". Qed.
 
-Program Definition sf_kpi `{dlangG Σ} {n} (S : oltyO Σ 0) (K : sf_kind Σ n) :
-  sf_kind Σ n.+1 := SfKind
+Program Definition sf_kpi `{dlangG Σ} (S : oltyO Σ) (K : sf_kind Σ) :
+  sf_kind Σ := SfKind
     (λI ρ φ1 φ2,
       ∀ arg, S anil ρ arg →
       K (arg .: ρ) (acurry φ1 arg) (acurry φ2 arg)).
 Next Obligation.
-  move=> Σ ? ? n S K ρ m T1 T2 HT U1 U2 HU /=.
+  move=> Σ ? ? S K ρ n T1 T2 HT U1 U2 HU /=.
   f_equiv => ?; f_equiv.
   by apply sf_kind_sub_ne_2; apply acurry_ne.
 Qed.
@@ -339,12 +339,12 @@ Section kinds_types.
   #[global] Instance sf_kintv_proper :
     Proper ((≡) ==> (≡) ==> (≡)) (sf_kintv (Σ := Σ)) := ne_proper_2 _.
 
-  #[global] Instance sf_kpi_ne n : NonExpansive2 (sf_kpi (Σ := Σ) (n := n)).
+  #[global] Instance sf_kpi_ne : NonExpansive2 (sf_kpi (Σ := Σ)).
   Proof. solve_proper_ho. Qed.
-  #[global] Instance sf_kpi_proper {n} :
-    Proper ((≡) ==> (≡) ==> (≡)) (sf_kpi (Σ := Σ) (n := n)) := ne_proper_2 _.
+  #[global] Instance sf_kpi_proper :
+    Proper ((≡) ==> (≡) ==> (≡)) (sf_kpi (Σ := Σ)) := ne_proper_2 _.
 
-  Lemma kShift_sf_kpi_eq {n} S (K : sf_kind Σ n) :
+  Lemma kShift_sf_kpi_eq S (K : sf_kind Σ) :
     kShift (sf_kpi S K) ≡ sf_kpi (oShift S) K.|[up (ren (+1))].
   Proof.
     move=> ???/=; properness; first done; f_equiv.
@@ -352,11 +352,11 @@ Section kinds_types.
   Qed.
 
   (** Subtle: this requires [ahead] to be total! *)
-  Lemma sTEq_oLam_oLaterN {n} (τ : oltyO Σ n) m :
+  Lemma sTEq_oLam_oLaterN (τ : oltyO Σ) m :
     oLaterN m (oLam τ) ≡ oLam (oLaterN m τ).
   Proof. done. Qed.
 
-  Lemma sTEq_oTAppV_oLaterN {n} (τ : oltyO Σ n.+1) m v:
+  Lemma sTEq_oTAppV_oLaterN (τ : oltyO Σ) m v:
     oLaterN m (oTAppV τ v) ≡ oTAppV (oLaterN m τ) v.
   Proof. done. Qed.
 End kinds_types.
@@ -366,11 +366,11 @@ Module SKindSyn.
 (* XXX rename *)
 (** An inductive representation of gHkDOT semantic kinds. *)
 Inductive s_kind {Σ} : nat → Type :=
-  | s_kintv : oltyO Σ 0 → oltyO Σ 0 → s_kind 0
-  | s_kpi n : oltyO Σ 0 → s_kind n → s_kind n.+1.
+  | s_kintv : oltyO Σ → oltyO Σ → s_kind 0
+  | s_kpi n : oltyO Σ → s_kind n → s_kind n.+1.
 #[global] Arguments s_kind: clear implicits.
 
-Inductive s_kind_rel {Σ} {R : relation (oltyO Σ 0)} : ∀ {n : nat}, relation (s_kind Σ n) :=
+Inductive s_kind_rel {Σ} {R : relation (oltyO Σ)} : ∀ {n : nat}, relation (s_kind Σ n) :=
   | s_kintv_rel L1 L2 U1 U2 :
     R L1 L2 → R U1 U2 →
     s_kind_rel (s_kintv L1 U1) (s_kintv L2 U2)
@@ -381,7 +381,7 @@ Inductive s_kind_rel {Σ} {R : relation (oltyO Σ 0)} : ∀ {n : nat}, relation 
 #[global] Arguments s_kind_rel {_} R _ _ _.
 
 Section s_kind_rel_prop.
-  Context `{R : relation (oltyO Σ 0)}.
+  Context `{R : relation (oltyO Σ)}.
   #[global] Instance s_kind_rel_refl n `(!Reflexive R) : Reflexive (s_kind_rel R n).
   Proof. elim; constructor; eauto. Qed.
 
@@ -418,7 +418,7 @@ End s_kind_ofe.
 Canonical Structure s_kindO Σ n := OfeT (s_kind Σ n) s_kind_ofe_mixin.
 
 Section s_kind_rel_proper.
-  Context `{R : relation (oltyO Σ 0)}.
+  Context `{R : relation (oltyO Σ)}.
 
   #[global] Instance s_kintv_proper_s_kind_rel : Proper (R ==> R ==> s_kind_rel R 0) s_kintv.
   Proof. constructor; auto. Qed.
@@ -464,7 +464,7 @@ Proof.
       by rewrite !hsubst_comp ?IHK ?up_comp.
 Qed.
 
-Fixpoint s_kind_to_sf_kind `{dlangG Σ} {n} (K : s_kind Σ n) : sf_kind Σ n :=
+Fixpoint s_kind_to_sf_kind `{dlangG Σ} {n} (K : s_kind Σ n) : sf_kind Σ :=
   match K with
   | s_kintv L U => sf_kintv L U
   | s_kpi S K => sf_kpi S (s_kind_to_sf_kind K)
@@ -483,7 +483,7 @@ Section s_kind_to_sf_kind.
   #[global] Instance s_kind_to_sf_kind_proper {n} :
     Proper ((≡) ==> (≡)) (s_kind_to_sf_kind (n := n)) := ne_proper _.
 
-  Lemma s_kind_equiv_intro {n} (K1 K2 : s_kind Σ n) : K1 ≡ K2 → s_to_sf K1 ≡@{sf_kind _ _} s_to_sf K2.
+  Lemma s_kind_equiv_intro {n} (K1 K2 : s_kind Σ n) : K1 ≡ K2 → s_to_sf K1 ≡@{sf_kind _} s_to_sf K2.
   Proof. apply s_kind_to_sf_kind_proper. Qed.
 
   Lemma s_kind_to_sf_kind_subst {n} (K : s_kind Σ n) ρ :
@@ -495,7 +495,7 @@ Section s_kind_to_sf_kind.
   Qed.
 End s_kind_to_sf_kind.
 
-Fixpoint ho_intv {Σ n} (K : s_kindO Σ n) : oltyO Σ n → oltyO Σ n → s_kindO Σ n :=
+Fixpoint ho_intv {Σ n} (K : s_kindO Σ n) : oltyO Σ → oltyO Σ → s_kindO Σ n :=
   match K with
   | s_kintv _ _ =>
     λ T1 T2, s_kintv T1 T2
@@ -554,15 +554,15 @@ Implicit Types
          (v w : vl) (e : tm) (d : dm) (ds : dms) (p : path)
          (ρ : var → vl) (l : label).
 
-Definition sem_kind_path_repl {Σ n} p q (K1 K2 : sf_kind Σ n) : Prop :=
+Definition sem_kind_path_repl {Σ} p q (K1 K2 : sf_kind Σ) : Prop :=
   ∀ ρ T1 T2, alias_paths p.|[ρ] q.|[ρ] → K1 ρ T1 T2 ≡ K2 ρ T1 T2.
 Notation "K1 ~sKd[ p := q  ]* K2" :=
   (sem_kind_path_repl p q K1 K2) (at level 70).
 
-Definition oDTMemK `{!dlangG Σ} {n} (K : sf_kind Σ n) : dltyO Σ :=
-  oDTMemRaw n (λI ρ ψ, K ρ (packHoLtyO ψ) (packHoLtyO ψ)).
+Definition oDTMemK `{!dlangG Σ} (K : sf_kind Σ) : dltyO Σ :=
+  oDTMemRaw (λI ρ ψ, K ρ (packHoLtyO ψ) (packHoLtyO ψ)).
 
-Definition oDTMemSpec `{!dlangG Σ} (L U : oltyO Σ 0) : dltyO Σ :=
+Definition oDTMemSpec `{!dlangG Σ} (L U : oltyO Σ) : dltyO Σ :=
   oDTMemK (sf_kintv L U).
 
 Lemma oDTMemSpec_oDTMem_eq `{!dlangG Σ} L U : oDTMemSpec L U ≡ oDTMem L U.
@@ -570,19 +570,19 @@ Proof.
   move=> ρ d /=; f_equiv=> ψ; f_equiv. apply sr_kintv_refl.
 Qed.
 
-Definition cTMemK `{!dlangG Σ} {n} l (K : sf_kind Σ n) : clty Σ := dty2clty l (oDTMemK K).
+Definition cTMemK `{!dlangG Σ} l (K : sf_kind Σ) : clty Σ := dty2clty l (oDTMemK K).
 Notation oTMemK l K := (clty_olty (cTMemK l K)).
 
 Definition oDTMemAnyKind `{!dlangG Σ} : dltyO Σ := Dlty (λI ρ d,
-  ∃ n (ψ : hoD Σ n), d ↗n[ n ] ψ).
+  ∃ (ψ : hoD Σ), d ↗n ψ).
 Definition cTMemAnyKind `{!dlangG Σ} l : clty Σ := dty2clty l oDTMemAnyKind.
 Notation oTMemAnyKind l := (clty_olty (cTMemAnyKind l)).
 
-Program Definition kpSubstOne `{!dlangG Σ} {n} p (K : sf_kind Σ n) : sf_kind Σ n :=
+Program Definition kpSubstOne `{!dlangG Σ} p (K : sf_kind Σ) : sf_kind Σ :=
   SfKind
     (λI ρ T1 T2, path_wp p.|[ρ] (λ v, K (v .: ρ) T1 T2)).
 Next Obligation.
-  move=> Σ ? n K v ρ m T1 T2 HT U1 U2 HU /=. f_equiv=>?. exact: sf_kind_sub_ne_2.
+  move=> Σ ? p K v m T1 T2 HT U1 U2 HU /=. f_equiv=>?. exact: sf_kind_sub_ne_2.
 Qed.
 Next Obligation.
   iIntros "* #Heq1 #Heq2 H". iApply (path_wp_wand with "H");
@@ -603,59 +603,59 @@ Next Obligation.
 Qed.
 Notation "K .sKp[ p /]" := (kpSubstOne p K) (at level 65).
 
-Definition oTApp `{!dlangG Σ} {n} (T : oltyO Σ n.+1) (p : path) : oltyO Σ n :=
+Definition oTApp `{!dlangG Σ} (T : oltyO Σ) (p : path) : oltyO Σ :=
   Olty (λ args ρ v, path_wp p.|[ρ] (λ w, T (acons w args) ρ v)).
 
 Section proper_eq.
   Context `{!dlangG Σ}.
 
-  #[global] Instance oDTMemK_ne n : NonExpansive (oDTMemK (Σ := Σ) (n := n)).
+  #[global] Instance oDTMemK_ne : NonExpansive (oDTMemK (Σ := Σ)).
   Proof. solve_proper_ho. Qed.
-  #[global] Instance oDTMemK_proper n :
-    Proper ((≡) ==> (≡)) (oDTMemK (Σ := Σ) (n := n)) := ne_proper _.
-  #[global] Instance cTMemK_ne n l : NonExpansive (cTMemK (Σ := Σ) (n := n) l).
+  #[global] Instance oDTMemK_proper :
+    Proper ((≡) ==> (≡)) (oDTMemK (Σ := Σ)) := ne_proper _.
+  #[global] Instance cTMemK_ne l : NonExpansive (cTMemK (Σ := Σ) l).
   Proof. solve_proper_ho. Qed.
-  #[global] Instance cTMemK_proper n l :
-    Proper ((≡) ==> (≡)) (cTMemK (Σ := Σ) (n := n) l) := ne_proper _.
+  #[global] Instance cTMemK_proper l :
+    Proper ((≡) ==> (≡)) (cTMemK (Σ := Σ) l) := ne_proper _.
 
-  Lemma cTMemK_eq {n} l (K : sf_kind Σ n) d ρ :
+  Lemma cTMemK_eq l (K : sf_kind Σ) d ρ :
     cTMemK l K ρ [(l, d)] ⊣⊢ oDTMemK K ρ d.
   Proof. apply dty2clty_singleton. Qed.
 
-  Lemma oTMemK_eq n l K args ρ v :
+  Lemma oTMemK_eq l K args ρ v :
     oTMemK l K args ρ v ⊣⊢
-    ∃ ψ d, ⌜v @ l ↘ d⌝ ∧ d ↗n[ n ] ψ ∧ K ρ (packHoLtyO ψ) (packHoLtyO ψ).
+    ∃ ψ d, ⌜v @ l ↘ d⌝ ∧ d ↗n ψ ∧ K ρ (packHoLtyO ψ) (packHoLtyO ψ).
   Proof. apply bi_exist_nested_swap. Qed.
 
   Lemma cTMemAnyKind_eq l d ρ :
     cTMemAnyKind l ρ [(l, d)] ⊣⊢ oDTMemAnyKind ρ d.
   Proof. apply dty2clty_singleton. Qed.
 
-  Lemma cTMemK_subst {n} l (K : sf_kind Σ n) ρ :
+  Lemma cTMemK_subst l (K : sf_kind Σ) ρ :
     (oTMemK l K).|[ρ] = oTMemK l K.|[ρ].
   Proof. done. Qed.
 
-  Lemma kpSubstOne_eq {n} (K : sf_kind Σ n) v :
+  Lemma kpSubstOne_eq (K : sf_kind Σ) v :
     K.|[v/] ≡ K .sKp[ pv v /].
   Proof. move=> ???. by rewrite /= path_wp_pv_eq subst_swap_base. Qed.
 
-  Lemma oTApp_pv {n} (T : oltyO Σ n.+1) w :
+  Lemma oTApp_pv (T : oltyO Σ) w :
     oTApp T (pv w) ≡ oTAppV T w.
   Proof. intros ???. by rewrite /= path_wp_pv_eq. Qed.
 
-  Lemma sTEq_oTApp_pv_oLaterN {n} (τ : oltyO Σ n.+1) m v:
+  Lemma sTEq_oTApp_pv_oLaterN (τ : oltyO Σ) m v:
     oLaterN m (oTApp τ (pv v)) ≡ oTApp (oLaterN m τ) (pv v).
   Proof. by rewrite !oTApp_pv. Qed.
 
-  Lemma sTEq_oTApp_oLaterN {n} (τ : oltyO Σ n.+1) m p args ρ v:
+  Lemma sTEq_oTApp_oLaterN (τ : oltyO Σ) m p args ρ v:
     oTApp (oLaterN m τ) p args ρ v ⊢ oLaterN m (oTApp τ p) args ρ v.
   Proof. by rewrite /= path_wp_laterN_swap. Qed.
 
-  Lemma sTEq_Beta {n} (T : oltyO Σ n) p :
+  Lemma sTEq_Beta (T : oltyO Σ) p :
     oTApp (oLam T) p ≡ T .sTp[ p /].
   Proof. done. Qed.
 
-  Lemma sTEq_BetaV {n} (T : oltyO Σ n) v :
+  Lemma sTEq_BetaV (T : oltyO Σ) v :
     oTAppV (oLam T) v ≡ T.|[v/].
   Proof. move => args ρ w /=. by rewrite subst_swap_base. Qed.
 

--- a/theories/Dot/lr/dot_lty.v
+++ b/theories/Dot/lr/dot_lty.v
@@ -29,7 +29,7 @@ That is, semantics for both definition lists and values, and proofs that they
 agree appropriately. *)
 Record clty {Σ} := _Clty {
   clty_dslty :> dslty Σ;
-  clty_olty : oltyO Σ 0;
+  clty_olty : oltyO Σ;
   clty_def2defs_head {l d ds ρ} :
     clty_dslty ρ [(l, d)] ⊢ clty_dslty ρ ((l, d) :: ds);
   clty_mono {l d ds ρ} :
@@ -81,13 +81,13 @@ Definition lift_dty_dms `{!dlangG Σ} l (TD : dltyO Σ) : dsltyO Σ := Dslty (λ
   ∃ d, ⌜ dms_lookup l ds = Some d ⌝ ∧ TD ρ d).
 Instance: Params (@lift_dty_dms) 3 := {}.
 
-Definition lift_dty_vl `{!dlangG Σ} l (TD : dltyO Σ) : oltyO Σ 0 :=
+Definition lift_dty_vl `{!dlangG Σ} l (TD : dltyO Σ) : oltyO Σ :=
   olty0 (λI ρ v, ∃ d, ⌜v @ l ↘ d ⌝ ∧ TD ρ d).
 Instance: Params (@lift_dty_vl) 3 := {}.
 
 (** This definition is only useful to show in [lift_dty_vl_equiv_paper] that
 certain definitions we give are equivalent to the ones in the paper. *)
-Definition lift_dty_vl_paper `{!dlangG Σ} (TD : dsltyO Σ) : oltyO Σ 0 := olty0 (λI ρ v,
+Definition lift_dty_vl_paper `{!dlangG Σ} (TD : dsltyO Σ) : oltyO Σ := olty0 (λI ρ v,
   ∃ ds, ⌜v = vobj ds⌝ ∧ TD ρ (selfSubst ds)).
 
 Section lift_dty_lemmas.
@@ -97,7 +97,7 @@ Section lift_dty_lemmas.
     lift_dty_vl l T ≡ lift_dty_vl_paper (lift_dty_dms l T).
   Proof.
     (* The proof is just a quantifier swap. *)
-    move=> args ρ v /=; rewrite bi_exist_nested_swap; f_equiv => d.
+    move=> args ρ v /=. rewrite bi_exist_nested_swap; f_equiv => d.
     setoid_rewrite (assoc bi_and); rewrite -and_exist_r /objLookup; f_equiv.
     by iIntros "!% /=".
   Qed.
@@ -125,7 +125,7 @@ Section lift_dty_lemmas.
   Qed.
 End lift_dty_lemmas.
 
-Program Definition olty2clty `{!dlangG Σ} (U : oltyO Σ 0) : cltyO Σ :=
+Program Definition olty2clty `{!dlangG Σ} (U : oltyO Σ) : cltyO Σ :=
   Clty ⊥ U.
 Solve All Obligations with by iIntros.
 #[global] Instance: Params (@olty2clty) 2 := {}.
@@ -208,7 +208,7 @@ Notation "Ds⟦ T ⟧" := (clty_dslty C⟦ T ⟧).
 
 (* We could inline [pty_interp] inside the [V⟦ _ ⟧] notation, but I suspect
 the [V⟦ _ ⟧*] notation needs [pty_interp] to be a first-class function. *)
-Definition pty_interp `{CTyInterp Σ} T : oltyO Σ 0 := clty_olty C⟦ T ⟧.
+Definition pty_interp `{CTyInterp Σ} T : oltyO Σ := clty_olty C⟦ T ⟧.
 #[global] Arguments pty_interp {_ _} !_ /.
 
 (** * Value interpretation of types (Fig. 9). *)

--- a/theories/Dot/lr/later_sub_sem.v
+++ b/theories/Dot/lr/later_sub_sem.v
@@ -59,7 +59,7 @@ Section TypeEquiv.
 End TypeEquiv.
 
 (* This is specialized to [anil] because contexts only contain proper types anyway. *)
-Definition s_ty_sub `{HdlangG: !dlangG Σ} (T1 T2 : oltyO Σ 0) := ∀ ρ v, T1 anil ρ v -∗ T2 anil ρ v.
+Definition s_ty_sub `{HdlangG: !dlangG Σ} (T1 T2 : oltyO Σ) := ∀ ρ v, T1 anil ρ v -∗ T2 anil ρ v.
 Notation "s⊨T T1 <: T2" := (s_ty_sub T1 T2) (at level 74, T1, T2 at next level).
 
 Definition ty_sub `{HdlangG: !dlangG Σ} T1 T2 := s⊨T V⟦ T1 ⟧ <: V⟦ T2 ⟧.

--- a/theories/Dot/lr/sem_unstamped_typing.v
+++ b/theories/Dot/lr/sem_unstamped_typing.v
@@ -75,7 +75,7 @@ Notation "Γ u⊨ e : T" := (iuetp Γ T e) (at level 74, e, T at next level).
 Theorem unstamped_s_safety_dot_sem
   Σ `{HdlangG : !dlangG Σ} `{HswapProp : !SwapPropI Σ}
   {e_u}
-  (τ : ∀ `{!dlangG Σ}, olty Σ 0)
+  (τ : ∀ `{!dlangG Σ}, olty Σ)
   (Hwp : ∀ `{!dlangG Σ} `(!SwapPropI Σ), ⊢ [] su⊨ e_u : τ):
   safe e_u.
 Proof.
@@ -106,7 +106,7 @@ Qed.
 
 #[local] Hint Resolve same_skel_dms_hasnt : core.
 
-Definition coveringσ `{!dlangG Σ} {i} σ (T : olty Σ i) : Prop :=
+Definition coveringσ `{!dlangG Σ} σ (T : olty Σ) : Prop :=
   ∀ args ρ, T args ρ ≡ T args (∞ σ.|[ρ]).
 
 Section coveringσ_intro_lemmas.
@@ -120,14 +120,14 @@ Section coveringσ_intro_lemmas.
   Qed.
 
   (* Maybe hard to use in general; [nclosed] requires equality on the nose? *)
-  Lemma nclosed_sem_coveringσ {n} {T : olty Σ 0} (Hcl : nclosed T n) :
+  Lemma nclosed_sem_coveringσ {n} {T : olty Σ} (Hcl : nclosed T n) :
     coveringσ (idsσ n) T.
   Proof.
     move=> args ρ v.
     by rewrite -olty_finsubst_commute_cl ?length_idsσ // closed_subst_idsρ.
   Qed.
 
-  Lemma coveringσ_shift {i} σ (T : olty Σ i) :
+  Lemma coveringσ_shift σ (T : olty Σ) :
     coveringσ σ T → coveringσ (push_var σ) (shift T).
   Proof.
     move => + args ρ => /(_ args (stail ρ)) HclT; cbn.
@@ -139,26 +139,26 @@ End coveringσ_intro_lemmas.
 Section tmem_unstamped_lemmas.
   Context `{!dlangG Σ}.
 
-  Lemma leadsto_envD_equiv_alloc {σ i} {T : olty Σ i}
+  Lemma leadsto_envD_equiv_alloc {σ} {T : olty Σ}
     (Hcl : coveringσ σ T): ⊢ |==> ∃ s, s ↝[ σ ] T.
   Proof.
-    iMod (saved_ho_sem_type_alloc _ T) as (s) "#Hs"; iIntros "!>".
+    iMod (saved_ho_sem_type_alloc T) as (s) "#Hs"; iIntros "!>".
     iExists s, T; iFrame "Hs"; iIntros "!%". apply Hcl.
   Qed.
 
-  Lemma leadsto_envD_equiv_alloc_shift {σ} {T : olty Σ 0} :
+  Lemma leadsto_envD_equiv_alloc_shift {σ} {T : olty Σ} :
     coveringσ σ T →
     ⊢ |==> ∃ s, s ↝[ push_var σ ] shift T.
   Proof. intros Hcl; apply leadsto_envD_equiv_alloc, coveringσ_shift, Hcl. Qed.
 
-  Lemma suD_Typ_Gen {l Γ fakeT s σ} {T : olty Σ 0} :
+  Lemma suD_Typ_Gen {l Γ fakeT s σ} {T : olty Σ} :
     s ↝[ σ ] T -∗ Γ su⊨ { l := dtysyn fakeT } : cTMem l (oLater T) (oLater T).
   Proof.
     iIntros "#Hs"; iModIntro. iExists (dtysem σ s).
     iSplit; first done; iApply (sD_Typ with "Hs").
   Qed.
 
-  Lemma suD_Typ {l σ Γ fakeT} {T : olty Σ 0} (HclT : coveringσ σ T):
+  Lemma suD_Typ {l σ Γ fakeT} {T : olty Σ} (HclT : coveringσ σ T):
     ⊢ Γ su⊨ { l := dtysyn fakeT } : cTMem l (oLater T) (oLater T).
   Proof.
     iMod (leadsto_envD_equiv_alloc HclT) as (s) "#Hs".

--- a/theories/Dot/lr/unary_lr.v
+++ b/theories/Dot/lr/unary_lr.v
@@ -39,7 +39,7 @@ Implicit Types (Σ : gFunctors)
 
 Section judgments.
   Context {Σ}.
-  Implicit Types (τ : oltyO Σ 0).
+  Implicit Types (τ : oltyO Σ).
 
   (** Expression typing *)
   Definition setp `{!dlangG Σ} e Γ τ : iProp Σ :=
@@ -62,9 +62,9 @@ Section judgments.
   #[global] Arguments sdtp : simpl never.
 
   (** Path typing *)
-  Definition sptp `{!dlangG Σ} p i Γ (T : oltyO Σ 0): iProp Σ :=
+  Definition sptp `{!dlangG Σ} p i Γ τ : iProp Σ :=
     |==> ∀ ρ, sG⟦Γ⟧* ρ →
-      ▷^i path_wp p.|[ρ] (oClose T ρ).
+      ▷^i path_wp p.|[ρ] (oClose τ ρ).
   #[global] Arguments sptp : simpl never.
 End judgments.
 
@@ -97,22 +97,22 @@ Section JudgEqs.
 End JudgEqs.
 
 (** When a definition points to a semantic type. Inlined in paper. *)
-Definition dm_to_type `{HdotG: !dlangG Σ} d i (ψ : hoD Σ i) : iProp Σ :=
-  ∃ s σ, ⌜ d = dtysem σ s ⌝ ∧ s ↗n[ σ , i ] ψ.
-Notation "d ↗n[ i  ] ψ" := (dm_to_type d i ψ) (at level 20).
+Definition dm_to_type `{HdotG: !dlangG Σ} d (ψ : hoD Σ) : iProp Σ :=
+  ∃ s σ, ⌜ d = dtysem σ s ⌝ ∧ s ↗n[ σ ] ψ.
+Notation "d ↗n ψ" := (dm_to_type d ψ) (at level 20).
 
 Section dm_to_type.
   Context `{HdotG: !dlangG Σ}.
 
-  Lemma dm_to_type_agree {d i ψ1 ψ2} args v : d ↗n[ i ] ψ1 -∗ d ↗n[ i ] ψ2 -∗ ▷ (ψ1 args v ≡ ψ2 args v).
+  Lemma dm_to_type_agree {d ψ1 ψ2} args v : d ↗n ψ1 -∗ d ↗n ψ2 -∗ ▷ (ψ1 args v ≡ ψ2 args v).
   Proof.
     iDestruct 1 as (s σ ?) "#Hs1".
     iDestruct 1 as (s' σ' ?) "#Hs2".
     simplify_eq. by iApply (stamp_σ_to_type_agree args with "Hs1 Hs2").
   Qed.
 
-  Lemma dm_to_type_intro d i s σ φ :
-    d = dtysem σ s → s ↝n[ i ] φ -∗ d ↗n[ i ] hoEnvD_inst σ φ.
+  Lemma dm_to_type_intro d s σ φ :
+    d = dtysem σ s → s ↝n φ -∗ d ↗n hoEnvD_inst σ φ.
   Proof.
     iIntros. iExists s, σ. iFrame "%".
     by iApply stamp_σ_to_type_intro.
@@ -124,12 +124,12 @@ End dm_to_type.
 (** ** Semantic path substitution and replacement. *)
 
 (** Semantic substitution of path in type. *)
-Definition opSubst `{!dlangG Σ} {n} p (T : oltyO Σ n) : oltyO Σ n :=
+Definition opSubst `{!dlangG Σ} p (T : oltyO Σ) : oltyO Σ :=
   Olty (λI args ρ v, path_wp p.|[ρ] (λ w, T args (w .: ρ) v)).
 Notation "T .sTp[ p /]" := (opSubst p T) (at level 65).
 
 (** Semantic definition of path replacement. *)
-Definition sem_ty_path_replI {Σ n} p q (T1 T2 : olty Σ n) : iProp Σ :=
+Definition sem_ty_path_replI {Σ} p q (T1 T2 : olty Σ) : iProp Σ :=
   |==> ∀ args ρ v (H : alias_paths p.|[ρ] q.|[ρ]), T1 args ρ v ≡ T2 args ρ v.
 Notation "T1 ~sTpI[ p := q  ]* T2" :=
   (sem_ty_path_replI p q T1 T2) (at level 70).
@@ -137,7 +137,7 @@ Notation "T1 ~sTpI[ p := q  ]* T2" :=
 (** Semantic definition of path replacement: alternative, weaker version.
 Unlike [sem_ty_path_replI], this version in [Prop] is less expressive, but
 sufficient for our goals and faster to use in certain proofs. *)
-Definition sem_ty_path_repl {Σ n} p q (T1 T2 : olty Σ n) : Prop :=
+Definition sem_ty_path_repl {Σ} p q (T1 T2 : olty Σ) : Prop :=
   ∀ args ρ v, alias_paths p.|[ρ] q.|[ρ] → T1 args ρ v ≡ T2 args ρ v.
 Notation "T1 ~sTpP[ p := q  ]* T2" :=
   (sem_ty_path_repl p q T1 T2) (at level 70).
@@ -145,41 +145,40 @@ Notation "T1 ~sTpP[ p := q  ]* T2" :=
 Section path_repl.
   Context `{!dlangG Σ}.
 
-  Lemma opSubst_pv_eq {n} v (T : oltyO Σ n) : T .sTp[ pv v /] ≡ T.|[v/].
+  Lemma opSubst_pv_eq v (T : oltyO Σ) : T .sTp[ pv v /] ≡ T.|[v/].
   Proof. move=> args ρ w /=. by rewrite path_wp_pv_eq subst_swap_base. Qed.
 
-  Lemma sem_psubst_one_repl {n} {T : olty Σ n} {args p v w ρ}:
+  Lemma sem_psubst_one_repl {T : olty Σ} {args p v w ρ}:
     alias_paths p.|[ρ] (pv v) →
     T .sTp[ p /] args ρ w ≡ T args (v .: ρ) w.
   Proof. move=> /alias_paths_elim_eq /= ->. by rewrite path_wp_pv_eq. Qed.
 
-  Lemma sem_ty_path_repl_eq {n} {p q} {T1 T2 : olty Σ n} :
+  Lemma sem_ty_path_repl_eq {p q} {T1 T2 : olty Σ} :
     T1 ~sTpP[ p := q ]* T2 → ⊢ T1 ~sTpI[ p := q ]* T2.
   Proof. iIntros "%Heq !% /=". apply: Heq. Qed.
   (* The reverse does not hold. *)
 End path_repl.
 
 (** ** gDOT semantic types. *)
-Definition vl_sel `{!dlangG Σ} {n} vp l args v : iProp Σ :=
-  ∃ d ψ, ⌜vp @ l ↘ d⌝ ∧ d ↗n[ n ] ψ ∧ packHoLtyO ψ args v.
+Definition vl_sel `{!dlangG Σ} vp l args v : iProp Σ :=
+  ∃ d ψ, ⌜vp @ l ↘ d⌝ ∧ d ↗n ψ ∧ packHoLtyO ψ args v.
 
-Definition oSelN `{!dlangG Σ} n p l : oltyO Σ n :=
+Definition oSel `{!dlangG Σ} p l : oltyO Σ :=
   Olty (λI args ρ v, path_wp p.|[ρ] (λ vp, vl_sel vp l args v)).
-Notation oSel := (oSelN 0).
 
 Section sem_types.
   Context `{HdotG: !dlangG Σ}.
-  Implicit Types (τ : oltyO Σ 0).
+  Implicit Types (τ : oltyO Σ).
 
-  Definition oDTMemRaw n (rK : env → hoD Σ n → iProp Σ): dltyO Σ := Dlty (λI ρ d,
-    ∃ ψ, d ↗n[ n ] ψ ∧ rK ρ ψ).
+  Definition oDTMemRaw (rK : env → hoD Σ → iProp Σ): dltyO Σ := Dlty (λI ρ d,
+    ∃ ψ, d ↗n ψ ∧ rK ρ ψ).
 
   (** Not a "real" kind, just a predicate over types. *)
   Definition dot_intv_type_pred τ1 τ2 ρ ψ : iProp Σ :=
     τ1 anil ρ ⊆ packHoLtyO ψ anil ∧ packHoLtyO ψ anil ⊆ τ2 anil ρ.
 
   (** [ D⟦ { A :: τ1 .. τ2 } ⟧ ]. *)
-  Definition oDTMem τ1 τ2 : dltyO Σ := oDTMemRaw _ (dot_intv_type_pred τ1 τ2).
+  Definition oDTMem τ1 τ2 : dltyO Σ := oDTMemRaw (dot_intv_type_pred τ1 τ2).
   #[global] Instance oDTMem_proper : Proper ((≡) ==> (≡) ==> (≡)) oDTMem.
   Proof.
     rewrite /oDTMem => ??? ??? ??/=; properness; try reflexivity;
@@ -223,13 +222,13 @@ Section sem_types.
     cVMem l T ρ [(l, d)] ⊣⊢ oDVMem T ρ d.
   Proof. apply dty2clty_singleton. Qed.
 
-  Lemma oSel_pv {n} w l args ρ v :
-    oSelN n (pv w) l args ρ v ⊣⊢
-      ∃ d ψ, ⌜w.[ρ] @ l ↘ d⌝ ∧ d ↗n[ n ] ψ ∧ ▷ ψ args v.
+  Lemma oSel_pv w l args ρ v :
+    oSel (pv w) l args ρ v ⊣⊢
+      ∃ d ψ, ⌜w.[ρ] @ l ↘ d⌝ ∧ d ↗n ψ ∧ ▷ ψ args v.
   Proof. by rewrite /= path_wp_pv_eq. Qed.
 
   (** [ V⟦ p.type ⟧]. *)
-  Definition oSing `{!dlangG Σ} p : olty Σ 0 := olty0 (λI ρ v, ⌜alias_paths p.|[ρ] (pv v)⌝).
+  Definition oSing `{!dlangG Σ} p : olty Σ := olty0 (λI ρ v, ⌜alias_paths p.|[ρ] (pv v)⌝).
 
   (** [ V⟦ ∀ x: τ1. τ2 ⟧]. *)
   (* Function types; this definition is contractive (similarly to what's
@@ -243,7 +242,7 @@ Section sem_types.
   Proof. solve_proper_ho. Qed.
 
   (** Semantics of primitive types. *)
-  Definition oPrim b : olty Σ 0 := olty0 (λI ρ v, ⌜pure_interp_prim b v⌝).
+  Definition oPrim b : olty Σ := olty0 (λI ρ v, ⌜pure_interp_prim b v⌝).
 
   (** Dispatch function defining [V⟦ T ⟧] and [Ds⟦ T ⟧]. *)
   (* Observe the naming pattern for semantic type constructors:
@@ -291,7 +290,7 @@ End sem_types.
 
 #[global] Instance: Params (@oAll) 2 := {}.
 
-Notation "d ↗ ψ" := (dm_to_type 0 d ψ) (at level 20).
+Notation "d ↗ ψ" := (dm_to_type d ψ) (at level 20).
 Notation "G⟦ Γ ⟧ ρ" := (sG⟦ V⟦ Γ ⟧* ⟧* ρ) (at level 10).
 
 (** Single-definition typing *)
@@ -345,7 +344,7 @@ End judgment_definitions.
 
 Section misc_lemmas.
   Context `{HdotG: !dlangG Σ}.
-  Implicit Types (τ L T U : olty Σ 0).
+  Implicit Types (τ L T U : olty Σ).
 
   Lemma iterate_TLater_oLater i (T : ty) :
     V⟦iterate TLater i T⟧ ≡ oLaterN i V⟦T⟧.
@@ -362,7 +361,7 @@ Section misc_lemmas.
 
   Lemma oTMem_eq l τ1 τ2 args ρ v :
     oTMem l τ1 τ2 args ρ v ⊣⊢
-    ∃ ψ d, ⌜v @ l ↘ d⌝ ∧ d ↗n[ 0 ] ψ ∧ dot_intv_type_pred τ1 τ2 ρ ψ.
+    ∃ ψ d, ⌜v @ l ↘ d⌝ ∧ d ↗n ψ ∧ dot_intv_type_pred τ1 τ2 ρ ψ.
   Proof. apply bi_exist_nested_swap. Qed.
 
   Lemma oTMem_shift A L U : oTMem A (shift L) (shift U) = shift (oTMem A L U).

--- a/theories/Dot/semtyp_lemmas/defs_lr.v
+++ b/theories/Dot/semtyp_lemmas/defs_lr.v
@@ -69,7 +69,7 @@ Section Sec.
     iApply (oDTMem_respects_sub with "(HL Hg) (HU Hg) Hd").
   Qed.
 
-  Lemma sD_Typ {Γ s σ} {T : oltyO Σ 0} l:
+  Lemma sD_Typ {Γ s σ} {T : oltyO Σ} l:
     s ↝[ σ ] T -∗
     Γ s⊨ { l := dtysem σ s } : cTMem l (oLater T) (oLater T).
   Proof.

--- a/theories/Dot/semtyp_lemmas/path_repl_lr.v
+++ b/theories/Dot/semtyp_lemmas/path_repl_lr.v
@@ -173,7 +173,7 @@ Section semantic_lemmas.
 
   (* Suppose path typing required termination *now* rather than later:
 
-    Definition sptp `{!dlangG Σ} p i Γ (T : oltyO Σ 0): iProp Σ :=
+    Definition sptp `{!dlangG Σ} p i Γ (T : oltyO Σ): iProp Σ :=
      ∀ ρ, sG⟦Γ⟧* ρ →
 -      ▷^i path_wp p.|[ρ] (λ v, oClose T ρ v).
 +      path_wp p.|[ρ] (λ v, ▷^i oClose T ρ v).


### PR DESCRIPTION
Final version of #338 and #346. All the changes that could have been split out, have been (see #343, #345, and small commits on `master`).

Rationale for dropping the dependency:
- we want to add syntax for these semantic types and kinds;
- we don't want to make that syntax dependently-typed, since Coq doesn't support that well;
- it's annoying to write an interpreter with type `ty -> ∃ n, olty Σ n`.

This MR switches the type of arguments `astream` from `vec vl n` to `list vl`.
1. Almost the entire theory survives (but sees #345 and the first commit).
2. However, `ahead : astream -> vl` becomes partial, breaking `sTEq_Eta`; that'll be fixed by switching `astream` to `nat -> vl` (in #342 / #348), similarly to what we did for environments ages ago.