### PR TITLE
Fix #381: Revise `Proper` instances, prove that `clty` is a `Cofe`

### DIFF
--- a/theories/Dot/examples/sem/semtyp_lemmas/sub_lr.v
+++ b/theories/Dot/examples/sem/semtyp_lemmas/sub_lr.v
@@ -29,7 +29,7 @@ Section Propers.
   Context `{HdotG: !dlangG Σ}.
   Implicit Types (τ L T U : olty Σ).
 
-  #[global] Instance sstpi_proper i j : Proper ((≡) ==> (≡) ==> (≡) ==> (≡)) (sstpi i j).
+  #[global] Instance sstpi_proper i j : Proper3 (sstpi i j).
   Proof.
     solve_proper_ho.
     (* intros ?? HG ?? H1 ?? H2; simplify_eq/=.

--- a/theories/Dot/hkdot/hkdot.v
+++ b/theories/Dot/hkdot/hkdot.v
@@ -58,7 +58,7 @@ Section gen_lemmas.
   Context `{Hdlang : dlangG Σ} `{HswapProp: SwapPropI Σ}.
 
   #[global] Instance sstpiK_proper i :
-    Proper ((≡) ==> (≡) ==> (≡) ==> (≡) ==> (≡)) (sstpiK (Σ := Σ) i).
+    Proper4 (sstpiK (Σ := Σ) i).
   Proof.
     rewrite /sstpiK=> Γ1 Γ2 HΓ T1 T2 HT U1 U2 HU K1 K2 HK.
     properness; rewrite (HΓ, HK); first done.
@@ -73,7 +73,7 @@ Section gen_lemmas.
   Proof. iIntros ">#HT !>" (ρ) "#Hg /=". iApply (Hsub with "Hg (HT Hg)"). Qed.
 
   #[global] Instance sSkd_proper i :
-    Proper ((≡) ==> (≡) ==> (≡) ==> (≡)) (sSkd (Σ := Σ) i).
+    Proper3 (sSkd (Σ := Σ) i).
   Proof.
     rewrite /sSkd => Γ1 Γ2 HΓ K1 K2 HK1 K3 K4 HK2.
     by properness; rewrite (HΓ, HK1, HK2).

--- a/theories/Dot/hkdot/sem_kind.v
+++ b/theories/Dot/hkdot/sem_kind.v
@@ -520,7 +520,7 @@ Section ho_intv.
   Qed.
 
   #[global] Instance ho_intv_proper {n}:
-    Proper ((≡) ==> (≡) ==> (≡) ==> (≡)) (ho_intv (n := n) (Σ := Σ)).
+    Proper3 (ho_intv (n := n) (Σ := Σ)).
   Proof.
     move=> K1 K2 /equiv_dist HK L1 L2 /equiv_dist HL U1 U2 /equiv_dist HU.
     apply /equiv_dist => m.

--- a/theories/Dot/hkdot/sem_kind.v
+++ b/theories/Dot/hkdot/sem_kind.v
@@ -444,11 +444,15 @@ Section s_kind_rel_proper.
   #[global] Instance s_kpi_proper n : Proper2 (s_kpi (Σ := Σ) (n := n)) := _.
 End s_kind_rel_proper.
 
-#[global] Instance s_kind_ids {Σ} : ∀ n, Ids (s_kind Σ n) := fix s_kind_ids n := λ _,
-  match n with
-  | 0 => s_kintv oTop oBot
-  | n.+1 => s_kpi inhabitant (s_kind_ids _ 0)
-  end.
+#[global] Instance s_kind_inhabited {Σ} : ∀ {n}, Inhabited (s_kind Σ n) :=
+  fix s_kind_inh n := populate $
+    match n with
+    | 0 => s_kintv oTop oBot
+    | n.+1 => s_kpi inhabitant (@inhabitant _ (s_kind_inh n))
+    end.
+#[global] Instance s_kind_ids {Σ} {n} : Ids (s_kind Σ n) :=
+  ASubstLangDefUtils.inh_ids.
+
 #[global] Instance hsubst_s_kind {Σ} : ∀ {n}, HSubst vl (s_kind Σ n) :=
   fix s_kind_hsubst {n} (ρ : env) (K : s_kindO Σ n) {struct K} : s_kindO Σ n :=
   match K with
@@ -464,7 +468,9 @@ End s_kind_rel_proper.
 Proof.
   split => //.
   - elim=> [S1 S2|{}n S K IHK] /=; by rewrite /= ?up_id ?IHK !hsubst_id.
-  - elim: n => [//|n + θ x] /=. by move ->.
+  - elim: n => [//|n + θ x] /=.
+    (* Defining [s_kind_ids] using [inh_ids] gives slightly odd reduction rules. *)
+    by rewrite (_ : inhabitant = ids (term := s_kind Σ n) 0) // => ->.
   - move=> + + K; elim: K => [S1 S2|{}n S K IHK] θ η /=;
       by rewrite !hsubst_comp ?IHK ?up_comp.
 Qed.

--- a/theories/Dot/hkdot/sem_kind.v
+++ b/theories/Dot/hkdot/sem_kind.v
@@ -212,18 +212,25 @@ Section sf_kind_subst.
     K.|[up (ren (+1))].|[ids 0/] ≡ K.
   Proof. move=> ρ /=; f_equiv; autosubst. Qed.
 
-  Definition oLam (τ : oltyO Σ) : oltyO Σ :=
-    Olty (λI args ρ, τ (atail args) (ahead args .: ρ)).
-    (* auncurry (λ v, Olty (λ args ρ, τ args (v .: ρ))). *)
-
-  Definition _oTAppV w (T : oltyO Σ) : oltyO Σ :=
-    Olty (λI args ρ, T (acons w.[ρ] args) ρ).
-
 End sf_kind_subst.
 
-Notation oTAppV T w := (_oTAppV w T).
+Definition oLam {Σ} (τ : oltyO Σ) : oltyO Σ :=
+  Olty (λI args ρ, τ (atail args) (ahead args .: ρ)).
+  (* auncurry (λ v, Olty (λ args ρ, τ args (v .: ρ))). *)
+
 #[global] Instance: Params (@oLam) 1 := {}.
+
+(* Arguments are ordered to optimize setoid rewriting and maximize [Params]. *)
+Definition _oTAppV {Σ} w (T : oltyO Σ) : oltyO Σ :=
+  Olty (λI args ρ, T (acons w.[ρ] args) ρ).
+
+(* Show a more natural ordering to the user. *)
+Notation oTAppV T w := (_oTAppV w T).
 #[global] Instance: Params (@_oTAppV) 2 := {}.
+
+Definition sr_kintv `{dlangG Σ} (L U : oltyO Σ) : sr_kind Σ := λI ρ φ1 φ2,
+  oClose L ρ ⊆ oClose φ1 ⊆ oClose φ2 ⊆ oClose U ρ.
+#[global] Instance: Params (@sr_kintv) 3 := {}.
 
 Section utils.
   Context `{dlangG Σ}.
@@ -249,9 +256,6 @@ Section utils.
   Lemma envApply_oTAppV_eq (T : olty Σ) v ρ :
     envApply (oTAppV T v) ρ ≡ acurry (envApply T ρ) v.[ρ].
   Proof. done. Qed.
-
-  Definition sr_kintv (L U : oltyO Σ) : sr_kind Σ := λI ρ φ1 φ2,
-    oClose L ρ ⊆ oClose φ1 ⊆ oClose φ2 ⊆ oClose U ρ.
 
   Lemma sr_kintv_refl L U ρ φ :
     sr_kintv L U ρ φ φ ⊣⊢ oClose L ρ ⊆ oClose φ ⊆ oClose U ρ.

--- a/theories/Dot/hkdot/sem_kind.v
+++ b/theories/Dot/hkdot/sem_kind.v
@@ -222,6 +222,7 @@ Section sf_kind_subst.
 End sf_kind_subst.
 
 Notation oTAppV T w := (_oTAppV w T).
+#[global] Instance: Params (@oLam) 1 := {}.
 #[global] Instance: Params (@_oTAppV) 2 := {}.
 
 Section utils.
@@ -302,6 +303,7 @@ Next Obligation.
   intros; rewrite sr_kintv_refl; iIntros "/= #(A & B & $)".
   iApply (subtype_trans with "A B").
 Qed.
+#[global] Instance : Params (@sf_kintv) 3 := {}.
 
 Notation sf_star := (sf_kintv oBot oTop).
 
@@ -335,6 +337,7 @@ Qed.
 Next Obligation.
   intros; iIntros "/= #H * #Harg"; iApply (sf_kind_sub_quasi_refl_2 with "(H Harg)").
 Qed.
+#[global] Instance : Params (@sf_kpi) 3 := {}.
 
 Section kinds_types.
   Context `{dlangG Σ}.

