### PR TITLE
Drop `Set Suggest Proof Using` and `Set Default Proof Using "Type"` which are now implied.

### DIFF
--- a/theories/DSub/fundamental.v
+++ b/theories/DSub/fundamental.v
@@ -11,7 +11,6 @@ From D.DSub Require Import unary_lr semtyp_lemmas.
 
 Implicit Types (L T U : ty) (v : vl) (e : tm) (Γ : ctx).
 
-Set Suggest Proof Using.
 Set Default Proof Using "Type*".
 
 Section swap_based_typing_lemmas.

--- a/theories/DSub/lr/semtyp_lemmas.v
+++ b/theories/DSub/lr/semtyp_lemmas.v
@@ -7,7 +7,6 @@ From D.pure_program_logic Require Import lifting.
 From D.DSub Require Import rules syn_lemmas.
 From D.DSub Require Import unary_lr.
 
-Set Suggest Proof Using.
 Set Default Proof Using "Type*".
 
 Implicit Types (L T U : ty) (v : vl) (e : tm) (Γ : ctx).

--- a/theories/DSub/lr/ty_interp_subst_lemmas.v
+++ b/theories/DSub/lr/ty_interp_subst_lemmas.v
@@ -1,7 +1,6 @@
 (** * Binding lemmas about DSub* logical relations. *)
 From D Require Import prelude iris_prelude asubst_base saved_interp_n.
 
-Set Suggest Proof Using.
 Set Default Proof Using "Type*".
 
 Module Type TyInterpLemmas (Import VS : VlSortsFullSig)

