### PR TITLE
Reimplement cTMem & c. over cTMemK

### DIFF
--- a/theories/Dot/examples/sem/no_russell_paradox.v
+++ b/theories/Dot/examples/sem/no_russell_paradox.v
@@ -39,7 +39,7 @@ Section Russell.
   (** Yes, v has a valid type member. *)
   Lemma vHasA: Hs ⊢ oTMem "A" oBot oTop anil ids v.
   Proof.
-    iIntros "#Hs".
+    rewrite oTMem_unfold. iIntros "#Hs".
     iExists _; iSplit. by iExists _; iSplit.
     iExists _; iSplit. by iApply dm_to_type_intro.
     by repeat iSplit; iIntros "% **".

--- a/theories/Dot/hkdot/sem_kind.v
+++ b/theories/Dot/hkdot/sem_kind.v
@@ -1,6 +1,6 @@
 From Coq Require FunctionalExtensionality.
-From D Require Import iris_prelude proper proofmode_extra.
-From D Require Export succ_notation.
+From D Require Import iris_prelude proofmode_extra.
+From D Require Export succ_notation proper. (* We export proper to use [sr_kintv_proper]. *)
 From D Require Import saved_interp_n asubst_intf dlang lty.
 From D Require Import swap_later_impl.
 
@@ -275,11 +275,17 @@ Section utils.
     by iApply (subtype_trans with "HM HU1").
     by iApply (subtype_trans with "HU2 HU").
   Qed.
+
+  #[global] Instance sr_kintv_ne n : Proper ((dist n) ==> (dist n) ==> eq ==> (dist n) ==> (dist n) ==> (dist n)) sr_kintv.
+  Proof. solve_proper_ho. Qed.
+
+  #[global] Instance sr_kintv_proper : Proper ((≡) ==> (≡) ==> eq ==> (≡) ==> (≡) ==> (≡)) sr_kintv.
+  Proof. solve_proper_ho. Qed.
 End utils.
 
 Program Definition sf_kintv `{dlangG Σ} (L U : oltyO Σ) : sf_kind Σ :=
   SfKind (sr_kintv L U).
-Next Obligation. cbn; solve_proper_ho. Qed.
+Next Obligation. cbn; intros. move=>??????. exact: sr_kintv_ne. Qed.
 Next Obligation.
   iIntros "* HT HU H"; iApply (sr_kintv_respects_hoLty_equiv_2 with "HU").
   iApply (sr_kintv_respects_hoLty_equiv_1 with "HT H").

--- a/theories/Dot/hkdot/sem_kind_dot.v
+++ b/theories/Dot/hkdot/sem_kind_dot.v
@@ -83,17 +83,31 @@ Definition oDTMem_eq : oDTMem = _ := oDTMem_aux.(seal_eq).
 Typeclasses Opaque oDTMem.
 #[global] Opaque oDTMem.
 
+
+#[global] Instance equiv_ext_dfun4_ppf {A B C D} : subrelation (≡@{A -d> B -d> C -d> D})
+              (pointwise_relation A (pointwise_relation B (forall_relation (const (≡))))).
+Proof. done. Qed.
+
+#[global] Instance equiv_ext_dfun4_ppp {A B C D} : subrelation (≡@{A -d> B -d> C -d> D})
+              (pointwise_relation A (pointwise_relation B (pointwise_relation C (≡)))).
+Proof. done. Qed.
+
+#[global] Instance equiv_ext_dfun3_pp {A B C} : subrelation (≡@{A -d> B -d> C})
+              (pointwise_relation A (pointwise_relation B (≡))).
+Proof. done. Qed.
+
+
 Section sem_TMem.
   Context `{HdotG: !dlangG Σ}.
   Implicit Types (τ : oltyO Σ).
 
-  Lemma oDTMem_unfold : oDTMem = λ L U, oDTMemRaw (dot_intv_type_pred L U).
+  Lemma oDTMem_unfold : oDTMem ≡@{_ -d> _ -d> dltyO Σ} λ L U, oDTMemRaw (dot_intv_type_pred L U).
   Proof. by rewrite oDTMem_eq. Qed.
 
   #[global] Instance oDTMem_proper : Proper ((≡) ==> (≡) ==> (≡)) oDTMem.
   Proof.