--- a/theories/Dot/hkdot/sem_kind.v
+++ b/theories/Dot/hkdot/sem_kind.v
@@ -444,12 +444,14 @@ Section s_kind_rel_proper.
   #[global] Instance s_kpi_proper n : Proper2 (s_kpi (Σ := Σ) (n := n)) := _.
 End s_kind_rel_proper.
 
-#[global] Instance s_kind_inhabited {Σ} : ∀ {n}, Inhabited (s_kind Σ n) :=
-  fix s_kind_inh n := populate $
-    match n with
-    | 0 => s_kintv oTop oBot
-    | n.+1 => s_kpi inhabitant (@inhabitant _ (s_kind_inh n))
-    end.
+Fixpoint s_kind_dummy {Σ n} : s_kind Σ n :=
+  match n with
+  | 0 => s_kintv oTop oBot
+  | n.+1 => s_kpi inhabitant s_kind_dummy
+  end.
+
+#[global] Instance s_kind_inhabited {Σ n} : Inhabited (s_kind Σ n) :=
+  populate s_kind_dummy.
 #[global] Instance s_kind_ids {Σ} {n} : Ids (s_kind Σ n) :=
   ASubstLangDefUtils.inh_ids.
 
@@ -468,9 +470,10 @@ End s_kind_rel_proper.
 Proof.
   split => //.
   - elim=> [S1 S2|{}n S K IHK] /=; by rewrite /= ?up_id ?IHK !hsubst_id.