--- a/theories/DSub/lr/unary_lr.v
+++ b/theories/DSub/lr/unary_lr.v
@@ -8,7 +8,6 @@ Include SavedHoInterp VlSorts. (* Defines [envD] and needed by TyInterpLemmas. *
 Include TyInterpLemmas VlSorts.
 Export ty_interp_lemmas.
 
-Set Suggest Proof Using.
 Set Default Proof Using "Type*".
 
 (** Deduce types from variable names, like on paper, for readability and to help

--- a/theories/DSub/syn/rules.v
+++ b/theories/DSub/syn/rules.v
@@ -2,8 +2,6 @@ From iris.program_logic Require Import language ectx_language.
 From D Require Import iris_extra.det_reduction.
 From D.DSub Require Import syn.
 
-Set Suggest Proof Using.
-
 Implicit Types e : tm.
 
 Section lang_rules.

--- a/theories/DSub/syn/rules.v
+++ b/theories/DSub/syn/rules.v
@@ -3,7 +3,6 @@ From D Require Import iris_extra.det_reduction.
 From D.DSub Require Import syn.
 
 Set Suggest Proof Using.
-Set Default Proof Using "Type".
 
 Implicit Types e : tm.
 

--- a/theories/DSub/syn/syn.v
+++ b/theories/DSub/syn/syn.v
@@ -2,7 +2,6 @@ From D Require Export prelude.
 From D Require Import asubst_intf asubst_base.
 From iris.program_logic Require ectx_language ectxi_language.
 
-Set Suggest Proof Using.
 Set Default Proof Using "Type*".
 
 (** This module is included right away. Its only point is asserting explicitly

--- a/theories/Dot/examples/hoas.v
+++ b/theories/Dot/examples/hoas.v
@@ -8,7 +8,6 @@ particular is not suitable for robust typing lemmas.
 From D Require Import tactics.
 From D.Dot Require Import syn ex_utils.
 
-Set Default Proof Using "Type".
 
 (*
 The algorithm we use is very different from McBride's Jigger:

--- a/theories/Dot/examples/old_fundamental.v
+++ b/theories/Dot/examples/old_fundamental.v
@@ -11,7 +11,6 @@ From D.Dot.examples.sem Require Export sub_lr sub_lr_syn.
 From D.Dot.examples.sem Require Import storeless_typing.
 
 Set Suggest Proof Using.
-Set Default Proof Using "Type".
 Set Implicit Arguments.
 Unset Strict Implicit.
 

--- a/theories/Dot/examples/old_fundamental.v
+++ b/theories/Dot/examples/old_fundamental.v
@@ -10,7 +10,6 @@ From D.Dot.examples.old_typing Require Import old_unstamped_typing old_unstamped
 From D.Dot.examples.sem Require Export sub_lr sub_lr_syn.
 From D.Dot.examples.sem Require Import storeless_typing.
 
-Set Suggest Proof Using.
 Set Implicit Arguments.
 Unset Strict Implicit.
 

--- a/theories/Dot/examples/old_typing/old_unstamped_typing_derived_rules.v
+++ b/theories/Dot/examples/old_typing/old_unstamped_typing_derived_rules.v
@@ -300,7 +300,6 @@ Proof. eapply iD_Path, (iP_Sngl_Refl (T := T)), Hx. Qed.
 (* If I add [iSub_Skolem_P] to the syntactic type system, what other rules
 can I derive? Apparently, subtyping for recursive types, almost. See below! *)
 
-Set Suggest Proof Using.
 Section cond.
   Context (Hskolem : ∀ Γ T1 T2 i j,
     iterate TLater i (shift T1) :: Γ u⊢ₚ pv (ids 0) : shift T2, j →

--- a/theories/Dot/examples/old_typing/old_unstamped_typing_to_typing.v
+++ b/theories/Dot/examples/old_typing/old_unstamped_typing_to_typing.v
@@ -8,7 +8,6 @@ Implicit Types (L T U : ty) (v : vl) (e : tm) (d : dm) (p : path) (ds : dms) (Γ
 
 Set Implicit Arguments.
 Unset Strict Implicit.
-Set Suggest Proof Using.
 
 #[local] Lemma iP_ISub_Der Γ i j T1 T2 p :
   Γ t⊢ₜ iterate TLater i T1 <:[ 0 ] iterate TLater (i + j) T2 →

--- a/theories/Dot/examples/old_typing/old_unstamped_typing_to_typing.v
+++ b/theories/Dot/examples/old_typing/old_unstamped_typing_to_typing.v
@@ -9,7 +9,6 @@ Implicit Types (L T U : ty) (v : vl) (e : tm) (d : dm) (p : path) (ds : dms) (Γ
 Set Implicit Arguments.
 Unset Strict Implicit.
 Set Suggest Proof Using.
-Set Default Proof Using "Type".
 
 #[local] Lemma iP_ISub_Der Γ i j T1 T2 p :
   Γ t⊢ₜ iterate TLater i T1 <:[ 0 ] iterate TLater (i + j) T2 →

--- a/theories/Dot/examples/sem/ex_iris_utils.v
+++ b/theories/Dot/examples/sem/ex_iris_utils.v
@@ -9,8 +9,6 @@ From D.Dot Require Export ex_utils hoas_ex_utils storeless_typing_ex_utils.
 From D.Dot Require Export old_fundamental examples_lr sem_unstamped_typing.
 Export loopTms.
 
-Set Suggest Proof Using.
-
 Implicit Types (v w : vl) (d : dm) (ds : dms).
 
 Example loopDefTyp Γ : Γ v⊢ₜ hloopDefV : hloopDefT.

--- a/theories/Dot/examples/sem/ex_iris_utils.v
+++ b/theories/Dot/examples/sem/ex_iris_utils.v
@@ -10,7 +10,6 @@ From D.Dot Require Export old_fundamental examples_lr sem_unstamped_typing.
 Export loopTms.
 
 Set Suggest Proof Using.
-Set Default Proof Using "Type".
 
 Implicit Types (v w : vl) (d : dm) (ds : dms).
 

--- a/theories/Dot/examples/sem/from_pdot_mutual_rec_sem.v
+++ b/theories/Dot/examples/sem/from_pdot_mutual_rec_sem.v
@@ -36,7 +36,6 @@ Import prelude.
 
 Set Implicit Arguments.
 Unset Strict Implicit.
-Set Suggest Proof Using.
 
 Section hoas.
   Import hoasNotation.

--- a/theories/Dot/examples/sem/from_pdot_mutual_rec_sem.v
+++ b/theories/Dot/examples/sem/from_pdot_mutual_rec_sem.v
@@ -37,7 +37,6 @@ Import prelude.
 Set Implicit Arguments.
 Unset Strict Implicit.
 Set Suggest Proof Using.
-Set Default Proof Using "Type".
 
 Section hoas.
   Import hoasNotation.

--- a/theories/Dot/examples/sem/no_russell_paradox.v
+++ b/theories/Dot/examples/sem/no_russell_paradox.v
@@ -9,7 +9,6 @@ Implicit Types
          (L T U : ty) (v : vl) (e : tm) (d : dm) (ds : dms)
          (Γ : ctx).
 Set Suggest Proof Using.
-Set Default Proof Using "Type".
 
 Section Russell.
   Context `{HdlangG : !dlangG Σ}.

--- a/theories/Dot/examples/sem/no_russell_paradox.v
+++ b/theories/Dot/examples/sem/no_russell_paradox.v
@@ -8,7 +8,6 @@ From D.Dot Require Import unary_lr.
 Implicit Types
          (L T U : ty) (v : vl) (e : tm) (d : dm) (ds : dms)
          (Γ : ctx).
-Set Suggest Proof Using.
 
 Section Russell.
   Context `{HdlangG : !dlangG Σ}.

--- a/theories/Dot/examples/sem/positive_div.v
+++ b/theories/Dot/examples/sem/positive_div.v
@@ -9,8 +9,6 @@ From D.Dot Require Import ex_iris_utils sem_unstamped_typing.
 
 Import dlang_adequacy.
 
-Set Suggest Proof Using.
-
 Implicit Types (v w : vl) (d : dm) (ds : dms).
 
 (** ** Example code. *)

--- a/theories/Dot/examples/sem/positive_div.v
+++ b/theories/Dot/examples/sem/positive_div.v
@@ -10,7 +10,6 @@ From D.Dot Require Import ex_iris_utils sem_unstamped_typing.
 Import dlang_adequacy.
 
 Set Suggest Proof Using.
-Set Default Proof Using "Type".
 
 Implicit Types (v w : vl) (d : dm) (ds : dms).
 

--- a/theories/Dot/examples/sem/prim_boolean_option.v
+++ b/theories/Dot/examples/sem/prim_boolean_option.v
@@ -11,7 +11,6 @@ Import DBNotation.
 
 Set Implicit Arguments.
 Set Suggest Proof Using.
-Set Default Proof Using "Type".
 
 Module prim_boolean_option_mod.
 Import hoasNotation.

--- a/theories/Dot/examples/sem/prim_boolean_option.v
+++ b/theories/Dot/examples/sem/prim_boolean_option.v
@@ -10,7 +10,6 @@ From D.Dot Require Import storeless_typing.
 Import DBNotation.
 
 Set Implicit Arguments.
-Set Suggest Proof Using.
 
 Module prim_boolean_option_mod.
 Import hoasNotation.

--- a/theories/Dot/examples/sem/semtyp_lemmas/examples_lr.v
+++ b/theories/Dot/examples/sem/semtyp_lemmas/examples_lr.v
@@ -12,8 +12,6 @@ Implicit Types (v : vl) (e : tm) (d : dm) (ds : dms) (ρ : env) (l : label).
 Set Implicit Arguments.
 Unset Strict Implicit.
 
-Set Suggest Proof Using.
-
 Section Lemmas.
   Context `{HdotG : !dlangG Σ}.
 

--- a/theories/Dot/examples/sem/semtyp_lemmas/examples_lr.v
+++ b/theories/Dot/examples/sem/semtyp_lemmas/examples_lr.v
@@ -13,7 +13,6 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 
 Set Suggest Proof Using.
-Set Default Proof Using "Type".
 
 Section Lemmas.
   Context `{HdotG : !dlangG Σ}.

--- a/theories/Dot/examples/sem/small_sem_ex.v
+++ b/theories/Dot/examples/sem/small_sem_ex.v
@@ -9,8 +9,6 @@ From D.Dot Require Import ex_iris_utils.
 From D.Dot.examples Require Import positive_div.
 Import dlang_adequacy.
 
-Set Suggest Proof Using.
-
 Implicit Types (v w : vl) (d : dm) (ds : dms).
 
 (** ** Example code. *)

--- a/theories/Dot/examples/sem/small_sem_ex.v
+++ b/theories/Dot/examples/sem/small_sem_ex.v
@@ -10,7 +10,6 @@ From D.Dot.examples Require Import positive_div.
 Import dlang_adequacy.
 
 Set Suggest Proof Using.
-Set Default Proof Using "Type".
 
 Implicit Types (v w : vl) (d : dm) (ds : dms).
 

--- a/theories/Dot/examples/sem/storeless_typing_ex.v
+++ b/theories/Dot/examples/sem/storeless_typing_ex.v
@@ -10,7 +10,6 @@ From D.Dot Require Import syn storeless_typing_ex_utils
 Implicit Types (L T U : ty) (v : vl) (e : tm) (d : dm) (ds : dms) (Γ : list ty).
 
 Set Suggest Proof Using.
-Set Default Proof Using "Type".
 
 Notation HashableString := (μ {@ val "hashCode" : TAll TUnit TInt }).
 (* From D Require Import typeExtraction *)

--- a/theories/Dot/examples/sem/storeless_typing_ex.v
+++ b/theories/Dot/examples/sem/storeless_typing_ex.v
@@ -9,8 +9,6 @@ From D.Dot Require Import syn storeless_typing_ex_utils
 
 Implicit Types (L T U : ty) (v : vl) (e : tm) (d : dm) (ds : dms) (Γ : list ty).
 
-Set Suggest Proof Using.
-
 Notation HashableString := (μ {@ val "hashCode" : TAll TUnit TInt }).
 (* From D Require Import typeExtraction *)
 

--- a/theories/Dot/examples/sem/storeless_typing_ex_utils.v
+++ b/theories/Dot/examples/sem/storeless_typing_ex_utils.v
@@ -8,7 +8,6 @@ From D.Dot Require Import syn.
 From D.Dot Require Export storeless_typing ex_utils hoas old_subtyping_derived_rules.
 Export DBNotation old_subtyping_derived_rules.
 
-Set Default Proof Using "Type".
 Set Suggest Proof Using.
 
 Implicit Types (L T U : ty) (v : vl) (e : tm) (d : dm) (ds : dms) (Γ : list ty).

--- a/theories/Dot/examples/sem/storeless_typing_ex_utils.v
+++ b/theories/Dot/examples/sem/storeless_typing_ex_utils.v
@@ -8,8 +8,6 @@ From D.Dot Require Import syn.
 From D.Dot Require Export storeless_typing ex_utils hoas old_subtyping_derived_rules.
 Export DBNotation old_subtyping_derived_rules.
 
-Set Suggest Proof Using.
-
 Implicit Types (L T U : ty) (v : vl) (e : tm) (d : dm) (ds : dms) (Γ : list ty).
 
 (**********************)

--- a/theories/Dot/examples/sem/syntyp_lemmas/examples_lr_syn.v
+++ b/theories/Dot/examples/sem/syntyp_lemmas/examples_lr_syn.v
@@ -12,7 +12,6 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 
 Set Suggest Proof Using.
-Set Default Proof Using "Type".
 
 Section Lemmas.
   Context `{HdotG : !dlangG Σ}.

--- a/theories/Dot/examples/sem/syntyp_lemmas/examples_lr_syn.v
+++ b/theories/Dot/examples/sem/syntyp_lemmas/examples_lr_syn.v
@@ -11,8 +11,6 @@ Implicit Types (v : vl) (e : tm) (d : dm) (ds : dms) (ρ : env) (l : label).
 Set Implicit Arguments.
 Unset Strict Implicit.
 
-Set Suggest Proof Using.
-
 Section Lemmas.
   Context `{HdotG : !dlangG Σ}.
 

--- a/theories/Dot/fundamental.v
+++ b/theories/Dot/fundamental.v
@@ -7,7 +7,6 @@ From D.Dot Require Export sem_unstamped_typing.
 
 From D.Dot Require Import typing path_repl_lemmas.
 Set Suggest Proof Using.
-Set Default Proof Using "Type".
 Set Implicit Arguments.
 Unset Strict Implicit.
 

--- a/theories/Dot/fundamental.v
+++ b/theories/Dot/fundamental.v
@@ -6,7 +6,6 @@ From D.Dot Require Export binding_lr_syn dsub_lr_syn path_repl_lr_syn prims_lr_s
 From D.Dot Require Export sem_unstamped_typing.
 
 From D.Dot Require Import typing path_repl_lemmas.
-Set Suggest Proof Using.
 Set Implicit Arguments.
 Unset Strict Implicit.
 

--- a/theories/Dot/hkdot/hkdot.v
+++ b/theories/Dot/hkdot/hkdot.v
@@ -14,7 +14,6 @@ From D.Dot Require hoas ex_utils.
 From D.Dot Require Import sem_kind sem_kind_dot.
 
 Set Suggest Proof Using.
-Set Default Proof Using "Type".
 Set Implicit Arguments.
 Unset Strict Implicit.
 

--- a/theories/Dot/hkdot/hkdot.v
+++ b/theories/Dot/hkdot/hkdot.v
@@ -13,7 +13,6 @@ From D.Dot Require hoas ex_utils.
 
 From D.Dot Require Import sem_kind sem_kind_dot.
 
-Set Suggest Proof Using.
 Set Implicit Arguments.
 Unset Strict Implicit.
 

--- a/theories/Dot/hkdot/sem_kind.v
+++ b/theories/Dot/hkdot/sem_kind.v
@@ -4,7 +4,6 @@ From D Require Export succ_notation proper. (* We export proper to use [sr_kintv
 From D Require Import saved_interp_n asubst_intf dlang lty.
 From D Require Import swap_later_impl.
 
-Set Suggest Proof Using.
 Set Implicit Arguments.
 Unset Strict Implicit.
 

--- a/theories/Dot/hkdot/sem_kind.v
+++ b/theories/Dot/hkdot/sem_kind.v
@@ -5,7 +5,6 @@ From D Require Import saved_interp_n asubst_intf dlang lty.
 From D Require Import swap_later_impl.
 
 Set Suggest Proof Using.
-Set Default Proof Using "Type".
 Set Implicit Arguments.
 Unset Strict Implicit.
 

--- a/theories/Dot/hkdot/sem_kind_dot.v
+++ b/theories/Dot/hkdot/sem_kind_dot.v
@@ -5,7 +5,6 @@ From D Require Import saved_interp_n asubst_intf dlang lty.
 From D Require Import swap_later_impl.
 From D.Dot Require Import dot_lty hkdot.sem_kind.
 
-Set Suggest Proof Using.
 Set Implicit Arguments.
 Unset Strict Implicit.
 

--- a/theories/Dot/hkdot/sem_kind_dot.v
+++ b/theories/Dot/hkdot/sem_kind_dot.v
@@ -6,7 +6,6 @@ From D Require Import swap_later_impl.
 From D.Dot Require Import dot_lty hkdot.sem_kind.
 
 Set Suggest Proof Using.
-Set Default Proof Using "Type".
 Set Implicit Arguments.
 Unset Strict Implicit.
 

--- a/theories/Dot/lr/dot_lty.v
+++ b/theories/Dot/lr/dot_lty.v
@@ -6,7 +6,6 @@ From D.Dot Require Export dlang_inst path_wp.
 
 Unset Program Cases.
 Set Suggest Proof Using.
-Set Default Proof Using "Type".
 
 Implicit Types (Σ : gFunctors)
          (v w : vl) (e : tm) (d : dm) (ds : dms) (p : path)

--- a/theories/Dot/lr/dot_lty.v
+++ b/theories/Dot/lr/dot_lty.v
@@ -5,7 +5,6 @@ From D.Dot Require Import syn.
 From D.Dot Require Export dlang_inst path_wp.
 
 Unset Program Cases.
-Set Suggest Proof Using.
 
 Implicit Types (Σ : gFunctors)
          (v w : vl) (e : tm) (d : dm) (ds : dms) (p : path)

--- a/theories/Dot/lr/dot_semtypes.v
+++ b/theories/Dot/lr/dot_semtypes.v
@@ -9,7 +9,6 @@ From D.pure_program_logic Require Import weakestpre.
 From D.Dot Require Export dot_lty sem_kind_dot.
 
 Unset Program Cases.
-Set Suggest Proof Using.
 
 Implicit Types (Σ : gFunctors)
          (v w : vl) (e : tm) (d : dm) (ds : dms) (p : path)

--- a/theories/Dot/lr/dot_semtypes.v
+++ b/theories/Dot/lr/dot_semtypes.v
@@ -10,7 +10,6 @@ From D.Dot Require Export dot_lty sem_kind_dot.
 
 Unset Program Cases.
 Set Suggest Proof Using.
-Set Default Proof Using "Type".
 
 Implicit Types (Σ : gFunctors)
          (v w : vl) (e : tm) (d : dm) (ds : dms) (p : path)

--- a/theories/Dot/lr/unary_lr.v
+++ b/theories/Dot/lr/unary_lr.v
@@ -9,7 +9,6 @@ From D.Dot Require Export dot_lty dot_semtypes sem_kind_dot.
 
 Unset Program Cases.
 Set Suggest Proof Using.
-Set Default Proof Using "Type".
 
 Implicit Types (Σ : gFunctors)
          (v w : vl) (e : tm) (d : dm) (ds : dms) (p : path)

--- a/theories/Dot/lr/unary_lr.v
+++ b/theories/Dot/lr/unary_lr.v
@@ -8,7 +8,6 @@ From D.pure_program_logic Require Import weakestpre.
 From D.Dot Require Export dot_lty dot_semtypes sem_kind_dot.
 
 Unset Program Cases.
-Set Suggest Proof Using.
 
 Implicit Types (Σ : gFunctors)
          (v w : vl) (e : tm) (d : dm) (ds : dms) (p : path)

--- a/theories/Dot/semtyp_lemmas/binding_lr.v
+++ b/theories/Dot/semtyp_lemmas/binding_lr.v
@@ -5,8 +5,6 @@ From D.Dot Require Import rules dot_semtypes later_sub_sem.
 
 Implicit Types (v : vl) (e : tm) (d : dm) (ds : dms) (ρ : env).
 
-Set Suggest Proof Using.
-
 Section LambdaIntros.
   Context `{HdlangG : !dlangG Σ}.
 

--- a/theories/Dot/semtyp_lemmas/binding_lr.v
+++ b/theories/Dot/semtyp_lemmas/binding_lr.v
@@ -6,7 +6,6 @@ From D.Dot Require Import rules dot_semtypes later_sub_sem.
 Implicit Types (v : vl) (e : tm) (d : dm) (ds : dms) (ρ : env).
 
 Set Suggest Proof Using.
-Set Default Proof Using "Type".
 
 Section LambdaIntros.
   Context `{HdlangG : !dlangG Σ}.

--- a/theories/Dot/semtyp_lemmas/defs_lr.v
+++ b/theories/Dot/semtyp_lemmas/defs_lr.v
@@ -5,7 +5,6 @@ From D.Dot Require Import dot_semtypes.
 Implicit Types (v : vl) (e : tm) (d : dm) (ds : dms).
 
 Set Suggest Proof Using.
-Set Default Proof Using "Type".
 
 Section Sec.
   Context `{HdotG : !dlangG Σ} `{!RecTyInterp Σ}.

--- a/theories/Dot/semtyp_lemmas/defs_lr.v
+++ b/theories/Dot/semtyp_lemmas/defs_lr.v
@@ -4,8 +4,6 @@ From D.Dot Require Import dot_semtypes.
 
 Implicit Types (v : vl) (e : tm) (d : dm) (ds : dms).
 
-Set Suggest Proof Using.
-
 Section Sec.
   Context `{HdotG : !dlangG Σ} `{!RecTyInterp Σ}.
 

--- a/theories/Dot/semtyp_lemmas/dsub_lr.v
+++ b/theories/Dot/semtyp_lemmas/dsub_lr.v
@@ -8,7 +8,6 @@ Implicit Types (Σ : gFunctors).
 Implicit Types (v : vl) (e : tm) (d : dm) (ds : dms) (ρ : env) (l : label).
 
 Set Suggest Proof Using.
-Set Default Proof Using "Type".
 Set Implicit Arguments.
 Unset Strict Implicit.
 

--- a/theories/Dot/semtyp_lemmas/dsub_lr.v
+++ b/theories/Dot/semtyp_lemmas/dsub_lr.v
@@ -7,7 +7,6 @@ From D.Dot Require Import dot_semtypes.
 Implicit Types (Σ : gFunctors).
 Implicit Types (v : vl) (e : tm) (d : dm) (ds : dms) (ρ : env) (l : label).
 
-Set Suggest Proof Using.
 Set Implicit Arguments.
 Unset Strict Implicit.
 

--- a/theories/Dot/semtyp_lemmas/later_sub_sem.v
+++ b/theories/Dot/semtyp_lemmas/later_sub_sem.v
@@ -5,7 +5,6 @@ From D Require Import proper.
 From D.Dot Require Import dot_semtypes.
 
 Set Suggest Proof Using.
-Set Default Proof Using "Type".
 
 (* This is specialized to [anil] because contexts only contain proper types anyway. *)
 Definition s_ty_sub `{HdlangG : !dlangG Σ} (T1 T2 : oltyO Σ) := ∀ ρ v, T1 anil ρ v -∗ T2 anil ρ v.

--- a/theories/Dot/semtyp_lemmas/later_sub_sem.v
+++ b/theories/Dot/semtyp_lemmas/later_sub_sem.v
@@ -4,8 +4,6 @@
 From D Require Import proper.
 From D.Dot Require Import dot_semtypes.
 
-Set Suggest Proof Using.
-
 (* This is specialized to [anil] because contexts only contain proper types anyway. *)
 Definition s_ty_sub `{HdlangG : !dlangG Σ} (T1 T2 : oltyO Σ) := ∀ ρ v, T1 anil ρ v -∗ T2 anil ρ v.
 Notation "s⊨T T1 <: T2" := (s_ty_sub T1 T2) (at level 74, T1, T2 at next level).

--- a/theories/Dot/semtyp_lemmas/path_repl_lr.v
+++ b/theories/Dot/semtyp_lemmas/path_repl_lr.v
@@ -10,8 +10,6 @@ Implicit Types
          (v w : vl) (t : tm) (d : dm) (ds : dms) (p q : path)
          (ρ : env) (l : label) (Pv : vl → Prop).
 
-Set Suggest Proof Using.
-
 Section semantic_lemmas.
   Context `{!dlangG Σ}.
   (** Non-pDOT rules start: *)

--- a/theories/Dot/semtyp_lemmas/path_repl_lr.v
+++ b/theories/Dot/semtyp_lemmas/path_repl_lr.v
@@ -11,7 +11,6 @@ Implicit Types
          (ρ : env) (l : label) (Pv : vl → Prop).
 
 Set Suggest Proof Using.
-Set Default Proof Using "Type".
 
 Section semantic_lemmas.
   Context `{!dlangG Σ}.

--- a/theories/Dot/semtyp_lemmas/prims_lr.v
+++ b/theories/Dot/semtyp_lemmas/prims_lr.v
@@ -9,8 +9,6 @@ From D.Dot Require Import rules dot_semtypes.
 
 Implicit Types (v : vl) (e : tm) (d : dm) (ds : dms) (n : Z).
 
-Set Suggest Proof Using.
-
 Inductive cond_bin_op_syntype : bin_op → ∀ (B1 B2 Br : base_ty),
   (prim_sem B1 → prim_sem B2 → Prop) → Set :=
 | ty_syn b B1 B2 Br : bin_op_syntype b B1 B2 Br →

--- a/theories/Dot/semtyp_lemmas/prims_lr.v
+++ b/theories/Dot/semtyp_lemmas/prims_lr.v
@@ -10,7 +10,6 @@ From D.Dot Require Import rules dot_semtypes.
 Implicit Types (v : vl) (e : tm) (d : dm) (ds : dms) (n : Z).
 
 Set Suggest Proof Using.
-Set Default Proof Using "Type".
 
 Inductive cond_bin_op_syntype : bin_op → ∀ (B1 B2 Br : base_ty),
   (prim_sem B1 → prim_sem B2 → Prop) → Set :=

--- a/theories/Dot/semtyp_lemmas/tproj_lr.v
+++ b/theories/Dot/semtyp_lemmas/tproj_lr.v
@@ -23,8 +23,6 @@ From D.Dot Require Import sem_unstamped_typing.
 Implicit Types (Σ : gFunctors).
 Implicit Types (v : vl) (e : tm) (d : dm) (ds : dms) (ρ : env) (l : label).
 
-Set Suggest Proof Using.
-
 Definition oExists `{!dlangG Σ} (T : oltyO Σ) (U : oltyO Σ) : oltyO Σ :=
   Olty (λI args ρ v,
   ∃ w,

--- a/theories/Dot/semtyp_lemmas/tproj_lr.v
+++ b/theories/Dot/semtyp_lemmas/tproj_lr.v
@@ -24,7 +24,6 @@ Implicit Types (Σ : gFunctors).
 Implicit Types (v : vl) (e : tm) (d : dm) (ds : dms) (ρ : env) (l : label).
 
 Set Suggest Proof Using.
-Set Default Proof Using "Type".
 
 Definition oExists `{!dlangG Σ} (T : oltyO Σ) (U : oltyO Σ) : oltyO Σ :=
   Olty (λI args ρ v,

--- a/theories/Dot/syn/path_repl.v
+++ b/theories/Dot/syn/path_repl.v
@@ -17,8 +17,6 @@ Implicit Types
          (T : ty) (K : kind) (v w : vl) (t : tm) (d : dm) (ds : dms) (p q : path)
          (l : label).
 
-Set Suggest Proof Using.
-
 Notation unshift T := T.|[ren pred].
 Notation unshiftV v := v.[ren pred].
 

--- a/theories/Dot/syn/path_repl.v
+++ b/theories/Dot/syn/path_repl.v
@@ -18,7 +18,6 @@ Implicit Types
          (l : label).
 
 Set Suggest Proof Using.
-Set Default Proof Using "Type".
 
 Notation unshift T := T.|[ren pred].
 Notation unshiftV v := v.[ren pred].

--- a/theories/Dot/syn/rules.v
+++ b/theories/Dot/syn/rules.v
@@ -8,7 +8,6 @@ From D Require Import iris_extra.det_reduction.
 From D.Dot Require Import syn.
 
 Set Suggest Proof Using.
-Set Default Proof Using "Type".
 
 Implicit Types e : tm.
 

--- a/theories/Dot/syn/rules.v
+++ b/theories/Dot/syn/rules.v
@@ -7,8 +7,6 @@ From iris.program_logic Require Import language ectx_language.
 From D Require Import iris_extra.det_reduction.
 From D.Dot Require Import syn.
 
-Set Suggest Proof Using.
-
 Implicit Types e : tm.
 
 Section lang_rules.

--- a/theories/Dot/syn/skeleton.v
+++ b/theories/Dot/syn/skeleton.v
@@ -8,7 +8,6 @@ From D.Dot Require Import syn rules.
 Set Implicit Arguments.
 
 Set Suggest Proof Using.
-Set Default Proof Using "Type".
 
 Implicit Types (efs : list tm) (σ : ()) (e : tm).
 Implicit Types (t : tm) (v : vl) (d : dm) (ds : dms) (p : path) (T : ty).

--- a/theories/Dot/syn/skeleton.v
+++ b/theories/Dot/syn/skeleton.v
@@ -7,8 +7,6 @@ From D.Dot Require Import syn rules.
 
 Set Implicit Arguments.
 
-Set Suggest Proof Using.
-
 Implicit Types (efs : list tm) (σ : ()) (e : tm).
 Implicit Types (t : tm) (v : vl) (d : dm) (ds : dms) (p : path) (T : ty).
 

--- a/theories/Dot/syn/syn.v
+++ b/theories/Dot/syn/syn.v
@@ -11,8 +11,6 @@ From D Require Import asubst_intf asubst_base.
 From iris.program_logic Require ectx_language.
 From iris.program_logic Require Import ectxi_language.
 
-Set Suggest Proof Using.
-
 (**
 This module is included right away, but it asserts explicitly
 that it implements our language interface [VlSortsFullSig].

--- a/theories/Dot/syn/syn.v
+++ b/theories/Dot/syn/syn.v
@@ -12,7 +12,6 @@ From iris.program_logic Require ectx_language.
 From iris.program_logic Require Import ectxi_language.
 
 Set Suggest Proof Using.
-Set Default Proof Using "Type".
 
 (**
 This module is included right away, but it asserts explicitly

--- a/theories/Dot/syn/traversals.v
+++ b/theories/Dot/syn/traversals.v
@@ -3,8 +3,6 @@ From D.Dot Require Import syn.
 Set Primitive Projections.
 Set Implicit Arguments.
 
-Set Suggest Proof Using.
-
 Implicit Types
          (S T U : ty) (v : vl) (e t : tm) (p : path) (d : dm) (ds : dms) (vs : vls)
          (Γ : ctx).

--- a/theories/Dot/syn/traversals.v
+++ b/theories/Dot/syn/traversals.v
@@ -4,7 +4,6 @@ Set Primitive Projections.
 Set Implicit Arguments.
 
 Set Suggest Proof Using.
-Set Default Proof Using "Type".
 
 Implicit Types
          (S T U : ty) (v : vl) (e t : tm) (p : path) (d : dm) (ds : dms) (vs : vls)

--- a/theories/Dot/syntyp_lemmas/binding_lr_syn.v
+++ b/theories/Dot/syntyp_lemmas/binding_lr_syn.v
@@ -8,7 +8,6 @@ From D.Dot Require Import binding_lr.
 Implicit Types (v : vl) (e : tm) (d : dm) (ds : dms) (ρ : env).
 
 Set Suggest Proof Using.
-Set Default Proof Using "Type".
 Set Implicit Arguments.
 Unset Strict Implicit.
 

--- a/theories/Dot/syntyp_lemmas/binding_lr_syn.v
+++ b/theories/Dot/syntyp_lemmas/binding_lr_syn.v
@@ -7,7 +7,6 @@ From D.Dot Require Import binding_lr.
 
 Implicit Types (v : vl) (e : tm) (d : dm) (ds : dms) (ρ : env).
 
-Set Suggest Proof Using.
 Set Implicit Arguments.
 Unset Strict Implicit.
 

--- a/theories/Dot/syntyp_lemmas/dsub_lr_syn.v
+++ b/theories/Dot/syntyp_lemmas/dsub_lr_syn.v
@@ -8,7 +8,6 @@ Implicit Types (Σ : gFunctors).
 Implicit Types (v : vl) (e : tm) (d : dm) (ds : dms) (ρ : env) (l : label).
 
 Set Suggest Proof Using.
-Set Default Proof Using "Type".
 Set Implicit Arguments.
 Unset Strict Implicit.
 

--- a/theories/Dot/syntyp_lemmas/dsub_lr_syn.v
+++ b/theories/Dot/syntyp_lemmas/dsub_lr_syn.v
@@ -7,7 +7,6 @@ From D.Dot Require Import unary_lr dsub_lr.
 Implicit Types (Σ : gFunctors).
 Implicit Types (v : vl) (e : tm) (d : dm) (ds : dms) (ρ : env) (l : label).
 
-Set Suggest Proof Using.
 Set Implicit Arguments.
 Unset Strict Implicit.
 

--- a/theories/Dot/syntyp_lemmas/later_sub_syn.v
+++ b/theories/Dot/syntyp_lemmas/later_sub_syn.v
@@ -8,8 +8,6 @@ From D.Dot Require Import typing_aux_defs.
 From D.Dot Require Import type_eq.
 From D.Dot Require Import dsub_lr. (* XXX *)
 
-Set Suggest Proof Using.
-
 Section TypeEquiv.
   Context `{HdlangG : !dlangG Σ}.
 

--- a/theories/Dot/syntyp_lemmas/later_sub_syn.v
+++ b/theories/Dot/syntyp_lemmas/later_sub_syn.v
@@ -9,7 +9,6 @@ From D.Dot Require Import type_eq.
 From D.Dot Require Import dsub_lr. (* XXX *)
 
 Set Suggest Proof Using.
-Set Default Proof Using "Type".
 
 Section TypeEquiv.
   Context `{HdlangG : !dlangG Σ}.

--- a/theories/Dot/syntyp_lemmas/path_repl_lr_syn.v
+++ b/theories/Dot/syntyp_lemmas/path_repl_lr_syn.v
@@ -11,9 +11,6 @@ Implicit Types
          (v w : vl) (t : tm) (d : dm) (ds : dms) (p q : path)
          (ρ : env) (l : label) (Pv : vl → Prop).
 
-Set Suggest Proof Using.
-
-
 Section path_repl.
   Context `{!dlangG Σ}.
 

--- a/theories/Dot/syntyp_lemmas/path_repl_lr_syn.v
+++ b/theories/Dot/syntyp_lemmas/path_repl_lr_syn.v
@@ -12,7 +12,6 @@ Implicit Types
          (ρ : env) (l : label) (Pv : vl → Prop).
 
 Set Suggest Proof Using.
-Set Default Proof Using "Type".
 
 
 Section path_repl.

--- a/theories/Dot/syntyp_lemmas/prims_lr_syn.v
+++ b/theories/Dot/syntyp_lemmas/prims_lr_syn.v
@@ -9,8 +9,6 @@ From D.Dot Require Import unary_lr prims_lr.
 
 Implicit Types (v : vl) (e : tm) (d : dm) (ds : dms) (ρ : env).
 
-Set Suggest Proof Using.
-
 Section Sec.
   Context `{HdlangG : !dlangG Σ}.
 

--- a/theories/Dot/syntyp_lemmas/prims_lr_syn.v
+++ b/theories/Dot/syntyp_lemmas/prims_lr_syn.v
@@ -10,7 +10,6 @@ From D.Dot Require Import unary_lr prims_lr.
 Implicit Types (v : vl) (e : tm) (d : dm) (ds : dms) (ρ : env).
 
 Set Suggest Proof Using.
-Set Default Proof Using "Type".
 
 Section Sec.
   Context `{HdlangG : !dlangG Σ}.

--- a/theories/Dot/typing/subtyping.v
+++ b/theories/Dot/typing/subtyping.v
@@ -7,7 +7,6 @@ From D.Dot Require Export core_stamping_defs.
 Set Implicit Arguments.
 Unset Strict Implicit.
 Set Suggest Proof Using.
-Set Default Proof Using "Type".
 
 Implicit Types (L T U : ty) (v : vl) (e : tm) (d : dm) (p : path) (ds : dms) (Γ : list ty).
 

--- a/theories/Dot/typing/subtyping.v
+++ b/theories/Dot/typing/subtyping.v
@@ -6,7 +6,6 @@ From D.Dot Require Export core_stamping_defs.
 
 Set Implicit Arguments.
 Unset Strict Implicit.
-Set Suggest Proof Using.
 
 Implicit Types (L T U : ty) (v : vl) (e : tm) (d : dm) (p : path) (ds : dms) (Γ : list ty).
 

--- a/theories/asubst_base.v
+++ b/theories/asubst_base.v
@@ -2,8 +2,6 @@
 From iris.program_logic Require Import language.
 From D Require Import prelude asubst_intf.
 
-Set Suggest Proof Using.
-
 (** The module type [Sorts] is a "mixin module" that is included directly in
 each language implementing [ValuesSig],
 *)

--- a/theories/asubst_base.v
+++ b/theories/asubst_base.v
@@ -3,7 +3,6 @@ From iris.program_logic Require Import language.
 From D Require Import prelude asubst_intf.
 
 Set Suggest Proof Using.
-Set Default Proof Using "Type".
 
 (** The module type [Sorts] is a "mixin module" that is included directly in
 each language implementing [ValuesSig],

--- a/theories/iris_extra/det_reduction.v
+++ b/theories/iris_extra/det_reduction.v
@@ -2,7 +2,6 @@
 From D Require Import prelude.
 From iris.program_logic Require language ectx_language.
 
-Set Suggest Proof Using.
 Set Default Proof Using "Type*".
 
 Set Implicit Arguments.

--- a/theories/iris_extra/dlang.v
+++ b/theories/iris_extra/dlang.v
@@ -6,8 +6,6 @@ From D Require Import iris_prelude asubst_intf cmra_prop_lift
 From D Require saved_interp_n.
 From D.iris_extra Require det_reduction.
 
-Set Suggest Proof Using.
-
 Module Type LiftWp (Import VS : VlSortsSig).
   Export prelude saved_interp_n.
   Implicit Types (v : vl) (σ vs : vls) (Σ : gFunctors).

--- a/theories/iris_extra/dlang.v
+++ b/theories/iris_extra/dlang.v
@@ -7,7 +7,6 @@ From D Require saved_interp_n.
 From D.iris_extra Require det_reduction.
 
 Set Suggest Proof Using.
-Set Default Proof Using "Type".
 
 Module Type LiftWp (Import VS : VlSortsSig).
   Export prelude saved_interp_n.

--- a/theories/iris_extra/lty.v
+++ b/theories/iris_extra/lty.v
@@ -20,8 +20,6 @@ From D Require Import prelude iris_prelude asubst_intf dlang proper.
 
 Implicit Types (Σ : gFunctors).
 
-Set Suggest Proof Using.
-
 #[global] Instance bottom_fun {A} `{Bottom B} : Bottom (A → B) := (λ _, ⊥).
 #[global] Instance top_fun {A} `{Top B} : Top (A → B) := (λ _, ⊤).
 #[global] Instance bottom_ofe_fun {A} {B : ofe} `{Bottom B} : Bottom (A -d> B) := (λ _, ⊥).

--- a/theories/iris_extra/lty.v
+++ b/theories/iris_extra/lty.v
@@ -21,7 +21,6 @@ From D Require Import prelude iris_prelude asubst_intf dlang proper.
 Implicit Types (Σ : gFunctors).
 
 Set Suggest Proof Using.
-Set Default Proof Using "Type".
 
 #[global] Instance bottom_fun {A} `{Bottom B} : Bottom (A → B) := (λ _, ⊥).
 #[global] Instance top_fun {A} `{Top B} : Top (A → B) := (λ _, ⊤).

--- a/theories/iris_extra/proofmode_extra.v
+++ b/theories/iris_extra/proofmode_extra.v
@@ -1,4 +1,5 @@
 From iris.proofmode Require Import proofmode.
+From D Require Import prelude.
 Import bi.
 
 Set Suggest Proof Using.

--- a/theories/iris_extra/proofmode_extra.v
+++ b/theories/iris_extra/proofmode_extra.v
@@ -2,8 +2,6 @@ From iris.proofmode Require Import proofmode.
 From D Require Import prelude.
 Import bi.
 
-Set Suggest Proof Using.
-
 Tactic Notation "iSplitWith" constr(H) "as" constr(H') :=
   iApply (bi.and_parallel with H); iSplit; iIntros H'.
 

--- a/theories/iris_extra/proofmode_extra.v
+++ b/theories/iris_extra/proofmode_extra.v
@@ -3,7 +3,6 @@ From D Require Import prelude.
 Import bi.
 
 Set Suggest Proof Using.
-Set Default Proof Using "Type".
 
 Tactic Notation "iSplitWith" constr(H) "as" constr(H') :=
   iApply (bi.and_parallel with H); iSplit; iIntros H'.

--- a/theories/iris_extra/saved_interp_dep.v
+++ b/theories/iris_extra/saved_interp_dep.v
@@ -4,7 +4,6 @@ From stdpp Require Import vector.
 From D Require Import prelude iris_prelude asubst_intf.
 
 Set Suggest Proof Using.
-Set Default Proof Using "Type".
 
 Import EqNotations.
 Unset Program Cases.

--- a/theories/iris_extra/saved_interp_dep.v
+++ b/theories/iris_extra/saved_interp_dep.v
@@ -3,8 +3,6 @@ From iris.base_logic Require Import lib.saved_prop.
 From stdpp Require Import vector.
 From D Require Import prelude iris_prelude asubst_intf.
 
-Set Suggest Proof Using.
-
 Import EqNotations.
 Unset Program Cases.
 

--- a/theories/pure_program_logic/adequacy.v
+++ b/theories/pure_program_logic/adequacy.v
@@ -2,7 +2,6 @@
 From stdpp Require Import relations.
 From iris.proofmode Require Import proofmode.
 From D.pure_program_logic Require Export weakestpre.
-Set Default Proof Using "Type".
 Import uPred.
 Import relations.
 

--- a/theories/pure_program_logic/lifting.v
+++ b/theories/pure_program_logic/lifting.v
@@ -1,7 +1,6 @@
 (** * Lift operational semantics to expression weakest preconditions. *)
 From D.pure_program_logic Require Export weakestpre.
 From iris.proofmode Require Import proofmode.
-Set Default Proof Using "Type".
 
 Section lifting.
 Context `{irisGS Λ Σ}.

--- a/theories/pure_program_logic/weakestpre.v
+++ b/theories/pure_program_logic/weakestpre.v
@@ -10,7 +10,6 @@ From iris.bi Require Export weakestpre.
 From iris.proofmode Require Import base proofmode classes.
 
 From D.iris_extra Require Export det_reduction.
-Set Default Proof Using "Type".
 Import uPred.
 
 Class irisGS (Λ : language) (Σ : gFunctors) `{InhabitedState Λ} := IrisG {


### PR DESCRIPTION
~~Beware: this is not correct, since it removes this settings from files that don't load the prelude.~~