-    rewrite oDTMem_unfold => ??? ??? ??/=; properness; try reflexivity;
-      solve_proper_ho.
+    move=> ??? ??? ??/=. rewrite oDTMem_unfold /=.
+    properness; try reflexivity; solve_proper_ho.
   Qed.
 
   (** Define [cTMem] by lifting [oDTMem] to [clty]s. *)
@@ -107,7 +121,7 @@ Section sem_TMem.
   Proof. solve_proper. Qed.
 
   Lemma cTMem_unfold :
-    cTMem = λ l L U, dty2clty l (oDTMemRaw (dot_intv_type_pred L U)).
+    cTMem ≡@{_ -d> _ -d> _ -d> cltyO Σ} λ l L U, dty2clty l (oDTMemRaw (dot_intv_type_pred L U)).
   Proof. by rewrite /cTMem oDTMem_eq. Qed.
 
   Lemma cTMem_eq l L U d ρ :
@@ -121,7 +135,7 @@ Section oTMem_lemmas.
   Context `{HdotG: !dlangG Σ}.
 
   Lemma oTMem_unfold l L U :
-    oTMem l L U = clty_olty (dty2clty l (oDTMemRaw (dot_intv_type_pred L U))).
+    oTMem l L U ≡ clty_olty (dty2clty l (oDTMemRaw (dot_intv_type_pred L U))).
   Proof. by rewrite cTMem_unfold. Qed.
 
   Lemma oTMem_eq l L U args ρ v :

--- a/theories/Dot/hkdot/sem_kind_dot.v
+++ b/theories/Dot/hkdot/sem_kind_dot.v
@@ -70,14 +70,10 @@ Definition dot_intv_type_pred `{!dlangG Σ} (L U : oltyO Σ) ρ ψ : iProp Σ :=
   L anil ρ ⊆ packHoLtyO ψ anil ∧ packHoLtyO ψ anil ⊆ U anil ρ.
 
 (** [ D⟦ { A :: τ1 .. τ2 } ⟧ ]. *)
-Definition oDTMem_def `{!dlangG Σ} L U : dltyO Σ := oDTMemK (sf_kintv L U).
-Definition oDTMem_aux : seal (@oDTMem_def). Proof. by eexists. Qed.
-Definition oDTMem := oDTMem_aux.(unseal).
-Definition oDTMem_eq : oDTMem = _ := oDTMem_aux.(seal_eq).
+Definition oDTMem `{!dlangG Σ} L U : dltyO Σ := oDTMemK (sf_kintv L U).
+Definition oDTMem_eq `{!dlangG Σ} : oDTMem = λ L U, oDTMemK (sf_kintv L U) := reflexivity _.
 
 #[global] Arguments oDTMem {_ _} _ _  _ : assert.
-Typeclasses Opaque oDTMem.
-#[global] Opaque oDTMem.
 
 Section sem_TMem.
   Context `{HdotG: !dlangG Σ}.
@@ -90,7 +86,7 @@ Section sem_TMem.
 
   #[global] Instance oDTMem_proper : Proper ((≡) ==> (≡) ==> (≡)) oDTMem.
   Proof.
-    move=> ??? ??? ??/=. rewrite !oDTMem_unfold/=.
+    move=> ??? ??? ??. rewrite !oDTMem_unfold/=.
     properness; try reflexivity; solve_proper_ho.
   Qed.
 

--- a/theories/Dot/hkdot/sem_kind_dot.v
+++ b/theories/Dot/hkdot/sem_kind_dot.v
@@ -20,8 +20,7 @@ Implicit Types
          (ρ : var → vl) (l : label).
 
 (** * Type members *)
-Definition oDTMemRaw `{!dlangG Σ} (rK : env → hoD Σ → iProp Σ): dltyO Σ := Dlty (λI ρ d,
-  ∃ ψ, d ↗n ψ ∧ rK ρ ψ).
+Notation oDTMemRaw rK := (Dlty (λI ρ d, ∃ ψ, d ↗n ψ ∧ rK ρ ψ)).
 
 (** [ D⟦ { A :: K } ⟧ ]. *)
 Definition oDTMemK `{!dlangG Σ} (K : sf_kind Σ) : dltyO Σ :=

--- a/theories/Dot/hkdot/sem_kind_dot.v
+++ b/theories/Dot/hkdot/sem_kind_dot.v
@@ -107,7 +107,7 @@ Section sem_TMem.
 
   Lemma cTMem_unfold l L U :
     cTMem l L U ≡ dty2clty l (oDTMemRaw (dot_intv_type_pred L U)).