-  - elim: n => [//|n + θ x] /=.
-    (* Defining [s_kind_ids] using [inh_ids] gives slightly odd reduction rules. *)
-    by rewrite (_ : inhabitant = ids (term := s_kind Σ n) 0) // => ->.
+  - (* Defining [s_kind_ids] using [inh_ids] gives slightly odd reduction rules. *)
+    rewrite /ids/s_kind_ids/ASubstLangDefUtils.inh_ids.
+    elim: n => [//|n + θ x] /=.
+    by move->.
   - move=> + + K; elim: K => [S1 S2|{}n S K IHK] θ η /=;
       by rewrite !hsubst_comp ?IHK ?up_comp.
 Qed.

--- a/theories/Dot/hkdot/sem_kind.v
+++ b/theories/Dot/hkdot/sem_kind.v
@@ -222,7 +222,7 @@ Section sf_kind_subst.
 End sf_kind_subst.
 
 Notation oTAppV T w := (_oTAppV w T).
-#[global] Instance: Params (@_oTAppV) 3 := {}.
+#[global] Instance: Params (@_oTAppV) 2 := {}.
 
 Section utils.
   Context `{dlangG Σ}.

--- a/theories/Dot/hkdot/sem_kind.v
+++ b/theories/Dot/hkdot/sem_kind.v
@@ -154,7 +154,7 @@ Qed.
 (* This is really properness of sf_kind_sub; but it's also proper over the
 first argument K. Maybe that's worth a wrapper with swapped arguments. *)
 Lemma sf_kind_proper {Σ} (K : sf_kind Σ) ρ :
-  Proper ((≡) ==> (≡) ==> (≡)) (K ρ).
+  Proper2 (K ρ).
 Proof. move=> T1 T2 HT U1 U2 HU. exact: sf_kind_sub_proper. Qed.
 Lemma sf_kind_proper' {Σ} (K : sf_kind Σ) ρ T1 T2 :
   T1 ≡ T2 → K ρ T1 T1 ≡ K ρ T2 T2.
@@ -184,7 +184,7 @@ Section sf_kind_subst.
   Proof. solve_proper_ho. Qed.
 
   #[global] Instance hsubst_sf_kind_proper ρ :
-    Proper ((≡) ==> (≡)) (hsubst (outer := sf_kind Σ) ρ) := ne_proper _.
+    Proper1 (hsubst (outer := sf_kind Σ) ρ) := ne_proper _.
 
   Definition kSubstOne {Σ} v (K : sf_kind Σ) : sf_kind Σ :=
     kSub (λ ρ, v.[ρ] .: ρ) K.
@@ -230,13 +230,13 @@ Section utils.
   #[global] Instance _oTAppV_ne v: NonExpansive (_oTAppV (Σ := Σ) v).
   Proof. solve_proper_ho. Qed.
   #[global] Instance _oTAppV_proper v:
-    Proper ((≡) ==> (≡)) (_oTAppV (Σ := Σ) v) := ne_proper _.
+    Proper1 (_oTAppV (Σ := Σ) v) := ne_proper _.
 
   #[global] Instance oLam_ne : NonExpansive (oLam (Σ := Σ)).
   Proof. solve_proper_ho. Qed.
 
   #[global] Instance oLam_proper :
-    Proper ((≡) ==> (≡)) (oLam (Σ := Σ)) := ne_proper _.
+    Proper1 (oLam (Σ := Σ)) := ne_proper _.
 
   Lemma oTAppV_subst (T : olty Σ) v ρ :
     (oTAppV T v).|[ρ] ≡ oTAppV T.|[ρ] v.[ρ].
@@ -342,12 +342,12 @@ Section kinds_types.
   #[global] Instance sf_kintv_ne : NonExpansive2 (sf_kintv (Σ := Σ)).
   Proof. rewrite /sf_kintv /sr_kintv. solve_proper_ho. Qed.
   #[global] Instance sf_kintv_proper :
-    Proper ((≡) ==> (≡) ==> (≡)) (sf_kintv (Σ := Σ)) := ne_proper_2 _.
+    Proper2 (sf_kintv (Σ := Σ)) := ne_proper_2 _.
 
   #[global] Instance sf_kpi_ne : NonExpansive2 (sf_kpi (Σ := Σ)).
   Proof. solve_proper_ho. Qed.
   #[global] Instance sf_kpi_proper :
-    Proper ((≡) ==> (≡) ==> (≡)) (sf_kpi (Σ := Σ)) := ne_proper_2 _.
+    Proper2 (sf_kpi (Σ := Σ)) := ne_proper_2 _.
 
   Lemma kShift_sf_kpi_eq S (K : sf_kind Σ) :
     kShift (sf_kpi S K) ≡ sf_kpi (oShift S) K.|[up (ren (+1))].
@@ -439,9 +439,9 @@ Section s_kind_rel_proper.
   #[global] Instance s_kpi_ne n : NonExpansive2 (s_kpi (Σ := Σ) (n := n)).
   Proof. apply _. Qed.
 
-  #[global] Instance s_kintv_proper : Proper ((≡) ==> (≡) ==> (≡)) (s_kintv (Σ := Σ)).
+  #[global] Instance s_kintv_proper : Proper2 (s_kintv (Σ := Σ)).
   Proof. apply _. Qed.
-  #[global] Instance s_kpi_proper n : Proper ((≡) ==> (≡) ==> (≡)) (s_kpi (Σ := Σ) (n := n)).
+  #[global] Instance s_kpi_proper n : Proper2 (s_kpi (Σ := Σ) (n := n)).
   Proof. apply _. Qed.
 End s_kind_rel_proper.
 
@@ -486,7 +486,7 @@ Section s_kind_to_sf_kind.
     NonExpansive (s_kind_to_sf_kind (n := n)).
   Proof. by induction 1; cbn; f_equiv. Qed.
   #[global] Instance s_kind_to_sf_kind_proper {n} :
-    Proper ((≡) ==> (≡)) (s_kind_to_sf_kind (n := n)) := ne_proper _.
+    Proper1 (s_kind_to_sf_kind (n := n)) := ne_proper _.
 
   Lemma s_kind_equiv_intro {n} (K1 K2 : s_kind Σ n) : K1 ≡ K2 → s_to_sf K1 ≡@{sf_kind _} s_to_sf K2.
   Proof. apply s_kind_to_sf_kind_proper. Qed.

--- a/theories/Dot/hkdot/sem_kind.v
+++ b/theories/Dot/hkdot/sem_kind.v
@@ -457,6 +457,7 @@ Fixpoint s_kind_hsubst {Σ n} (ρ : env) (K : s_kindO Σ n) : s_kindO Σ n :=
     s_kpi S.|[ρ] K.|[up ρ]
   end.
 #[global] Instance hsubst_s_kind {Σ n} : HSubst vl (s_kind Σ n) := s_kind_hsubst.
+(* TODO #381: does this work reasonably? *)
 #[global] Instance: Params (@hsubst_s_kind) 2 := {}.
 
 #[global] Instance s_kind_hsubst_lemmas {Σ n} : HSubstLemmas vl (s_kind Σ n).

--- a/theories/Dot/hkdot/sem_kind.v
+++ b/theories/Dot/hkdot/sem_kind.v
@@ -229,14 +229,14 @@ Section utils.
 
   #[global] Instance _oTAppV_ne v: NonExpansive (_oTAppV (Σ := Σ) v).
   Proof. solve_proper_ho. Qed.
-  #[global] Instance _oTAppV_proper v:
-    Proper1 (_oTAppV (Σ := Σ) v) := ne_proper _.
+  #[global] Instance _oTAppV_proper v: Proper1 (_oTAppV (Σ := Σ) v) :=
+    ne_proper _.
 
   #[global] Instance oLam_ne : NonExpansive (oLam (Σ := Σ)).
   Proof. solve_proper_ho. Qed.
 
-  #[global] Instance oLam_proper :
-    Proper1 (oLam (Σ := Σ)) := ne_proper _.
+  #[global] Instance oLam_proper : Proper1 (oLam (Σ := Σ)) :=
+    ne_proper _.
 
   Lemma oTAppV_subst (T : olty Σ) v ρ :
     (oTAppV T v).|[ρ] ≡ oTAppV T.|[ρ] v.[ρ].
@@ -341,13 +341,13 @@ Section kinds_types.
 
   #[global] Instance sf_kintv_ne : NonExpansive2 (sf_kintv (Σ := Σ)).
   Proof. rewrite /sf_kintv /sr_kintv. solve_proper_ho. Qed.
-  #[global] Instance sf_kintv_proper :
-    Proper2 (sf_kintv (Σ := Σ)) := ne_proper_2 _.
+  #[global] Instance sf_kintv_proper : Proper2 (sf_kintv (Σ := Σ)) :=
+    ne_proper_2 _.
 
   #[global] Instance sf_kpi_ne : NonExpansive2 (sf_kpi (Σ := Σ)).
   Proof. solve_proper_ho. Qed.
-  #[global] Instance sf_kpi_proper :
-    Proper2 (sf_kpi (Σ := Σ)) := ne_proper_2 _.
+  #[global] Instance sf_kpi_proper : Proper2 (sf_kpi (Σ := Σ)) :=
+    ne_proper_2 _.
 
   Lemma kShift_sf_kpi_eq S (K : sf_kind Σ) :
     kShift (sf_kpi S K) ≡ sf_kpi (oShift S) K.|[up (ren (+1))].
@@ -434,15 +434,11 @@ End s_kind_rel_proper.
 Section s_kind_rel_proper.
   Context {Σ}.
 
-  #[global] Instance s_kintv_ne : NonExpansive2 (s_kintv (Σ := Σ)).
-  Proof. apply _. Qed.
-  #[global] Instance s_kpi_ne n : NonExpansive2 (s_kpi (Σ := Σ) (n := n)).
-  Proof. apply _. Qed.
+  #[global] Instance s_kintv_ne : NonExpansive2 (s_kintv (Σ := Σ)) := _.
+  #[global] Instance s_kintv_proper : Proper2 (s_kintv (Σ := Σ)) := _.
 
-  #[global] Instance s_kintv_proper : Proper2 (s_kintv (Σ := Σ)).
-  Proof. apply _. Qed.
-  #[global] Instance s_kpi_proper n : Proper2 (s_kpi (Σ := Σ) (n := n)).
-  Proof. apply _. Qed.
+  #[global] Instance s_kpi_ne n : NonExpansive2 (s_kpi (Σ := Σ) (n := n)) := _.
+  #[global] Instance s_kpi_proper n : Proper2 (s_kpi (Σ := Σ) (n := n)) := _.
 End s_kind_rel_proper.
 
 #[global] Instance s_kind_ids {Σ} : ∀ n, Ids (s_kind Σ n) := fix s_kind_ids n := λ _,

--- a/theories/Dot/hkdot/sem_kind.v
+++ b/theories/Dot/hkdot/sem_kind.v
@@ -154,7 +154,7 @@ Qed.
 (* This is really properness of sf_kind_sub; but it's also proper over the
 first argument K. Maybe that's worth a wrapper with swapped arguments. *)
 Lemma sf_kind_proper {Σ} (K : sf_kind Σ) ρ :
-  Proper2 (K ρ).
+  Proper2 (sf_kind_sub K ρ).
 Proof. move=> T1 T2 HT U1 U2 HU. exact: sf_kind_sub_proper. Qed.
 Lemma sf_kind_proper' {Σ} (K : sf_kind Σ) ρ T1 T2 :
   T1 ≡ T2 → K ρ T1 T1 ≡ K ρ T2 T2.
@@ -449,14 +449,14 @@ End s_kind_rel_proper.
   | 0 => s_kintv oTop oBot
   | n.+1 => s_kpi inhabitant (s_kind_ids _ 0)
   end.
-Fixpoint s_kind_hsubst {Σ n} (ρ : env) (K : s_kindO Σ n) : s_kindO Σ n :=
+#[global] Instance hsubst_s_kind {Σ} : ∀ {n}, HSubst vl (s_kind Σ n) :=
+  fix s_kind_hsubst {n} (ρ : env) (K : s_kindO Σ n) {struct K} : s_kindO Σ n :=
   match K with
   | s_kintv S1 S2 => s_kintv S1.|[ρ] S2.|[ρ]
-  | @s_kpi _ n S K =>
-    let _ : HSubst vl (s_kind Σ n) := s_kind_hsubst in
+  | @s_kpi _ n' S K =>
+    let _ : HSubst vl (s_kind Σ n') := s_kind_hsubst in
     s_kpi S.|[ρ] K.|[up ρ]
   end.
-#[global] Instance hsubst_s_kind {Σ n} : HSubst vl (s_kind Σ n) := s_kind_hsubst.
 (* TODO #381: does this work reasonably? *)
 #[global] Instance: Params (@hsubst_s_kind) 2 := {}.
 

--- a/theories/Dot/hkdot/sem_kind_dot.v
+++ b/theories/Dot/hkdot/sem_kind_dot.v
@@ -40,11 +40,11 @@ Section TMem_Proper.
   #[global] Instance oDTMemK_ne : NonExpansive (oDTMemK (Σ := Σ)).
   Proof. solve_proper_ho. Qed.
   #[global] Instance oDTMemK_proper :
-    Proper ((≡) ==> (≡)) (oDTMemK (Σ := Σ)) := ne_proper _.
+    Proper1 (oDTMemK (Σ := Σ)) := ne_proper _.
   #[global] Instance cTMemK_ne l : NonExpansive (cTMemK (Σ := Σ) l).
   Proof. solve_proper_ho. Qed.
   #[global] Instance cTMemK_proper l :
-    Proper ((≡) ==> (≡)) (cTMemK (Σ := Σ) l) := ne_proper _.
+    Proper1 (cTMemK (Σ := Σ) l) := ne_proper _.
 
   Lemma cTMemK_eq l (K : sf_kind Σ) d ρ :
     cTMemK l K ρ [(l, d)] ⊣⊢ oDTMemK K ρ d.
@@ -84,7 +84,7 @@ Section sem_TMem.
     rewrite oDTMem_eq => ρ d /=. f_equiv=> ψ; f_equiv. apply sr_kintv_refl.
   Qed.
 
-  #[global] Instance oDTMem_proper : Proper ((≡) ==> (≡) ==> (≡)) oDTMem.
+  #[global] Instance oDTMem_proper : Proper2 oDTMem.
   Proof. move=> ??? ??? ??/=. properness; [done|]. exact: sr_kintv_proper. Qed.
 
   (** Define [cTMem] by lifting [oDTMem] to [clty]s. *)
@@ -94,7 +94,7 @@ Section sem_TMem.
   [ Ds⟦ { l >: τ1 <: τ2 } ⟧] and [ V⟦ { l >: τ1 <: τ2 } ⟧ ],
   which are here a derived notation; see [cTMemL]. *)
   Definition cTMem l L U : clty Σ := dty2clty l (oDTMem L U).
-  #[global] Instance cTMem_proper l : Proper ((≡) ==> (≡) ==> (≡)) (cTMem l).
+  #[global] Instance cTMem_proper l : Proper2 (cTMem l).
   Proof. solve_proper. Qed.
 
   Lemma cTMem_unfold l L U :

--- a/theories/Dot/hkdot/sem_kind_dot.v
+++ b/theories/Dot/hkdot/sem_kind_dot.v
@@ -77,7 +77,10 @@ Definition oDTMem `{!dlangG Σ} L U : dltyO Σ := oDTMemK (sf_kintv L U).
 Definition oDTMem_eq `{!dlangG Σ} : oDTMem = λ L U, oDTMemK (sf_kintv L U) := reflexivity _.
 #[global] Instance : Params (@oDTMem) 2 := {}.
 
-#[global] Arguments oDTMem {_ _} _ _  _ : assert.
+#[global] Arguments oDTMem {Σ _} L U ρ : rename.
+
+Definition cTMem `{!dlangG Σ} l L U : clty Σ := dty2clty l (oDTMem L U).
+#[global] Instance : Params (@cTMem) 3 := {}.
 
 Section sem_TMem.
   Context `{HdotG: !dlangG Σ}.
@@ -100,9 +103,12 @@ Section sem_TMem.
   Beware: the ICFP'20 defines instead
   [ Ds⟦ { l >: τ1 <: τ2 } ⟧] and [ V⟦ { l >: τ1 <: τ2 } ⟧ ],
   which are here a derived notation; see [cTMemL]. *)
-  Definition cTMem l L U : clty Σ := dty2clty l (oDTMem L U).
-  #[global] Instance cTMem_proper l : Proper2 (cTMem l).
+
+  #[global] Instance cTMem_ne l : NonExpansive2 (cTMem l).
   Proof. solve_proper. Qed.
+
+  #[global] Instance cTMem_proper l : Proper2 (cTMem l) :=
+    ne_proper_2 _.
 
   Lemma cTMem_unfold l L U :
     cTMem l L U ≡ dty2clty l (oDTMemRaw (dot_intv_type_pred L U)).

--- a/theories/Dot/hkdot/sem_kind_dot.v
+++ b/theories/Dot/hkdot/sem_kind_dot.v
@@ -25,8 +25,10 @@ Notation oDTMemRaw rK := (Dlty (λI ρ d, ∃ ψ, d ↗n ψ ∧ rK ρ ψ)).
 (** [ D⟦ { A :: K } ⟧ ]. *)
 Definition oDTMemK `{!dlangG Σ} (K : sf_kind Σ) : dltyO Σ :=
   oDTMemRaw (λI ρ ψ, K ρ (packHoLtyO ψ) (packHoLtyO ψ)).
+#[global] Instance : Params (@oDTMemK) 2 := {}.
 
 Definition cTMemK `{!dlangG Σ} l (K : sf_kind Σ) : clty Σ := dty2clty l (oDTMemK K).
+#[global] Instance : Params (@cTMemK) 3 := {}.
 Notation oTMemK l K := (clty_olty (cTMemK l K)).
 
 Definition oDTMemAnyKind `{!dlangG Σ} : dltyO Σ := Dlty (λI ρ d,
@@ -68,10 +70,12 @@ End TMem_Proper.
 (** Not a "real" kind, just a predicate over types. *)
 Definition dot_intv_type_pred `{!dlangG Σ} (L U : oltyO Σ) ρ ψ : iProp Σ :=
   L anil ρ ⊆ packHoLtyO ψ anil ∧ packHoLtyO ψ anil ⊆ U anil ρ.
+#[global] Instance : Params (@dot_intv_type_pred) 2 := {}.
 
 (** [ D⟦ { A :: τ1 .. τ2 } ⟧ ]. *)
 Definition oDTMem `{!dlangG Σ} L U : dltyO Σ := oDTMemK (sf_kintv L U).
 Definition oDTMem_eq `{!dlangG Σ} : oDTMem = λ L U, oDTMemK (sf_kintv L U) := reflexivity _.
+#[global] Instance : Params (@oDTMem) 2 := {}.
 
 #[global] Arguments oDTMem {_ _} _ _  _ : assert.
 
@@ -84,8 +88,11 @@ Section sem_TMem.
     rewrite oDTMem_eq => ρ d /=. f_equiv=> ψ; f_equiv. apply sr_kintv_refl.
   Qed.
 
-  #[global] Instance oDTMem_proper : Proper2 oDTMem.
-  Proof. move=> ??? ??? ??/=. properness; [done|]. exact: sr_kintv_proper. Qed.
+  #[global] Instance oDTMem_ne : NonExpansive2 oDTMem.
+  Proof. move=> ? ??? ??? ??/=. solve_proper. Qed.
+
+  #[global] Instance oDTMem_proper : Proper2 oDTMem :=
+    ne_proper_2 _.
 
   (** Define [cTMem] by lifting [oDTMem] to [clty]s. *)
   (**
@@ -140,6 +147,7 @@ Notation "K1 ~sKpP[ p := q  ]* K2" :=
 
 Definition oTApp `{!dlangG Σ} (T : oltyO Σ) (p : path) : oltyO Σ :=
   Olty (λ args ρ v, path_wp p.|[ρ] (λ w, T (acons w args) ρ v)).
+#[global] Instance : Params (@oTApp) 2 := {}.
 
 Program Definition kpSubstOne `{!dlangG Σ} p (K : sf_kind Σ) : sf_kind Σ :=
   SfKind

--- a/theories/Dot/hkdot/sem_kind_dot.v
+++ b/theories/Dot/hkdot/sem_kind_dot.v
@@ -39,12 +39,12 @@ Section TMem_Proper.
 
   #[global] Instance oDTMemK_ne : NonExpansive (oDTMemK (Σ := Σ)).
   Proof. solve_proper_ho. Qed.
-  #[global] Instance oDTMemK_proper :
-    Proper1 (oDTMemK (Σ := Σ)) := ne_proper _.
+  #[global] Instance oDTMemK_proper : Proper1 (oDTMemK (Σ := Σ)) :=
+    ne_proper _.
   #[global] Instance cTMemK_ne l : NonExpansive (cTMemK (Σ := Σ) l).
   Proof. solve_proper_ho. Qed.
-  #[global] Instance cTMemK_proper l :
-    Proper1 (cTMemK (Σ := Σ) l) := ne_proper _.
+  #[global] Instance cTMemK_proper l : Proper1 (cTMemK (Σ := Σ) l) :=
+    ne_proper _.
 
   Lemma cTMemK_eq l (K : sf_kind Σ) d ρ :
     cTMemK l K ρ [(l, d)] ⊣⊢ oDTMemK K ρ d.

--- a/theories/Dot/hkdot/sem_kind_dot.v
+++ b/theories/Dot/hkdot/sem_kind_dot.v
@@ -151,9 +151,13 @@ Definition sem_kind_path_repl {Σ} p q (K1 K2 : sf_kind Σ) : Prop :=
 Notation "K1 ~sKpP[ p := q  ]* K2" :=
   (sem_kind_path_repl p q K1 K2) (at level 70).
 
-Definition oTApp `{!dlangG Σ} (T : oltyO Σ) (p : path) : oltyO Σ :=
+(* Arguments are ordered to optimize setoid rewriting and maximize [Params]. *)
+Definition _oTApp `{!dlangG Σ} (p : path) (T : oltyO Σ) : oltyO Σ :=
   Olty (λ args ρ v, path_wp p.|[ρ] (λ w, T (acons w args) ρ v)).
-#[global] Instance : Params (@oTApp) 2 := {}.
+#[global] Instance : Params (@_oTApp) 3 := {}.
+
+(* Show a more natural ordering to the user. *)
+Notation oTApp T p := (_oTApp p T).
 
 Program Definition kpSubstOne `{!dlangG Σ} p (K : sf_kind Σ) : sf_kind Σ :=
   SfKind
@@ -183,11 +187,11 @@ Notation "K .sKp[ p /]" := (kpSubstOne p K) (at level 65).
 Section proper_eq.
   Context `{!dlangG Σ}.
 
-  #[global] Instance oTApp_ne n : Proper (dist n ==> eq ==> dist n) oTApp.
-  Proof. move=> T1 T2 HT. solve_proper_prepare. apply: path_wp_ne=>v. exact: HT. Qed.
+  #[global] Instance _oTApp_ne p : NonExpansive (_oTApp p).
+  Proof. move=> n T1 T2 HT args ρ v /=. apply: path_wp_ne=> w. exact: HT. Qed.
 
-  #[global] Instance oTApp_proper : Proper ((≡) ==> eq ==> (≡)) oTApp.
-  Proof. move=> T1 T2 HT. solve_proper_prepare. apply: path_wp_proper=>v. exact: HT. Qed.
+  #[global] Instance _oTApp_proper p : Proper1 (_oTApp p) :=
+    ne_proper _.
 
   Lemma kpSubstOne_eq (K : sf_kind Σ) v :
     K.|[v/] ≡ K .sKp[ pv v /].

--- a/theories/Dot/hkdot/sem_kind_dot.v
+++ b/theories/Dot/hkdot/sem_kind_dot.v
@@ -169,7 +169,7 @@ Notation "K .sKp[ p /]" := (kpSubstOne p K) (at level 65).
 Section proper_eq.
   Context `{!dlangG Σ}.
 
-  #[global] Instance oTApp_ne n : Proper ((dist n) ==> eq ==> (dist n)) oTApp.
+  #[global] Instance oTApp_ne n : Proper (dist n ==> eq ==> dist n) oTApp.
   Proof. move=> T1 T2 HT. solve_proper_prepare. apply: path_wp_ne=>v. exact: HT. Qed.
 
   #[global] Instance oTApp_proper : Proper ((≡) ==> eq ==> (≡)) oTApp.

--- a/theories/Dot/lr/dot_lty.v
+++ b/theories/Dot/lr/dot_lty.v
@@ -80,8 +80,10 @@ Section clty_ofe.
   Instance clty_dist : Dist (clty Σ) := λ n A B, iso A ≡{n}≡ iso B.
   Lemma clty_ofe_mixin : OfeMixin (clty Σ).
   Proof. exact: (iso_ofe_mixin iso). Qed.
+
+  Canonical Structure cltyO := OfeT (clty Σ) clty_ofe_mixin.
 End clty_ofe.
-Canonical Structure cltyO Σ := OfeT (clty Σ) clty_ofe_mixin.
+Arguments cltyO : clear implicits.
 
 Section clty_ofe_proper.
   Context {Σ}.
@@ -191,7 +193,8 @@ Section DefsTypes.
   Program Definition cTop : clty Σ := Clty (Dslty (λI _ _, True)) oTop.
   Solve All Obligations with eauto.
 
-  #[global] Instance : Bottom (clty Σ) := olty2clty ⊥.
+  #[global] Instance clty_bottom : Bottom (clty Σ) := olty2clty ⊥.
+  #[global] Instance clty_inh : Inhabited (clty Σ) := populate ⊥.
 
   Program Definition cAnd (Tds1 Tds2 : clty Σ): clty Σ :=
     Clty (Dslty (λI ρ ds, Tds1 ρ ds ∧ Tds2 ρ ds)) (oAnd (c2o Tds1) (c2o Tds2)).

--- a/theories/Dot/lr/dot_lty.v
+++ b/theories/Dot/lr/dot_lty.v
@@ -125,8 +125,8 @@ Section clty_ofe_proper.
 
   #[global] Instance clty_olty_ne : NonExpansive (clty_olty (Σ := Σ)).
   Proof. by move=> ???[/= _ H]. Qed.
-  #[global] Instance clty_olty_proper :
-    Proper1 (clty_olty (Σ := Σ)) := ne_proper _.
+  #[global] Instance clty_olty_proper : Proper1 (clty_olty (Σ := Σ)) :=
+    ne_proper _.
 
   #[global] Instance clty_dslty_ne n :
     Proper (dist n ==> (=) ==> dist n) (clty_dslty (Σ := Σ)).
@@ -164,13 +164,13 @@ Section lift_dty_lemmas.
 
   #[global] Instance lift_dty_dms_ne l : NonExpansive (lift_dty_dms l).
   Proof. rewrite /lift_dty_dms/= => ??? ??/=; properness; solve_proper_ho. Qed.
-  #[global] Instance lift_dty_dms_proper l :
-    Proper1 (lift_dty_dms l) := ne_proper _.
+  #[global] Instance lift_dty_dms_proper l : Proper1 (lift_dty_dms l) :=
+    ne_proper _.
 
   #[global] Instance lift_dty_vl_ne l : NonExpansive (lift_dty_vl l).
   Proof. rewrite /lift_dty_vl => ??; simplify_eq; solve_proper_ho. Qed.
-  #[global] Instance lift_dty_vl_proper l :
-    Proper1 (lift_dty_vl l) := ne_proper _.
+  #[global] Instance lift_dty_vl_proper l : Proper1 (lift_dty_vl l) :=
+    ne_proper _.
 
   Lemma lift_dty_dms_singleton_eq' (TD : dlty Σ) l1 l2 ρ d :
     lift_dty_dms l1 TD ρ [(l2, d)] ⊣⊢ ⌜ l1 = l2 ⌝ ∧ TD ρ d.
@@ -239,8 +239,8 @@ Section DefsTypes.
 
   #[global] Instance cAnd_ne : NonExpansive2 cAnd.
   Proof. split; rewrite /=; repeat f_equiv; solve_proper_ho. Qed.
-  #[global] Instance cAnd_proper:
-    Proper2 cAnd := ne_proper_2 _.
+  #[global] Instance cAnd_proper : Proper2 cAnd :=
+    ne_proper_2 _.
 
   Lemma cAnd_olty2clty T1 T2 :
     cAnd (olty2clty T1) (olty2clty T2) ≡ olty2clty (oAnd T1 T2).

--- a/theories/Dot/lr/dot_lty.v
+++ b/theories/Dot/lr/dot_lty.v
@@ -126,7 +126,7 @@ Section clty_ofe_proper.
   #[global] Instance clty_olty_ne : NonExpansive (clty_olty (Σ := Σ)).
   Proof. by move=> ???[/= _ H]. Qed.
   #[global] Instance clty_olty_proper :
-    Proper ((≡) ==> (≡)) (clty_olty (Σ := Σ)) := ne_proper _.
+    Proper1 (clty_olty (Σ := Σ)) := ne_proper _.
 
   #[global] Instance clty_dslty_ne n :
     Proper (dist n ==> (=) ==> dist n) (clty_dslty (Σ := Σ)).
@@ -165,12 +165,12 @@ Section lift_dty_lemmas.
   #[global] Instance lift_dty_dms_ne l : NonExpansive (lift_dty_dms l).
   Proof. rewrite /lift_dty_dms/= => ??? ??/=; properness; solve_proper_ho. Qed.
   #[global] Instance lift_dty_dms_proper l :
-    Proper ((≡) ==> (≡)) (lift_dty_dms l) := ne_proper _.
+    Proper1 (lift_dty_dms l) := ne_proper _.
 
   #[global] Instance lift_dty_vl_ne l : NonExpansive (lift_dty_vl l).
   Proof. rewrite /lift_dty_vl => ??; simplify_eq; solve_proper_ho. Qed.
   #[global] Instance lift_dty_vl_proper l :
-    Proper ((≡) ==> (≡)) (lift_dty_vl l) := ne_proper _.
+    Proper1 (lift_dty_vl l) := ne_proper _.
 
   Lemma lift_dty_dms_singleton_eq' (TD : dlty Σ) l1 l2 ρ d :
     lift_dty_dms l1 TD ρ [(l2, d)] ⊣⊢ ⌜ l1 = l2 ⌝ ∧ TD ρ d.
@@ -210,12 +210,12 @@ Section DefsTypes.
 
   #[global] Instance olty2clty_ne : NonExpansive olty2clty.
   Proof. split; rewrite /=; by repeat f_equiv. Qed.
-  #[global] Instance olty2clty_proper : Proper ((≡) ==> (≡)) olty2clty :=
+  #[global] Instance olty2clty_proper : Proper1 olty2clty :=
     ne_proper _.
 
   #[global] Instance dty2clty_ne l : NonExpansive (dty2clty l).
   Proof. split; rewrite /dty2clty/=; by repeat f_equiv. Qed.
-  #[global] Instance dty2clty_proper l : Proper ((≡) ==> (≡)) (dty2clty l) :=
+  #[global] Instance dty2clty_proper l : Proper1 (dty2clty l) :=
     ne_proper _.
 
   Lemma dty2clty_singleton l (TD : dlty Σ) ρ d :
@@ -240,7 +240,7 @@ Section DefsTypes.
   #[global] Instance cAnd_ne : NonExpansive2 cAnd.
   Proof. split; rewrite /=; repeat f_equiv; solve_proper_ho. Qed.
   #[global] Instance cAnd_proper:
-    Proper ((≡) ==> (≡) ==> (≡)) cAnd := ne_proper_2 _.
+    Proper2 cAnd := ne_proper_2 _.
 
   Lemma cAnd_olty2clty T1 T2 :
     cAnd (olty2clty T1) (olty2clty T2) ≡ olty2clty (oAnd T1 T2).

--- a/theories/Dot/lr/dot_lty.v
+++ b/theories/Dot/lr/dot_lty.v
@@ -210,13 +210,13 @@ Section DefsTypes.
 
   #[global] Instance olty2clty_ne : NonExpansive olty2clty.
   Proof. split; rewrite /=; by repeat f_equiv. Qed.
-  #[global] Instance olty2clty_proper :
-    Proper ((≡) ==> (≡)) olty2clty := ne_proper _.
+  #[global] Instance olty2clty_proper : Proper ((≡) ==> (≡)) olty2clty :=
+    ne_proper _.
 
   #[global] Instance dty2clty_ne l : NonExpansive (dty2clty l).
   Proof. split; rewrite /dty2clty/=; by repeat f_equiv. Qed.
-  #[global] Instance dty2clty_proper l :
-    Proper ((≡) ==> (≡)) (dty2clty l) := ne_proper _.
+  #[global] Instance dty2clty_proper l : Proper ((≡) ==> (≡)) (dty2clty l) :=
+    ne_proper _.
 
   Lemma dty2clty_singleton l (TD : dlty Σ) ρ d :
     dty2clty l TD ρ [(l, d)] ≡ TD ρ d.

--- a/theories/Dot/lr/dot_semtypes.v
+++ b/theories/Dot/lr/dot_semtypes.v
@@ -93,7 +93,7 @@ Section sem_types.
     ∃ pmem, ⌜d = dpt pmem⌝ ∧ path_wp pmem (oClose τ ρ)).
   #[global] Instance oDVMem_ne : NonExpansive oDVMem.
   Proof. solve_proper_ho. Qed.
-  #[global] Instance oDVMem_proper : Proper ((≡) ==> (≡)) oDVMem :=
+  #[global] Instance oDVMem_proper : Proper1 oDVMem :=
     ne_proper _.
 
   Lemma oDVMem_eq T ρ p :
@@ -106,7 +106,7 @@ Section sem_types.
   Definition cVMem l τ : clty Σ := dty2clty l (oDVMem τ).
   #[global] Instance cVMem_ne l : NonExpansive (cVMem l).
   Proof. solve_proper. Qed.
-  #[global] Instance cVMem_proper l : Proper ((≡) ==> (≡)) (cVMem l) :=
+  #[global] Instance cVMem_proper l : Proper1 (cVMem l) :=
     ne_proper _.
 
   Lemma cVMem_eq l T d ρ :
@@ -330,23 +330,23 @@ Section Propers.
   Qed.
   #[global] Instance: Params (@sstpd) 3 := {}.
 
-  #[global] Instance setp_proper e : Proper ((≡) ==> (≡) ==> (≡)) (setp e).
+  #[global] Instance setp_proper e : Proper2 (setp e).
   Proof.
     solve_proper_ho.
     (* intros ?? HG ?? HT ???; simplify_eq/=. by properness; [rewrite HG|apply HT]. *)
   Qed.
   #[global] Instance: Params (@setp) 3 := {}.
 
-  #[global] Instance sdstp_proper ds : Proper ((≡) ==> (≡) ==> (≡)) (sdstp ds).
+  #[global] Instance sdstp_proper ds : Proper2 (sdstp ds).
   Proof.
     rewrite /sdstp => ??? [?? _] [?? _] [/= ??]; properness; by f_equiv.
   Qed.
   #[global] Instance: Params (@sdstp) 3 := {}.
 
-  #[global] Instance sdtp_proper l d : Proper ((≡) ==> (≡) ==> (≡)) (sdtp l d) := _.
+  #[global] Instance sdtp_proper l d : Proper2 (sdtp l d) := _.
   #[global] Instance: Params (@sdtp) 4 := {}.
 
-  #[global] Instance sptp_proper p i : Proper ((≡) ==> (≡) ==> (≡)) (sptp p i).
+  #[global] Instance sptp_proper p i : Proper2 (sptp p i).
   Proof. solve_proper_ho. Qed.
   #[global] Instance: Params (@sptp) 4 := {}.
 End Propers.

--- a/theories/Dot/lr/dot_semtypes.v
+++ b/theories/Dot/lr/dot_semtypes.v
@@ -339,7 +339,7 @@ Section Propers.
 
   #[global] Instance sdstp_proper ds : Proper ((≡) ==> (≡) ==> (≡)) (sdstp ds).
   Proof.
-    rewrite /sdstp => ??? [?? _ _ _] [?? _ _ _] [/= ??]; properness; by f_equiv.
+    rewrite /sdstp => ??? [?? _] [?? _] [/= ??]; properness; by f_equiv.
   Qed.
   #[global] Instance: Params (@sdstp) 3 := {}.
 

--- a/theories/Dot/lr/dot_semtypes.v
+++ b/theories/Dot/lr/dot_semtypes.v
@@ -322,7 +322,7 @@ Section Propers.
   Context `{HdotG: !dlangG Σ}.
 
   (** Judgments *)
-  #[global] Instance sstpd_proper i : Proper ((≡) ==> (≡) ==> (≡) ==> (≡)) (sstpd i).
+  #[global] Instance sstpd_proper i : Proper3 (sstpd i).
   Proof.
     solve_proper_ho.
     (* intros ?? HG ?? H1 ?? H2; rewrite /sstpd /subtype_lty;

--- a/theories/Dot/lr/sem_unstamped_typing.v
+++ b/theories/Dot/lr/sem_unstamped_typing.v
@@ -46,13 +46,13 @@ End unstamped_judgs.
 Section unstamped_judgs_proper.
   Context `{!dlangG Σ}.
 
-  #[global] Instance suetp_proper e : Proper ((≡) ==> (≡) ==> (≡)) (suetp e).
+  #[global] Instance suetp_proper e : Proper2 (suetp e).
   Proof. rewrite /suetp => ??????. by repeat f_equiv. Qed.
 
-  #[global] Instance sudstp_proper ds : Proper ((≡) ==> (≡) ==> (≡)) (sudstp ds).
+  #[global] Instance sudstp_proper ds : Proper2 (sudstp ds).
   Proof. rewrite /sudstp => ??????; by repeat f_equiv. Qed.
 
-  #[global] Instance sudtp_proper l d : Proper ((≡) ==> (≡) ==> (≡)) (sudtp l d).
+  #[global] Instance sudtp_proper l d : Proper2 (sudtp l d).
   Proof. rewrite /sudtp => ??????. by repeat f_equiv. Qed.
 End unstamped_judgs_proper.
 

--- a/theories/Dot/semtyp_lemmas/tproj_lr.v
+++ b/theories/Dot/semtyp_lemmas/tproj_lr.v
@@ -97,7 +97,8 @@ Section type_proj_setoid_equality.
 
   #[global] Instance oProjN_ne A : NonExpansive (oProj A).
   Proof. solve_proper_ho. Qed.
-  #[global] Instance oProjN_proper A : Proper1 (oProj A) := ne_proper _.
+  #[global] Instance oProjN_proper A : Proper1 (oProj A) :=
+    ne_proper _.
 
   Lemma oProjN_eq A T args ρ v :
     oProj A T args ρ v ⊣⊢ ∃ w, oClose T ρ w ∧ vl_sel w A args v.

--- a/theories/Dot/semtyp_lemmas/tproj_lr.v
+++ b/theories/Dot/semtyp_lemmas/tproj_lr.v
@@ -97,7 +97,7 @@ Section type_proj_setoid_equality.
 
   #[global] Instance oProjN_ne A : NonExpansive (oProj A).
   Proof. solve_proper_ho. Qed.
-  #[global] Instance oProjN_proper A : Proper ((≡) ==> (≡)) (oProj A) := ne_proper _.
+  #[global] Instance oProjN_proper A : Proper1 (oProj A) := ne_proper _.
 
   Lemma oProjN_eq A T args ρ v :
     oProj A T args ρ v ⊣⊢ ∃ w, oClose T ρ w ∧ vl_sel w A args v.

--- a/theories/iris_extra/iris_prelude.v
+++ b/theories/iris_extra/iris_prelude.v
@@ -15,6 +15,10 @@ Notation "'λI' x .. y , t" := (fun x => .. (fun y => t%I) ..)
   (at level 200, x binder, y binder, right associativity,
   only parsing) : function_scope.
 
+Notation "'λneI' x .. y , t" := (λne x, .. (λne y, t%I) ..)
+  (at level 200, x binder, y binder, right associativity,
+  only parsing) : function_scope.
+
 (** * Automation for Iris program logic. *)
 (** Instances for [IntoVal], used e.g. by [wp_value]; copied from F_mu. *)
 #[global] Hint Extern 5 (IntoVal _ _) => eapply of_to_val; fast_done : typeclass_instances.

--- a/theories/iris_extra/lty.v
+++ b/theories/iris_extra/lty.v
@@ -314,6 +314,12 @@ End oShift.
 
 Notation oClose τ := (τ anil) (only parsing).
 
+Definition interp_expr `{dlangG Σ} (φ : hoEnvD Σ) : envPred tm Σ :=
+  λI ρ t, WP t {{ oClose φ ρ }}.
+#[global] Arguments interp_expr /.
+
+Notation "sE⟦ τ ⟧" := (interp_expr τ).
+
 (** Semantic typing contexts [Γ]; the paper only uses syntactic typing
 contexts [Γ]. *)
 Definition sCtx Σ := listO (oltyO Σ).
@@ -359,16 +365,18 @@ Section env_oltyped.
       iApply (hoEnvD_weaken_one (shiftN x τ)).
       iApply (IHΓ (stail ρ) x Hx with "Hg").
   Qed.
-
-  Definition interp_expr (φ : hoEnvD Σ) : envPred tm Σ :=
-    λI ρ t, WP t {{ oClose φ ρ }}.
-  #[global] Arguments interp_expr /.
 End env_oltyped.
-
-Notation "sE⟦ τ ⟧" := (interp_expr τ).
 
 (** ** Constructors for language-independent semantic types, corresponding to
 [⊤], [⊥], [T₁ ∧ T₂], [T₁ ∨ T₂], [μ x. T], [▷]. *)
+
+(** *** We can define once and for all basic "logical" types: top, bottom, and, or, later and μ. *)
+
+(** Semantic type constructor for [⊤] *)
+Definition oTop {Σ} : oltyO Σ := ⊤.
+
+(** Semantic type constructor for [⊥] *)
+Definition oBot {Σ} : oltyO Σ := ⊥.
 
 (** Semantic type constructor for [▷^n T] *)
 Definition oLaterN {Σ} n (τ : oltyO Σ) := Olty (λI args ρ v, ▷^n τ args ρ v).
@@ -376,14 +384,51 @@ Definition oLaterN {Σ} n (τ : oltyO Σ) := Olty (λI args ρ v, ▷^n τ args 
 Notation oLater := (oLaterN 1).
 #[global] Instance: Params (@oLaterN) 2 := {}.
 
-Section olty_ofe_2.
-  Context {Σ}.
-  Implicit Types (φ : hoEnvD Σ) (τ : oltyO Σ).
+(** Semantic type constructor for [T₁ ∧ T₂] *)
+Definition oAnd {Σ} (τ1 τ2 : oltyO Σ) : oltyO Σ := Olty (λI args ρ v, τ1 args ρ v ∧ τ2 args ρ v).
+(** Semantic type constructor for [T₁ ∨ T₂] *)
+Definition oOr {Σ} (τ1 τ2 : oltyO Σ) : oltyO Σ := Olty (λI args ρ v, τ1 args ρ v ∨ τ2 args ρ v).
+(** Semantic type constructor for [μ x. T] *)
+Definition oMu {Σ} (τ : oltyO Σ) : oltyO Σ := Olty (λI args ρ v, τ args (v .: ρ) v).
 
-  (** oLaterN *)
+#[global] Instance: Params (@oAnd) 1 := {}.
+#[global] Instance: Params (@oOr) 1 := {}.
+#[global] Instance: Params (@oMu) 1 := {}.
+
+Section olty_proper.
+  Context {Σ}.
+
+  Definition olty0 (φ : envD Σ) : oltyO Σ :=
+    Olty (aopen φ).
+
   #[global] Instance oLaterN_ne m : NonExpansive (oLaterN (Σ := Σ) m).
   Proof. solve_proper_ho. Qed.
   #[global] Instance oLaterN_proper m : Proper ((≡) ==> (≡)) (oLaterN m) := ne_proper _.
+
+  #[global] Instance oAnd_ne : NonExpansive2 (oAnd (Σ := Σ)).
+  Proof. solve_proper_ho. Qed.
+  #[global] Instance oAnd_proper : Proper2 oAnd :=
+    ne_proper_2 _.
+
+  #[global] Instance oOr_ne : NonExpansive2 (oOr (Σ := Σ)).
+  Proof. solve_proper_ho. Qed.
+  #[global] Instance oOr_proper : Proper2 oOr :=
+    ne_proper_2 _.
+
+  #[global] Instance oMu_ne : NonExpansive (oMu (Σ := Σ)).
+  Proof. solve_proper_ho. Qed.
+  #[global] Instance oMu_proper : Proper1 oMu :=
+    ne_proper _.
+End olty_proper.
+
+Section olty_lemmas.
+  Context {Σ}.
+  Implicit Types (φ : hoEnvD Σ) (τ : oltyO Σ).
+
+  #[global] Instance top_olty : Top (oltyO Σ) := Olty ⊤.
+  #[global] Instance bot_olty : Bottom (oltyO Σ) := Olty ⊥.
+
+  (** oLaterN *)
 
   Lemma oLaterN_eq n τ args ρ v : oLaterN n τ args ρ v = (▷^n τ args ρ v)%I.
   Proof. done. Qed.
@@ -404,39 +449,6 @@ Section olty_ofe_2.
     oLaterN (m + n) T ≡ oLaterN m (oLaterN n T).
   Proof. move=> ???. by rewrite/= laterN_plus. Qed.
 
-  Definition olty0 (φ : envD Σ) : oltyO Σ :=
-    Olty (aopen φ).
-
-  (** *** We can define once and for all basic "logical" types: top, bottom, and, or, later and μ. *)
-
-  (** Semantic type constructor for [⊤] *)
-  Definition oTop : oltyO Σ := ⊤.
-  #[global] Instance top_olty : Top (oltyO Σ) := Olty ⊤.
-
-  (** Semantic type constructor for [⊥] *)
-  Definition oBot : oltyO Σ := ⊥.
-  #[global] Instance bot_olty : Bottom (oltyO Σ) := Olty ⊥.
-
-  (** Semantic type constructor for [T₁ ∧ T₂] *)
-  Definition oAnd τ1 τ2 : oltyO Σ := Olty (λI args ρ v, τ1 args ρ v ∧ τ2 args ρ v).
-  #[global] Instance oAnd_ne : NonExpansive2 oAnd.
-  Proof. solve_proper_ho. Qed.
-  #[global] Instance oAnd_proper : Proper ((≡) ==> (≡) ==> (≡)) oAnd :=
-    ne_proper_2 _.
-
-  (** Semantic type constructor for [T₁ ∨ T₂] *)
-  Definition oOr τ1 τ2 : oltyO Σ := Olty (λI args ρ v, τ1 args ρ v ∨ τ2 args ρ v).
-  #[global] Instance oOr_ne : NonExpansive2 oOr.
-  Proof. solve_proper_ho. Qed.
-  #[global] Instance oOr_proper : Proper ((≡) ==> (≡) ==> (≡)) oOr :=
-    ne_proper_2 _.
-
-  (** Semantic type constructor for [μ x. T] *)
-  Definition oMu (τ : oltyO Σ) : oltyO Σ := Olty (λI args ρ v, τ args (v .: ρ) v).
-  #[global] Instance oMu_ne : NonExpansive oMu.
-  Proof. solve_proper_ho. Qed.
-  #[global] Instance oMu_proper : Proper ((≡) ==> (≡)) oMu := ne_proper _.
-
   Lemma oMu_eq (τ : oltyO Σ) args ρ v : oMu τ args ρ v = τ args (v .: ρ) v.
   Proof. done. Qed.
 
@@ -444,7 +456,7 @@ Section olty_ofe_2.
   Proof. move=> args ρ v. by rewrite /= (hoEnvD_weaken_one T args _ v). Qed.
 
   Lemma sTEq_oLaterN_oTop n :
-    oLaterN n oTop ≡ oTop.
+    oLaterN (Σ := Σ) n oTop ≡ oTop.
   Proof. iIntros; eauto. Qed.
 
   Lemma sTEq_oLaterN_oMu (τ : oltyO Σ) n :
@@ -458,9 +470,5 @@ Section olty_ofe_2.
   Lemma sTEq_oLaterN_oOr (τ1 τ2 : oltyO Σ) n :
     oLaterN n (oOr τ1 τ2) ≡ oOr (oLaterN n τ1) (oLaterN n τ2).
   Proof. move => args ρ v /=. by rewrite laterN_or. Qed.
-End olty_ofe_2.
-
-#[global] Instance: Params (@oAnd) 1 := {}.
-#[global] Instance: Params (@oOr) 1 := {}.
-#[global] Instance: Params (@oMu) 1 := {}.
+End olty_lemmas.
 End Lty.

--- a/theories/iris_extra/lty.v
+++ b/theories/iris_extra/lty.v
@@ -460,7 +460,7 @@ Section olty_ofe_2.
   Proof. move => args ρ v /=. by rewrite laterN_or. Qed.
 End olty_ofe_2.
 
-#[global] Instance: Params (@oAnd) 2 := {}.
-#[global] Instance: Params (@oOr) 2 := {}.
-#[global] Instance: Params (@oMu) 2 := {}.
+#[global] Instance: Params (@oAnd) 1 := {}.
+#[global] Instance: Params (@oOr) 1 := {}.
+#[global] Instance: Params (@oMu) 1 := {}.
 End Lty.

--- a/theories/iris_extra/lty.v
+++ b/theories/iris_extra/lty.v
@@ -117,8 +117,8 @@ Section subtype_lty.
 
   #[global] Instance subtype_lty_ne : NonExpansive2 (subtype_lty (Σ := Σ)).
   Proof. solve_proper_ho. Qed.
-  #[global] Instance subtype_lty_proper :
-    Proper2 (subtype_lty (Σ := Σ)) := ne_proper_2 _.
+  #[global] Instance subtype_lty_proper : Proper2 (subtype_lty (Σ := Σ)) :=
+    ne_proper_2 _.
 
   Lemma subtype_refl {T}: ⊢ T ⊆@{Σ} T.
   Proof. by iIntros "%v $". Qed.
@@ -156,8 +156,8 @@ Definition packHoLtyO {Σ} (φ : hoD Σ) : hoLtyO Σ :=
 #[global] Instance packHoLtyO_contractive {Σ} :
   Contractive (packHoLtyO (Σ := Σ)).
 Proof. solve_contractive_ho. Qed.
-#[global] Instance packHoLtyO_proper {Σ} :
-  Proper1 (packHoLtyO (Σ := Σ)) := contractive_proper _.
+#[global] Instance packHoLtyO_proper {Σ} : Proper1 (packHoLtyO (Σ := Σ)) :=
+  contractive_proper _.
 
 (** ** Substitution over [olty]. *)
 Section olty_subst.
@@ -291,7 +291,8 @@ Section olty_subst.
 
   #[global] Instance oShift_ne: NonExpansive oShift.
   Proof. solve_proper_ho. Qed.
-  #[global] Instance oShift_proper : Proper1 oShift := ne_proper _.
+  #[global] Instance oShift_proper : Proper1 oShift :=
+    ne_proper _.
 End olty_subst.
 
 #[global] Instance: Params (@oShift) 1 := {}.
@@ -403,7 +404,8 @@ Section olty_proper.
 
   #[global] Instance oLaterN_ne m : NonExpansive (oLaterN (Σ := Σ) m).
   Proof. solve_proper_ho. Qed.
-  #[global] Instance oLaterN_proper m : Proper1 (oLaterN m) := ne_proper _.
+  #[global] Instance oLaterN_proper m : Proper1 (oLaterN m) :=
+    ne_proper _.
 
   #[global] Instance oAnd_ne : NonExpansive2 (oAnd (Σ := Σ)).
   Proof. solve_proper_ho. Qed.

--- a/theories/iris_extra/lty.v
+++ b/theories/iris_extra/lty.v
@@ -118,7 +118,7 @@ Section subtype_lty.
   #[global] Instance subtype_lty_ne : NonExpansive2 (subtype_lty (Σ := Σ)).
   Proof. solve_proper_ho. Qed.
   #[global] Instance subtype_lty_proper :
-    Proper ((≡) ==> (≡) ==> (≡)) (subtype_lty (Σ := Σ)) := ne_proper_2 _.
+    Proper2 (subtype_lty (Σ := Σ)) := ne_proper_2 _.
 
   Lemma subtype_refl {T}: ⊢ T ⊆@{Σ} T.
   Proof. by iIntros "%v $". Qed.
@@ -157,7 +157,7 @@ Definition packHoLtyO {Σ} (φ : hoD Σ) : hoLtyO Σ :=
   Contractive (packHoLtyO (Σ := Σ)).
 Proof. solve_contractive_ho. Qed.
 #[global] Instance packHoLtyO_proper {Σ} :
-  Proper ((≡) ==> (≡)) (packHoLtyO (Σ := Σ)) := contractive_proper _.
+  Proper1 (packHoLtyO (Σ := Σ)) := contractive_proper _.
 
 (** ** Substitution over [olty]. *)
 Section olty_subst.
@@ -254,7 +254,7 @@ Section olty_subst.
   Proof. solve_proper_ho. Qed.
 
   #[global] Instance hsubst_olty_proper ρ :
-    Proper ((≡) ==> (≡)) (hsubst (outer := oltyO Σ) ρ) := ne_proper _.
+    Proper1 (hsubst (outer := oltyO Σ) ρ) := ne_proper _.
 
   Lemma olty_subst_compose_ind τ args ρ1 ρ2 v: τ.|[ρ1] args ρ2 v ⊣⊢ τ args (ρ1 >> ρ2) v.
   Proof. apply hoEnvD_subst_compose_ind. Qed.
@@ -291,7 +291,7 @@ Section olty_subst.
 
   #[global] Instance oShift_ne: NonExpansive oShift.
   Proof. solve_proper_ho. Qed.
-  #[global] Instance oShift_proper : Proper ((≡) ==> (≡)) oShift := ne_proper _.
+  #[global] Instance oShift_proper : Proper1 oShift := ne_proper _.
 End olty_subst.
 
 #[global] Instance: Params (@oShift) 1 := {}.
@@ -352,7 +352,7 @@ Section env_oltyped.
   Qed.
 
   #[global] Instance env_oltyped_proper ρ :
-    Proper ((≡) ==> (≡)) (env_oltyped ρ) := ne_proper _.
+    Proper1 (env_oltyped ρ) := ne_proper _.
 
   Lemma s_interp_env_lookup Γ ρ (τ : olty Σ) x:
     Γ !! x = Some τ →
@@ -403,7 +403,7 @@ Section olty_proper.
 
   #[global] Instance oLaterN_ne m : NonExpansive (oLaterN (Σ := Σ) m).
   Proof. solve_proper_ho. Qed.
-  #[global] Instance oLaterN_proper m : Proper ((≡) ==> (≡)) (oLaterN m) := ne_proper _.
+  #[global] Instance oLaterN_proper m : Proper1 (oLaterN m) := ne_proper _.
 
   #[global] Instance oAnd_ne : NonExpansive2 (oAnd (Σ := Σ)).
   Proof. solve_proper_ho. Qed.


### PR DESCRIPTION
Prepare for #379 and #365 by fixing a few existing bugs with setoid rewriting.

Background: in that MR, the logical relation `V[[ T ]]` will become an Iris fixpoint, so its defining equations will only hold up to setoid equality, not definitional equality; hence, many fast calls to `simpl` will be replaced by slow calls to setoid rewriting (like `rewrite ?(list_of_def_eq_lemmas).`).

This MR:
- fixes a few `Params` instances, which triggered `rewrite` misbehaviors (things like "can't rewrite reliably in the first arg of `oAnd`").
- add quite a few missing ones; I've done a review last weekend, tho I'm not sure it was complete. But #379 now works well enough that I'm going to merge this.

In addition:
- we prove here that `clty` is a Cofe, even if that's really part of #379.
- revise `s_kind_ids`/`s_kind_ids`/`s_kind_dummy`.