-  Proof. by rewrite /cTMem oDTMem_eq. Qed.
+  Proof. by rewrite /cTMem oDTMem_unfold. Qed.
 
   Lemma cTMem_eq l L U d ρ :
     cTMem l L U ρ [(l, d)] ⊣⊢ oDTMem L U ρ d.

--- a/theories/Dot/hkdot/sem_kind_dot.v
+++ b/theories/Dot/hkdot/sem_kind_dot.v
@@ -85,10 +85,7 @@ Section sem_TMem.
   Qed.
 
   #[global] Instance oDTMem_proper : Proper ((≡) ==> (≡) ==> (≡)) oDTMem.
-  Proof.
-    move=> ??? ??? ??. rewrite !oDTMem_unfold/=.
-    properness; try reflexivity; solve_proper_ho.
-  Qed.
+  Proof. move=> ??? ??? ??/=. properness; [done|]. exact: sr_kintv_proper. Qed.
 
   (** Define [cTMem] by lifting [oDTMem] to [clty]s. *)
   (**
@@ -164,6 +161,12 @@ Notation "K .sKp[ p /]" := (kpSubstOne p K) (at level 65).
 
 Section proper_eq.
   Context `{!dlangG Σ}.
+
+  #[global] Instance oTApp_ne n : Proper ((dist n) ==> eq ==> (dist n)) oTApp.
+  Proof. move=> T1 T2 HT. solve_proper_prepare. apply: path_wp_ne=>v. exact: HT. Qed.
+
+  #[global] Instance oTApp_proper : Proper ((≡) ==> eq ==> (≡)) oTApp.
+  Proof. move=> T1 T2 HT. solve_proper_prepare. apply: path_wp_proper=>v. exact: HT. Qed.
 
   Lemma kpSubstOne_eq (K : sf_kind Σ) v :
     K.|[v/] ≡ K .sKp[ pv v /].

--- a/theories/Dot/hkdot/sem_kind_dot.v
+++ b/theories/Dot/hkdot/sem_kind_dot.v
@@ -83,31 +83,17 @@ Definition oDTMem_eq : oDTMem = _ := oDTMem_aux.(seal_eq).
 Typeclasses Opaque oDTMem.
 #[global] Opaque oDTMem.
 
-
-#[global] Instance equiv_ext_dfun4_ppf {A B C D} : subrelation (≡@{A -d> B -d> C -d> D})
-              (pointwise_relation A (pointwise_relation B (forall_relation (const (≡))))).
-Proof. done. Qed.
-
-#[global] Instance equiv_ext_dfun4_ppp {A B C D} : subrelation (≡@{A -d> B -d> C -d> D})
-              (pointwise_relation A (pointwise_relation B (pointwise_relation C (≡)))).
-Proof. done. Qed.
-
-#[global] Instance equiv_ext_dfun3_pp {A B C} : subrelation (≡@{A -d> B -d> C})
-              (pointwise_relation A (pointwise_relation B (≡))).
-Proof. done. Qed.
-
-
 Section sem_TMem.
   Context `{HdotG: !dlangG Σ}.
   Implicit Types (τ : oltyO Σ).
 
-  Lemma oDTMem_unfold : oDTMem ≡@{_ -d> _ -d> dltyO Σ} λ L U, oDTMemRaw (dot_intv_type_pred L U).
+  Lemma oDTMem_unfold : oDTMem = λ L U, oDTMemRaw (dot_intv_type_pred L U).
   Proof. by rewrite oDTMem_eq. Qed.
 
   #[global] Instance oDTMem_proper : Proper ((≡) ==> (≡) ==> (≡)) oDTMem.
   Proof.
-    move=> ??? ??? ??/=. rewrite oDTMem_unfold /=.
-    properness; try reflexivity; solve_proper_ho.
+    rewrite oDTMem_unfold => ??? ??? ??/=; properness; try reflexivity;
+      solve_proper_ho.
   Qed.
 
   (** Define [cTMem] by lifting [oDTMem] to [clty]s. *)
@@ -121,7 +107,7 @@ Section sem_TMem.
   Proof. solve_proper. Qed.
 
   Lemma cTMem_unfold :
-    cTMem ≡@{_ -d> _ -d> _ -d> cltyO Σ} λ l L U, dty2clty l (oDTMemRaw (dot_intv_type_pred L U)).
+    cTMem = λ l L U, dty2clty l (oDTMemRaw (dot_intv_type_pred L U)).
   Proof. by rewrite /cTMem oDTMem_eq. Qed.
 
   Lemma cTMem_eq l L U d ρ :
@@ -135,7 +121,7 @@ Section oTMem_lemmas.
   Context `{HdotG: !dlangG Σ}.
 
   Lemma oTMem_unfold l L U :
-    oTMem l L U ≡ clty_olty (dty2clty l (oDTMemRaw (dot_intv_type_pred L U))).
+    oTMem l L U = clty_olty (dty2clty l (oDTMemRaw (dot_intv_type_pred L U))).
   Proof. by rewrite cTMem_unfold. Qed.
 
   Lemma oTMem_eq l L U args ρ v :

--- a/theories/Dot/hkdot/sem_kind_dot.v
+++ b/theories/Dot/hkdot/sem_kind_dot.v
@@ -70,11 +70,11 @@ End TMem_Proper.
 
 (** ** Type members: derive special case for gDOT. *)
 (** Not a "real" kind, just a predicate over types. *)
-Definition dot_intv_type_pred `{!dlangG Σ} (τ1 τ2 : oltyO Σ) ρ ψ : iProp Σ :=
-  τ1 anil ρ ⊆ packHoLtyO ψ anil ∧ packHoLtyO ψ anil ⊆ τ2 anil ρ.
+Definition dot_intv_type_pred `{!dlangG Σ} (L U : oltyO Σ) ρ ψ : iProp Σ :=
+  L anil ρ ⊆ packHoLtyO ψ anil ∧ packHoLtyO ψ anil ⊆ U anil ρ.
 
 (** [ D⟦ { A :: τ1 .. τ2 } ⟧ ]. *)
-Definition oDTMem_def `{!dlangG Σ} τ1 τ2 : dltyO Σ := oDTMemRaw (dot_intv_type_pred τ1 τ2).
+Definition oDTMem_def `{!dlangG Σ} L U : dltyO Σ := oDTMemRaw (dot_intv_type_pred L U).
 Definition oDTMem_aux : seal (@oDTMem_def). Proof. by eexists. Qed.
 Definition oDTMem := oDTMem_aux.(unseal).
 Definition oDTMem_eq : oDTMem = _ := oDTMem_aux.(seal_eq).
@@ -102,32 +102,32 @@ Section sem_TMem.
   Beware: the ICFP'20 defines instead
   [ Ds⟦ { l >: τ1 <: τ2 } ⟧] and [ V⟦ { l >: τ1 <: τ2 } ⟧ ],
   which are here a derived notation; see [cTMemL]. *)
-  Definition cTMem l τ1 τ2 : clty Σ := dty2clty l (oDTMem τ1 τ2).
+  Definition cTMem l L U : clty Σ := dty2clty l (oDTMem L U).
   #[global] Instance cTMem_proper l : Proper ((≡) ==> (≡) ==> (≡)) (cTMem l).
   Proof. solve_proper. Qed.
 
   Lemma cTMem_unfold :
-    cTMem = λ l τ1 τ2, dty2clty l (oDTMemRaw (dot_intv_type_pred τ1 τ2)).
+    cTMem = λ l L U, dty2clty l (oDTMemRaw (dot_intv_type_pred L U)).
   Proof. by rewrite /cTMem oDTMem_eq. Qed.
 
-  Lemma cTMem_eq l τ1 τ2 d ρ :
-    cTMem l τ1 τ2 ρ [(l, d)] ⊣⊢ oDTMem τ1 τ2 ρ d.
+  Lemma cTMem_eq l L U d ρ :
+    cTMem l L U ρ [(l, d)] ⊣⊢ oDTMem L U ρ d.
   Proof. apply dty2clty_singleton. Qed.
 End sem_TMem.
 
-Notation oTMem l τ1 τ2 := (clty_olty (cTMem l τ1 τ2)).
+Notation oTMem l L U := (clty_olty (cTMem l L U)).
 
 Section oTMem_lemmas.
   Context `{HdotG: !dlangG Σ}.
 
-  Lemma oTMem_unfold l τ1 τ2 :
-    oTMem l τ1 τ2 = clty_olty (dty2clty l (oDTMemRaw (dot_intv_type_pred τ1 τ2))).
+  Lemma oTMem_unfold l L U :
+    oTMem l L U = clty_olty (dty2clty l (oDTMemRaw (dot_intv_type_pred L U))).
   Proof. by rewrite cTMem_unfold. Qed.
 
-  Lemma oTMem_eq l τ1 τ2 args ρ v :
-    oTMem l τ1 τ2 args ρ v ⊣⊢
-    ∃ ψ d, ⌜v @ l ↘ d⌝ ∧ d ↗n ψ ∧ dot_intv_type_pred τ1 τ2 ρ ψ.
-  Proof. rewrite /cTMem oDTMem_eq. apply bi_exist_nested_swap. Qed.
+  Lemma oTMem_eq l L U args ρ v :
+    oTMem l L U args ρ v ⊣⊢
+    ∃ ψ d, ⌜v @ l ↘ d⌝ ∧ d ↗n ψ ∧ dot_intv_type_pred L U ρ ψ.
+  Proof. rewrite oTMem_unfold. apply bi_exist_nested_swap. Qed.
 
   Lemma oTMem_shift A L U : oTMem A (shift L) (shift U) = shift (oTMem A L U).
   Proof. rewrite /cTMem !oDTMem_eq. done. Qed.

--- a/theories/Dot/hkdot/sem_kind_dot.v
+++ b/theories/Dot/hkdot/sem_kind_dot.v
@@ -87,13 +87,13 @@ Section sem_TMem.
   Context `{HdotG: !dlangG Σ}.
   Implicit Types (τ : oltyO Σ).
 
-  Lemma oDTMem_unfold : oDTMem = λ L U, oDTMemRaw (dot_intv_type_pred L U).
+  Lemma oDTMem_unfold L U : oDTMem L U ≡ oDTMemRaw (dot_intv_type_pred L U).
   Proof. by rewrite oDTMem_eq. Qed.
 
   #[global] Instance oDTMem_proper : Proper ((≡) ==> (≡) ==> (≡)) oDTMem.
   Proof.
-    rewrite oDTMem_unfold => ??? ??? ??/=; properness; try reflexivity;
-      solve_proper_ho.
+    move=> ??? ??? ??/=. rewrite !oDTMem_unfold/=.
+    properness; try reflexivity; solve_proper_ho.
   Qed.
 
   (** Define [cTMem] by lifting [oDTMem] to [clty]s. *)
@@ -106,8 +106,8 @@ Section sem_TMem.
   #[global] Instance cTMem_proper l : Proper ((≡) ==> (≡) ==> (≡)) (cTMem l).
   Proof. solve_proper. Qed.
 
-  Lemma cTMem_unfold :
-    cTMem = λ l L U, dty2clty l (oDTMemRaw (dot_intv_type_pred L U)).
+  Lemma cTMem_unfold l L U :
+    cTMem l L U ≡ dty2clty l (oDTMemRaw (dot_intv_type_pred L U)).
   Proof. by rewrite /cTMem oDTMem_eq. Qed.
 
   Lemma cTMem_eq l L U d ρ :
@@ -121,7 +121,7 @@ Section oTMem_lemmas.
   Context `{HdotG: !dlangG Σ}.
 
   Lemma oTMem_unfold l L U :
-    oTMem l L U = clty_olty (dty2clty l (oDTMemRaw (dot_intv_type_pred L U))).
+    oTMem l L U ≡ clty_olty (dty2clty l (oDTMemRaw (dot_intv_type_pred L U))).
   Proof. by rewrite cTMem_unfold. Qed.
 
   Lemma oTMem_eq l L U args ρ v :

--- a/theories/Dot/hkdot/sem_kind_dot.v
+++ b/theories/Dot/hkdot/sem_kind_dot.v
@@ -26,9 +26,6 @@ Notation oDTMemRaw rK := (Dlty (λI ρ d, ∃ ψ, d ↗n ψ ∧ rK ρ ψ)).
 Definition oDTMemK `{!dlangG Σ} (K : sf_kind Σ) : dltyO Σ :=
   oDTMemRaw (λI ρ ψ, K ρ (packHoLtyO ψ) (packHoLtyO ψ)).
 
-Definition oDTMemSpec `{!dlangG Σ} (L U : oltyO Σ) : dltyO Σ :=
-  oDTMemK (sf_kintv L U).
-
 Definition cTMemK `{!dlangG Σ} l (K : sf_kind Σ) : clty Σ := dty2clty l (oDTMemK K).
 Notation oTMemK l K := (clty_olty (cTMemK l K)).
 
@@ -73,7 +70,7 @@ Definition dot_intv_type_pred `{!dlangG Σ} (L U : oltyO Σ) ρ ψ : iProp Σ :=
   L anil ρ ⊆ packHoLtyO ψ anil ∧ packHoLtyO ψ anil ⊆ U anil ρ.
 
 (** [ D⟦ { A :: τ1 .. τ2 } ⟧ ]. *)
-Definition oDTMem_def `{!dlangG Σ} L U : dltyO Σ := oDTMemRaw (dot_intv_type_pred L U).
+Definition oDTMem_def `{!dlangG Σ} L U : dltyO Σ := oDTMemK (sf_kintv L U).
 Definition oDTMem_aux : seal (@oDTMem_def). Proof. by eexists. Qed.
 Definition oDTMem := oDTMem_aux.(unseal).
 Definition oDTMem_eq : oDTMem = _ := oDTMem_aux.(seal_eq).
@@ -87,7 +84,9 @@ Section sem_TMem.
   Implicit Types (τ : oltyO Σ).
 
   Lemma oDTMem_unfold L U : oDTMem L U ≡ oDTMemRaw (dot_intv_type_pred L U).
-  Proof. by rewrite oDTMem_eq. Qed.
+  Proof.
+    rewrite oDTMem_eq => ρ d /=. f_equiv=> ψ; f_equiv. apply sr_kintv_refl.
+  Qed.
 
   #[global] Instance oDTMem_proper : Proper ((≡) ==> (≡) ==> (≡)) oDTMem.
   Proof.
@@ -131,11 +130,6 @@ Section oTMem_lemmas.
   Lemma oTMem_shift A L U : oTMem A (shift L) (shift U) = shift (oTMem A L U).
   Proof. rewrite /cTMem !oDTMem_eq. done. Qed.
 End oTMem_lemmas.
-
-Lemma oDTMemSpec_oDTMem_eq `{!dlangG Σ} L U : oDTMemSpec L U ≡ oDTMem L U.
-Proof.
-  rewrite oDTMem_unfold => ρ d /=; f_equiv=> ψ; f_equiv. apply sr_kintv_refl.
-Qed.
 
 (** * Path application and substitution *)
 

--- a/theories/Dot/lr/dot_semtypes.v
+++ b/theories/Dot/lr/dot_semtypes.v
@@ -166,6 +166,7 @@ Section misc_lemmas.
     oTMem l L U anil ρ w -∗
     U anil ρ v.
   Proof.
+    rewrite oTMem_unfold.
     iIntros "Hφ"; iDestruct 1 as (d1 Hl1 φ1) "(Hdφ1 & _ & HφU)".
     iApply "HφU".
     iDestruct "Hφ" as (d2 φ2 Hl2) "[Hdφ2 Hφ2v]".
@@ -178,6 +179,7 @@ Section misc_lemmas.
     oTMem l L U anil ρ w -∗
     vl_sel w l anil v.
   Proof.
+    rewrite oTMem_unfold.
     iIntros "HL"; iDestruct 1 as (d Hl φ) "[Hdφ [HLφ _]]".
     iExists d, φ; iFrame (Hl) "Hdφ". iApply ("HLφ" with "HL").
   Qed.
@@ -200,6 +202,7 @@ Section misc_lemmas.
     U1 anil ρ ⊆ U2 anil ρ -∗
     oDTMem L1 U1 ρ d -∗ oDTMem L2 U2 ρ d.
   Proof.
+    rewrite !oDTMem_unfold.
     iIntros "#HsubL #HsubU"; iDestruct 1 as (φ) "#(Hφl & #HLφ & #HφU)".
     iExists φ; iSplit; first done; iSplit; iIntros "%w #Hw".
     - iApply ("HLφ" with "(HsubL Hw)").

--- a/theories/Dot/lr/unary_lr.v
+++ b/theories/Dot/lr/unary_lr.v
@@ -70,7 +70,7 @@ Section log_rel.
   #[global] Instance pinterp_lemmas: CTyInterpLemmas Σ.
   Proof.
     split; rewrite /pty_interp;
-      induction T => args sb1 sb2 w; rewrite /= /pty_interp /dot_intv_type_pred /subtype_lty /=;
+      induction T => args sb1 sb2 w; rewrite /= /pty_interp ?oDTMem_unfold /dot_intv_type_pred /subtype_lty /=;
       properness; rewrite ?scons_up_swap ?hsubst_comp; trivial.
     by apply path_wp_proper => ?.
   Qed.
@@ -138,7 +138,7 @@ Section path_repl_lemmas.
     V⟦ T1 ⟧ ~sTpP[ p := q ]* V⟦ T2 ⟧.
   Proof.
     rewrite /sem_ty_path_repl; induction Hrew => args ρ v He /=;
-      rewrite /dot_intv_type_pred /subtype_lty/=; properness;
+      rewrite ?oDTMem_unfold /dot_intv_type_pred /subtype_lty/=; properness;
       try by [ exact: path_replacement_equiv | exact: rewrite_path_path_repl
          | apply IHHrew; rewrite ?hsubst_comp | | f_equiv => ?; exact: IHHrew].
   Qed.

--- a/theories/Dot/lr/unary_lr.v
+++ b/theories/Dot/lr/unary_lr.v
@@ -70,9 +70,8 @@ Section log_rel.
   #[global] Instance pinterp_lemmas: CTyInterpLemmas Σ.
   Proof.
     split; rewrite /pty_interp;
-      induction T => args sb1 sb2 w; rewrite /= /pty_interp /=;
-      properness;
-      rewrite ?oDTMem_unfold /dot_intv_type_pred /subtype_lty /=; properness;
+      induction T => args sb1 sb2 w;
+      rewrite /= /pty_interp /sr_kintv /subtype_lty /=; properness;
       rewrite ?scons_up_swap ?hsubst_comp; trivial.
     by apply path_wp_proper => ?.
   Qed.
@@ -140,8 +139,7 @@ Section path_repl_lemmas.
     V⟦ T1 ⟧ ~sTpP[ p := q ]* V⟦ T2 ⟧.
   Proof.
     rewrite /sem_ty_path_repl; induction Hrew => args ρ v He /=;
-      properness.
-      all: rewrite ?oDTMem_unfold /dot_intv_type_pred /subtype_lty/=; properness.
+      rewrite /= /pty_interp /sr_kintv /subtype_lty /=; properness.
       all: try by [ exact: path_replacement_equiv | exact: rewrite_path_path_repl
          | apply IHHrew; rewrite ?hsubst_comp | | f_equiv => ?; exact: IHHrew].
   Qed.

--- a/theories/Dot/lr/unary_lr.v
+++ b/theories/Dot/lr/unary_lr.v
@@ -70,8 +70,10 @@ Section log_rel.
   #[global] Instance pinterp_lemmas: CTyInterpLemmas Σ.
   Proof.
     split; rewrite /pty_interp;
-      induction T => args sb1 sb2 w; rewrite /= /pty_interp ?oDTMem_unfold /dot_intv_type_pred /subtype_lty /=;
-      properness; rewrite ?scons_up_swap ?hsubst_comp; trivial.
+      induction T => args sb1 sb2 w; rewrite /= /pty_interp /=;
+      properness;
+      rewrite ?oDTMem_unfold /dot_intv_type_pred /subtype_lty /=; properness;
+      rewrite ?scons_up_swap ?hsubst_comp; trivial.
     by apply path_wp_proper => ?.
   Qed.
 
@@ -138,8 +140,9 @@ Section path_repl_lemmas.
     V⟦ T1 ⟧ ~sTpP[ p := q ]* V⟦ T2 ⟧.
   Proof.
     rewrite /sem_ty_path_repl; induction Hrew => args ρ v He /=;
-      rewrite ?oDTMem_unfold /dot_intv_type_pred /subtype_lty/=; properness;
-      try by [ exact: path_replacement_equiv | exact: rewrite_path_path_repl
+      properness.
+      all: rewrite ?oDTMem_unfold /dot_intv_type_pred /subtype_lty/=; properness.
+      all: try by [ exact: path_replacement_equiv | exact: rewrite_path_path_repl
          | apply IHHrew; rewrite ?hsubst_comp | | f_equiv => ?; exact: IHHrew].
   Qed.
 

--- a/theories/Dot/semtyp_lemmas/defs_lr.v
+++ b/theories/Dot/semtyp_lemmas/defs_lr.v
@@ -73,7 +73,7 @@ Section Sec.
     s ↝[ σ ] T -∗
     Γ s⊨ { l := dtysem σ s } : cTMem l (oLater T) (oLater T).
   Proof.
-    rewrite !sdtp_eq'; iDestruct 1 as (φ Hγφ) "#Hγ".
+    rewrite !sdtp_eq' oDTMem_unfold; iDestruct 1 as (φ Hγφ) "#Hγ".
     iIntros "!>" (ρ Hpid) "#Hg"; iExists (hoEnvD_inst (σ.|[ρ]) φ); iSplit.
     by iApply (dm_to_type_intro with "Hγ").
     by iSplit; iIntros (v) "#H"; iNext; rewrite /= (Hγφ _ _).

--- a/theories/Dot/semtyp_lemmas/defs_lr.v
+++ b/theories/Dot/semtyp_lemmas/defs_lr.v
@@ -73,8 +73,9 @@ Section Sec.
     s ↝[ σ ] T -∗
     Γ s⊨ { l := dtysem σ s } : cTMem l (oLater T) (oLater T).
   Proof.
-    rewrite !sdtp_eq' oDTMem_unfold; iDestruct 1 as (φ Hγφ) "#Hγ".
-    iIntros "!>" (ρ Hpid) "#Hg"; iExists (hoEnvD_inst (σ.|[ρ]) φ); iSplit.
+    rewrite !sdtp_eq'; iDestruct 1 as (φ Hγφ) "#Hγ".
+    iIntros "!>" (ρ Hpid) "#Hg"; rewrite oDTMem_unfold.
+    iExists (hoEnvD_inst (σ.|[ρ]) φ); iSplit.
     by iApply (dm_to_type_intro with "Hγ").
     by iSplit; iIntros (v) "#H"; iNext; rewrite /= (Hγφ _ _).
   Qed.

--- a/theories/Dot/semtyp_lemmas/tproj_lr.v
+++ b/theories/Dot/semtyp_lemmas/tproj_lr.v
@@ -360,7 +360,7 @@ Section type_proj.
 
     iIntros "!> %ρ %v #HT"; rewrite oProjN_eq.
     iAssert (oTMemL A T T anil ρ auxV.[ρ])%I as "{HwT} #Hw". {
-      rewrite -(path_wp_pv_eq auxV.[ρ]). by iApply "HwT".
+      rewrite -(path_wp_pv_eq auxV.[ρ]) !oTMem_unfold. by iApply "HwT".
     }
 
     iExists auxV.[ρ]; iFrame "Hw".

--- a/theories/Dot/semtyp_lemmas/tproj_lr.v
+++ b/theories/Dot/semtyp_lemmas/tproj_lr.v
@@ -360,7 +360,11 @@ Section type_proj.
 
     iIntros "!> %ρ %v #HT"; rewrite oProjN_eq.
     iAssert (oTMemL A T T anil ρ auxV.[ρ])%I as "{HwT} #Hw". {
-      rewrite -(path_wp_pv_eq auxV.[ρ]) !oTMem_unfold. by iApply "HwT".
+      rewrite -(path_wp_pv_eq auxV.[ρ]).
+      iSpecialize ("HwT" $! ρ with "[//]").
+      iApply (path_wp_proper with "HwT").
+      move=>?/=. f_equiv=> d.
+      by rewrite !oDTMem_unfold.
     }
 
     iExists auxV.[ρ]; iFrame "Hw".

--- a/theories/Dot/semtyp_lemmas/tproj_lr.v
+++ b/theories/Dot/semtyp_lemmas/tproj_lr.v
@@ -360,11 +360,7 @@ Section type_proj.
 
     iIntros "!> %ρ %v #HT"; rewrite oProjN_eq.
     iAssert (oTMemL A T T anil ρ auxV.[ρ])%I as "{HwT} #Hw". {
-      rewrite -(path_wp_pv_eq auxV.[ρ]).
-      iSpecialize ("HwT" $! ρ with "[//]").
-      iApply (path_wp_proper with "HwT").
-      move=>?/=. f_equiv=> d.
-      by rewrite !oDTMem_unfold.
+      rewrite -(path_wp_pv_eq auxV.[ρ]). by iApply "HwT".
     }
 
     iExists auxV.[ρ]; iFrame "Hw".


### PR DESCRIPTION
Needed for #302: since the syntax `TTMem` will become a shortcut for `TTMemK`, we'll need semantic lemmas for (the corresponding special case of) `TTMemK`, but those are written using `cTMem` & c.; and that's why we must reimplement `cTMem` in terms of `cTMemK`.

For this MR, I eschewed making the history "maximally clean" — each commit still makes sense, but I haven't pushed cleanups as early as possible.