### PR TITLE
Prepare for using guarded recursion (and fixing #385)

### DIFF
--- a/theories/Dot/examples/sem/from_pdot_mutual_rec_sem.v
+++ b/theories/Dot/examples/sem/from_pdot_mutual_rec_sem.v
@@ -242,9 +242,11 @@ Lemma HvF Γ : newTypeRefΓ Γ u⊢ₜ
   hsomeType hoasNotation.hx2, 0 <: val "isEmpty" : TSing false, 0.
 Proof. lThis; mltcrush. Qed.
 
-Tactic Notation "lrSimpl" := iEval (cbv [pty_interp]).
+(** Note: for performance, this tactic rewrites with [vlr] exactly once; hence
+it requires attention. *)
+Tactic Notation "lrSimpl" := iEval (rewrite vlr).
 Tactic Notation "lrSimpl" "in" constr(iSelP) :=
-  iEval (cbv [pty_interp]) in iSelP.
+  iEval (rewrite vlr) in iSelP.
 
 #[local] Arguments iPPred_car : simpl never.
 #[local] Arguments pty_interp : simpl never.
@@ -300,7 +302,7 @@ Proof.
   cbn [shift]; rewrite (_ : shiftV x1 = x2) //.
   rewrite path_wp_pv_eq.
   rewrite subst_comp ren_scons subst_id /newTypeRefΓ.
-  lrSimpl; iSplit. { lrSimpl in "Hg"; iDestruct "Hg" as "[_ $]". }
+  lrSimpl; iSplit. { iDestruct "Hg" as "[_ $]". }
   iClear "Hg".
 
   (* Just to restate/simplify the current goal (for some extra readability). *)
@@ -308,7 +310,7 @@ Proof.
     last by iApply "Hgoal".
   lrSimpl.
   iExists (dpt p); iFrame (Hl); rewrite oDVMem_eq path_wp_eq.
-  iExists optV; iFrame (Hal); lrSimpl in "Hw"; lrSimpl.
+  iExists optV; iFrame (Hal); lrSimpl in "Hw".
   by iDestruct "Hw" as "#[$ _]".
 Qed.
 

--- a/theories/Dot/examples/sem/from_pdot_mutual_rec_sem.v
+++ b/theories/Dot/examples/sem/from_pdot_mutual_rec_sem.v
@@ -267,16 +267,18 @@ Proof.
   rewrite /interp_expr wp_value_inv sem_later /of_val.
   wp_pure.
 
-  rewrite oVMem_eq; iDestruct "Hx0" as (p Hl) "Hx0".
+  lrSimpl in "Hx0"; rewrite oVMem_eq. iDestruct "Hx0" as (p Hl) "Hx0".
   rewrite path_wp_eq; iDestruct "Hx0" as (optV Hal) "HoptV"; rewrite sem_later.
   wp_pure.
   have [n HpOptV] := path_wp_exec_pure _ _ Hal; wp_pure => {HpOptV n}.
-  rewrite /hoptionTyConcr1; lrSimpl in "HoptV".
+  lrSimpl in "HoptV".
   iDestruct "HoptV" as "[Hw|Hw]";
     [iPoseProof "HvT" as "Hv" | iPoseProof "HvF" as "Hv"]; iClear "HvT HvF".
-  all: iSpecialize ("Hv" $! _ optV with "Hg Hw");
-    lrSimpl in "Hv"; iDestruct "Hv" as (? Hl' pb ->) "Hpb"; lrSimpl in "Hpb";
-    rewrite path_wp_pure_exec; iDestruct "Hpb" as %(bv & [n1 Hexec] & Heq).
+  all: iSpecialize ("Hv" $! _ optV with "Hg Hw").
+  all: lrSimpl in "Hv"; iDestruct "Hv" as (? Hl' pb ->) "Hpb".
+  all: rewrite path_wp_pure_exec; iDestruct "Hpb" as (bv) "Hpb".
+  all: lrSimpl in "Hpb"; iDestruct "Hpb" as %([n1 Hexec] & Heq).
+    (* iDestruct "Hpb" as %(bv & [n1 Hexec] & Heq). *)
   all: move: Heq; rewrite alias_paths_pv_eq_2 path_wp_pure_pv_eq => Heq; cbn in Heq;
     wp_pure; wp_pure => {Hl' n1 pb Hexec}.
   all: rewrite -{bv}Heq; wp_pure; wp_pure.
@@ -284,13 +286,14 @@ Proof.
   wp_pure.
   (* To conclude, prove the right subtyping for hsomeType and TypeRef. *)
   iSpecialize ("Hsub" with "Hg"); lrSimpl in "Hsub".
+
   lrSimpl; iApply "Hsub"; iClear "Hsub".
 
   (* Just to restate the current goal (for some extra readability). *)
   iAssert (V⟦ shift typeRefTBody ⟧ anil ρ
     (shiftV (ν [val "symb" = x1])).[up ρ].[vint 0/])
     as "Hgoal"; last by iApply "Hgoal".
-  lrSimpl; iSplit; last by [].
+  lrSimpl; iSplit; lrSimpl; last by [].
   rewrite up_sub_compose_vl (_ : (shiftV _).[_] = ν [val "symb" = shiftV (ρ 0)]); last
     by autosubst.
   iApply oVMem_eq; iExists _; iSplit; first by eauto.
@@ -303,6 +306,7 @@ Proof.
   (* Just to restate/simplify the current goal (for some extra readability). *)
   iAssert (V⟦ val "tpe" : hsomeConcrT ⊥ ⊤ ⟧ anil ρ (ρ 0)) as "Hgoal";
     last by iApply "Hgoal".
+  lrSimpl.
   iExists (dpt p); iFrame (Hl); rewrite oDVMem_eq path_wp_eq.
   iExists optV; iFrame (Hal); lrSimpl in "Hw"; lrSimpl.
   by iDestruct "Hw" as "#[$ _]".

--- a/theories/Dot/examples/sem/no_russell_paradox.v
+++ b/theories/Dot/examples/sem/no_russell_paradox.v
@@ -52,7 +52,7 @@ Section Russell.
     iEval (rewrite uAu_unfold) in "HuauV'".
     iDestruct "HuauV'" as (d ψ Hl) "[Hs1 Hvav]".
     have Hdeq : d = dtysem [] s. by move: Hl => /= [ds [[<- /=] ?]]; simplify_eq.
-    iAssert (d ↗n aopen (russell_p ids)) as "#Hs2". by iApply (dm_to_type_intro with "Hs").
+    iAssert (d ↗ aopen (russell_p ids)) as "#Hs2". by iApply (dm_to_type_intro with "Hs").
     iPoseProof (dm_to_type_agree anil v with "Hs1 Hs2") as "#Hag".
     (* without lock, iNext would strip a later in [HuauV]. *)
     rewrite [uAu]lock; iNext; unlock.

--- a/theories/Dot/examples/sem/positive_div.v
+++ b/theories/Dot/examples/sem/positive_div.v
@@ -140,7 +140,7 @@ Section div_example.
     ⊢ |==> oAll V⟦ 𝐙 ⟧ (olty0 (λI ρ v, ⌜ ∃ n : Z, v = n ∧ n > 0 ⌝)) anil ids hmkPosV.
   Proof using Type*. iApply wp_value_inv'. iApply (ty_mkPos with "[//]"). Qed.
 
-  Lemma wp_div_spec (m : Z) w : ipos anil ids w -∗ WP m `div` w {{ ⟦ 𝐙 ⟧ ids }}.
+  Lemma wp_div_spec (m : Z) w : ipos anil ids w -∗ WP m `div` w {{ oInt anil ids }}.
   Proof. iDestruct 1 as %(n&?&?); simplify_eq. wp_bin. by iIntros "!%"; naive_solver. Qed.
   Close Scope Z_scope.
 

--- a/theories/Dot/examples/sem/positive_div.v
+++ b/theories/Dot/examples/sem/positive_div.v
@@ -16,6 +16,7 @@ Implicit Types (v w : vl) (d : dm) (ds : dms).
 
 (** ** Example code. *)
 Section examplesBodies.
+  Context `{HdlangG : !dlangG Σ}.
   Import hoasNotation.
 
   Definition hdivV := λ: m n, m `div` (htskip n).
@@ -32,6 +33,14 @@ Section examplesBodies.
     val "mkPos" : 𝐙 →: self @; "Pos";
     val "div" : 𝐙 →: self @; "Pos" →: 𝐙
   }.
+  Definition oposModTTail : clty Σ :=
+    cAnd
+      (cVMem "mkPos" (oAll oInt (oSel x1 "Pos")))
+      (cAnd
+        (cVMem "div" (oAll oInt (oAll (oSel x1 "Pos") oInt)))
+        cTop).
+  Lemma hposModTTail_eq : C⟦ hposModTTail hx0 ⟧ ≡ oposModTTail.
+  Proof. rw. done. Qed.
 
   Definition hposModTBody self : hty := {@
     type "Pos" >: ⊥ <: 𝐙;
@@ -43,8 +52,24 @@ Section examplesBodies.
     hposModTBody x = hTAnd (type "Pos" >: ⊥ <: 𝐙) (hposModTTail x) :=
     reflexivity _.
 
+  Definition oposModTBody : clty Σ :=
+    cAnd (cTMemL "Pos" oBot oInt)
+    oposModTTail.
+  Lemma hposModTBody_eq : C⟦ hposModTBody hx0 ⟧ ≡ oposModTBody.
+  Proof.
+    rewrite hposModTBody_alt cinterp_TAnd hposModTTail_eq.
+    rw. done.
+  Qed.
+
   (** Actual type *)
   Definition hposModT := μ: self, hposModTBody self.
+  Definition oposModT := oMu (c2o oposModTBody).
+
+  Lemma hposModT_eq : V⟦ hposModT ⟧ ≡ oposModT.
+  Proof.
+    rewrite /hposModT /oposModT interp_TMu.
+    apply oMu_proper, hposModTBody_eq.
+  Qed.
 End examplesBodies.
 
 #[local] Hint Constructors bin_op_syntype cond_bin_op_syntype : core.
@@ -106,7 +131,8 @@ Section div_example.
     ⊢ [] s⊨ hmkPosV : oAll V⟦ 𝐙 ⟧ (olty0 (λI ρ v, ⌜ ∃ n : Z, v = n ∧ n > 0 ⌝)).
   Proof using Type*.
     rewrite -sT_All_I /setp /= /shead; iMod wp_if_ge as "#Hge".
-    iIntros "!>" (ρ). iDestruct 1 as %(_ & n & Hw); simplify_eq/=; rewrite Hw.
+    iIntros "!>" (ρ). rewrite /hsubst/hsubst_hoEnvD. rw.
+    iDestruct 1 as %(_ & n & Hw); simplify_eq/=; rewrite Hw.
     iApply wp_wand; [iApply "Hge" | naive_solver].
   Qed.
 
@@ -137,8 +163,9 @@ Section div_example.
       [iApply sBot_Stp | iApply sStp_ipos_nat].
   Qed.
 
+  (** Actual type *)
   #[local] Definition oPreciseBody :=
-    c2o (cAnd (cTMemL "Pos" ipos ipos) C⟦ hposModTTail hx0 ⟧).
+    c2o (cAnd (cTMemL "Pos" ipos ipos) oposModTTail).
 
   (**
   Show that our program is semantically well-typed,
@@ -146,7 +173,7 @@ Section div_example.
   *)
   Theorem posModTy : ⊢ [] u⊨ hposModV : hposModT.
   Proof using Type*.
-    rewrite /hposModT.
+    rewrite /iuetp hposModT_eq fmap_nil.
     have HctxSub :
       s⊨G oLater oPreciseBody :: [] <:* oLater <$> [oPreciseBody].
     by iIntros "% $".

--- a/theories/Dot/hkdot/sem_kind_dot.v
+++ b/theories/Dot/hkdot/sem_kind_dot.v
@@ -82,6 +82,8 @@ Definition oDTMem_eq `{!dlangG Σ} L U : oDTMem L U = oDTMemK (sf_kintv L U) := 
 Definition cTMem `{!dlangG Σ} l L U : clty Σ := dty2clty l (oDTMem L U).
 #[global] Instance : Params (@cTMem) 3 := {}.
 
+Notation oTMem l L U := (clty_olty (cTMem l L U)).
+
 Section sem_TMem.
   Context `{HdotG : !dlangG Σ}.
   Implicit Types (τ : oltyO Σ).
@@ -117,12 +119,6 @@ Section sem_TMem.
   Lemma cTMem_eq l L U d ρ :
     cTMem l L U ρ [(l, d)] ⊣⊢ oDTMem L U ρ d.
   Proof. apply dty2clty_singleton. Qed.
-End sem_TMem.
-
-Notation oTMem l L U := (clty_olty (cTMem l L U)).
-
-Section oTMem_lemmas.
-  Context `{HdotG : !dlangG Σ}.
 
   Lemma oTMem_unfold l L U :
     oTMem l L U ≡ clty_olty (dty2clty l (oDTMemRaw (dot_intv_type_pred L U))).
@@ -135,7 +131,7 @@ Section oTMem_lemmas.
 
   Lemma oTMem_shift A L U : oTMem A (shift L) (shift U) = shift (oTMem A L U).
   Proof. rewrite /cTMem !oDTMem_eq. done. Qed.
-End oTMem_lemmas.
+End sem_TMem.
 
 (** * Path application and substitution *)
 

--- a/theories/Dot/hkdot/sem_kind_dot.v
+++ b/theories/Dot/hkdot/sem_kind_dot.v
@@ -47,6 +47,10 @@ Section TMem_Proper.
   Proof. solve_proper_ho. Qed.
   #[global] Instance cTMemK_proper l : Proper1 (cTMemK (Σ := Σ) l) :=
     ne_proper _.
+End TMem_Proper.
+
+Section TMem_lemmas.
+  Context `{HdotG : !dlangG Σ}.
 
   Lemma cTMemK_eq l (K : sf_kind Σ) d ρ :
     cTMemK l K ρ [(l, d)] ⊣⊢ oDTMemK K ρ d.
@@ -64,7 +68,7 @@ Section TMem_Proper.
   Lemma cTMemK_subst l (K : sf_kind Σ) ρ :
     (oTMemK l K).|[ρ] = oTMemK l K.|[ρ].
   Proof. done. Qed.
-End TMem_Proper.
+End TMem_lemmas.
 
 (** ** Type members: derive special case for gDOT. *)
 (** Not a "real" kind, just a predicate over types. *)
@@ -84,6 +88,22 @@ Definition cTMem `{!dlangG Σ} l L U : clty Σ := dty2clty l (oDTMem L U).
 
 Notation oTMem l L U := (clty_olty (cTMem l L U)).
 
+Section TMem_Proper.
+  Context `{HdotG : !dlangG Σ}.
+
+  #[global] Instance oDTMem_ne : NonExpansive2 oDTMem.
+  Proof. move=> ? ??? ??? ??/=. solve_proper. Qed.
+
+  #[global] Instance oDTMem_proper : Proper2 oDTMem :=
+    ne_proper_2 _.
+
+  #[global] Instance cTMem_ne l : NonExpansive2 (cTMem l).
+  Proof. solve_proper. Qed.
+
+  #[global] Instance cTMem_proper l : Proper2 (cTMem l) :=
+    ne_proper_2 _.
+End TMem_Proper.
+
 Section sem_TMem.
   Context `{HdotG : !dlangG Σ}.
   Implicit Types (τ : oltyO Σ).
@@ -93,24 +113,12 @@ Section sem_TMem.
     rewrite oDTMem_eq => ρ d /=. f_equiv=> ψ; f_equiv. apply sr_kintv_refl.
   Qed.
 
-  #[global] Instance oDTMem_ne : NonExpansive2 oDTMem.
-  Proof. move=> ? ??? ??? ??/=. solve_proper. Qed.
-
-  #[global] Instance oDTMem_proper : Proper2 oDTMem :=
-    ne_proper_2 _.
-
   (** Define [cTMem] by lifting [oDTMem] to [clty]s. *)
   (**
   [ Ds⟦ { l :: τ1 .. τ2 } ⟧] and [ V⟦ { l :: τ1 .. τ2 } ⟧ ].
   Beware: the ICFP'20 defines instead
   [ Ds⟦ { l >: τ1 <: τ2 } ⟧] and [ V⟦ { l >: τ1 <: τ2 } ⟧ ],
   which are here a derived notation; see [cTMemL]. *)
-
-  #[global] Instance cTMem_ne l : NonExpansive2 (cTMem l).
-  Proof. solve_proper. Qed.
-
-  #[global] Instance cTMem_proper l : Proper2 (cTMem l) :=
-    ne_proper_2 _.
 
   Lemma cTMem_unfold l L U :
     cTMem l L U ≡ dty2clty l (oDTMemRaw (dot_intv_type_pred L U)).

--- a/theories/Dot/hkdot/sem_kind_dot.v
+++ b/theories/Dot/hkdot/sem_kind_dot.v
@@ -74,7 +74,7 @@ Definition dot_intv_type_pred `{!dlangG Σ} (L U : oltyO Σ) ρ ψ : iProp Σ :=
 
 (** [ D⟦ { A :: τ1 .. τ2 } ⟧ ]. *)
 Definition oDTMem `{!dlangG Σ} L U : dltyO Σ := oDTMemK (sf_kintv L U).
-Definition oDTMem_eq `{!dlangG Σ} : oDTMem = λ L U, oDTMemK (sf_kintv L U) := reflexivity _.
+Definition oDTMem_eq `{!dlangG Σ} L U : oDTMem L U = oDTMemK (sf_kintv L U) := reflexivity _.
 #[global] Instance : Params (@oDTMem) 2 := {}.
 
 #[global] Arguments oDTMem {Σ _} L U ρ : rename.

--- a/theories/Dot/hkdot/sem_kind_dot.v
+++ b/theories/Dot/hkdot/sem_kind_dot.v
@@ -20,7 +20,7 @@ Implicit Types
          (ρ : var → vl) (l : label).
 
 (** * Type members *)
-Notation oDTMemRaw rK := (Dlty (λI ρ d, ∃ ψ, d ↗n ψ ∧ rK ρ ψ)).
+Notation oDTMemRaw rK := (Dlty (λI ρ d, ∃ ψ, d ↗ ψ ∧ rK ρ ψ)).
 
 (** [ D⟦ { A :: K } ⟧ ]. *)
 Definition oDTMemK `{!dlangG Σ} (K : sf_kind Σ) : dltyO Σ :=
@@ -32,7 +32,7 @@ Definition cTMemK `{!dlangG Σ} l (K : sf_kind Σ) : clty Σ := dty2clty l (oDTM
 Notation oTMemK l K := (clty_olty (cTMemK l K)).
 
 Definition oDTMemAnyKind `{!dlangG Σ} : dltyO Σ := Dlty (λI ρ d,
-  ∃ (ψ : hoD Σ), d ↗n ψ).
+  ∃ (ψ : hoD Σ), d ↗ ψ).
 Definition cTMemAnyKind `{!dlangG Σ} l : clty Σ := dty2clty l oDTMemAnyKind.
 Notation oTMemAnyKind l := (clty_olty (cTMemAnyKind l)).
 
@@ -54,7 +54,7 @@ Section TMem_Proper.
 
   Lemma oTMemK_eq l K args ρ v :
     oTMemK l K args ρ v ⊣⊢
-    ∃ ψ d, ⌜v @ l ↘ d⌝ ∧ d ↗n ψ ∧ K ρ (packHoLtyO ψ) (packHoLtyO ψ).
+    ∃ ψ d, ⌜v @ l ↘ d⌝ ∧ d ↗ ψ ∧ K ρ (packHoLtyO ψ) (packHoLtyO ψ).
   Proof. apply bi_exist_nested_swap. Qed.
 
   Lemma cTMemAnyKind_eq l d ρ :
@@ -130,7 +130,7 @@ Section oTMem_lemmas.
 
   Lemma oTMem_eq l L U args ρ v :
     oTMem l L U args ρ v ⊣⊢
-    ∃ ψ d, ⌜v @ l ↘ d⌝ ∧ d ↗n ψ ∧ dot_intv_type_pred L U ρ ψ.
+    ∃ ψ d, ⌜v @ l ↘ d⌝ ∧ d ↗ ψ ∧ dot_intv_type_pred L U ρ ψ.
   Proof. rewrite oTMem_unfold. apply bi_exist_nested_swap. Qed.
 
   Lemma oTMem_shift A L U : oTMem A (shift L) (shift U) = shift (oTMem A L U).

--- a/theories/Dot/lr/dot_lty.v
+++ b/theories/Dot/lr/dot_lty.v
@@ -300,12 +300,12 @@ End path_repl.
 (** When a definition points to a semantic type. Inlined in paper. *)
 Definition dm_to_type `{HdotG : !dlangG Σ} d (ψ : hoD Σ) : iProp Σ :=
   ∃ s σ, ⌜ d = dtysem σ s ⌝ ∧ s ↗n[ σ ] ψ.
-Notation "d ↗n ψ" := (dm_to_type d ψ) (at level 20).
+Notation "d ↗ ψ" := (dm_to_type d ψ) (at level 20).
 
 Section dm_to_type.
   Context `{HdotG : !dlangG Σ}.
 
-  Lemma dm_to_type_agree {d ψ1 ψ2} args v : d ↗n ψ1 -∗ d ↗n ψ2 -∗ ▷ (ψ1 args v ≡ ψ2 args v).
+  Lemma dm_to_type_agree {d ψ1 ψ2} args v : d ↗ ψ1 -∗ d ↗ ψ2 -∗ ▷ (ψ1 args v ≡ ψ2 args v).
   Proof.
     iDestruct 1 as (s σ ?) "#Hs1".
     iDestruct 1 as (s' σ' ?) "#Hs2".
@@ -313,7 +313,7 @@ Section dm_to_type.
   Qed.
 
   Lemma dm_to_type_intro d s σ φ :
-    d = dtysem σ s → s ↝n φ -∗ d ↗n hoEnvD_inst σ φ.
+    d = dtysem σ s → s ↝n φ -∗ d ↗ hoEnvD_inst σ φ.
   Proof.
     iIntros. iExists s, σ. iFrame "%".
     by iApply stamp_σ_to_type_intro.

--- a/theories/Dot/lr/dot_lty.v
+++ b/theories/Dot/lr/dot_lty.v
@@ -299,7 +299,10 @@ End path_repl.
 
 (** When a definition points to a semantic type. Inlined in paper. *)
 Definition dm_to_type `{HdotG : !dlangG Σ} d (ψ : hoD Σ) : iProp Σ :=
-  ∃ s σ, ⌜ d = dtysem σ s ⌝ ∧ s ↗n[ σ ] ψ.
+  match d with
+  | dtysem σ s => s ↗n[ σ ] ψ
+  | _ => False
+  end.
 Notation "d ↗ ψ" := (dm_to_type d ψ) (at level 20).
 
 Section dm_to_type.
@@ -307,17 +310,12 @@ Section dm_to_type.
 
   Lemma dm_to_type_agree {d ψ1 ψ2} args v : d ↗ ψ1 -∗ d ↗ ψ2 -∗ ▷ (ψ1 args v ≡ ψ2 args v).
   Proof.
-    iDestruct 1 as (s σ ?) "#Hs1".
-    iDestruct 1 as (s' σ' ?) "#Hs2".
-    simplify_eq. by iApply (stamp_σ_to_type_agree args with "Hs1 Hs2").
+    destruct d; simpl; [ | apply stamp_σ_to_type_agree | ]; by iIntros "[]".
   Qed.
 
   Lemma dm_to_type_intro d s σ φ :
     d = dtysem σ s → s ↝n φ -∗ d ↗ hoEnvD_inst σ φ.
-  Proof.
-    iIntros. iExists s, σ. iFrame "%".
-    by iApply stamp_σ_to_type_intro.
-  Qed.
+  Proof. move=>->/=. apply stamp_σ_to_type_intro. Qed.
 
   #[global] Opaque dm_to_type.
 End dm_to_type.

--- a/theories/Dot/lr/dot_semtypes.v
+++ b/theories/Dot/lr/dot_semtypes.v
@@ -79,7 +79,7 @@ End JudgEqs.
 
 (** ** gDOT semantic types. *)
 Definition vl_sel `{!dlangG Σ} vp l args v : iProp Σ :=
-  ∃ d ψ, ⌜vp @ l ↘ d⌝ ∧ d ↗n ψ ∧ packHoLtyO ψ args v.
+  ∃ d ψ, ⌜vp @ l ↘ d⌝ ∧ d ↗ ψ ∧ packHoLtyO ψ args v.
 
 Definition oSel `{!dlangG Σ} p l : oltyO Σ :=
   Olty (λI args ρ v, path_wp p.|[ρ] (λ vp, vl_sel vp l args v)).
@@ -115,7 +115,7 @@ Section sem_types.
 
   Lemma oSel_pv w l args ρ v :
     oSel (pv w) l args ρ v ⊣⊢
-      ∃ d ψ, ⌜w.[ρ] @ l ↘ d⌝ ∧ d ↗n ψ ∧ ▷ ψ args v.
+      ∃ d ψ, ⌜w.[ρ] @ l ↘ d⌝ ∧ d ↗ ψ ∧ ▷ ψ args v.
   Proof. by rewrite /= path_wp_pv_eq. Qed.
 
   (** [ V⟦ p.type ⟧]. *)

--- a/theories/Dot/lr/dot_semtypes.v
+++ b/theories/Dot/lr/dot_semtypes.v
@@ -113,11 +113,6 @@ Section sem_types.
     cVMem l T ρ [(l, d)] ⊣⊢ oDVMem T ρ d.
   Proof. apply dty2clty_singleton. Qed.
 
-  Lemma oSel_pv w l args ρ v :
-    oSel (pv w) l args ρ v ⊣⊢
-      ∃ d ψ, ⌜w.[ρ] @ l ↘ d⌝ ∧ d ↗ ψ ∧ ▷ ψ args v.
-  Proof. by rewrite /= path_wp_pv_eq. Qed.
-
   (** [ V⟦ p.type ⟧]. *)
   Definition oSing `{!dlangG Σ} p : olty Σ := olty0 (λI ρ v, ⌜alias_paths p.|[ρ] (pv v)⌝).
 
@@ -154,6 +149,11 @@ Notation oVMem l τ := (clty_olty (cVMem l τ)).
 Section misc_lemmas.
   Context `{HdotG : !dlangG Σ}.
   Implicit Types (τ L T U : olty Σ).
+
+  Lemma oSel_pv w l args ρ v :
+    oSel (pv w) l args ρ v ⊣⊢
+      ∃ d ψ, ⌜w.[ρ] @ l ↘ d⌝ ∧ d ↗ ψ ∧ ▷ ψ args v.
+  Proof. by rewrite /= path_wp_pv_eq. Qed.
 
   Lemma oVMem_eq l T anil ρ v :
     oVMem l T anil ρ v ⊣⊢

--- a/theories/Dot/lr/unary_lr.v
+++ b/theories/Dot/lr/unary_lr.v
@@ -96,6 +96,16 @@ Section logrel_binding_lemmas.
   Proof. apply (interp_commute_subst _ (v .: ids)). Qed.
 End logrel_binding_lemmas.
 
+Notation cBot := (olty2clty oBot).
+Notation cOr T1 T2 := (olty2clty $ oOr T1 T2).
+Notation cLater T := (olty2clty $ oLater T).
+Notation cPrim b := (olty2clty $ oPrim b).
+Notation cAll T1 T2 := (olty2clty $ oAll T1 T2).
+Notation cMu T := (olty2clty $ oMu T).
+Notation cSel p l := (olty2clty $ oSel p l).
+Notation cSing p := (olty2clty $ oSing p).
+Notation cLam T := (olty2clty $ oLam T).
+Notation cApp T p := (olty2clty $ oTApp T p).
 
 Section log_rel.
   Context `{HdotG : !dlangG Σ}.

--- a/theories/Dot/lr/unary_lr.v
+++ b/theories/Dot/lr/unary_lr.v
@@ -164,6 +164,94 @@ Section log_rel.
   #[global] Instance dot_ty_interp : CTyInterp Σ := Reduce ty_interp.
   #[global] Instance dot_kind_interp : SfKindInterp Σ := Reduce kind_interp.
 
+  Section kinterp_lemmas.
+    Lemma kinterp_kintv L U : K⟦ kintv L U ⟧ ≡ sf_kintv V⟦ L ⟧ V⟦ U ⟧.
+    Proof. done. Qed.
+    Lemma kinterp_kpi S K : K⟦ kpi S K ⟧ ≡ sf_kpi V⟦ S ⟧ K⟦ K ⟧.
+    Proof. done. Qed.
+  End kinterp_lemmas.
+
+  Definition klr := (kinterp_kintv, kinterp_kpi).
+
+  Section cinterp_lemmas.
+    Ltac fast_work := done.
+    Ltac fast_go := done.
+    Ltac go := fast_go.
+
+    Lemma cinterp_TTop : C⟦ TTop ⟧ ≡ cTop.
+    Proof. fast_go. Qed.
+    Lemma cinterp_TBot : C⟦ TBot ⟧ ≡ cBot.
+    Proof. fast_go. Qed.
+
+    Lemma cinterp_kTTMem l K1 : C⟦ kTTMem l K1 ⟧ ≡ cTMemK l K⟦ K1 ⟧.
+    Proof. fast_go. Qed.
+    Lemma cinterp_kTSel n p l : C⟦ kTSel n p l ⟧ ≡ cSel p l.
+    Proof. fast_go. Qed.
+
+    Lemma cinterp_TAnd T1 T2 : C⟦ TAnd T1 T2 ⟧ ≡ cAnd C⟦ T1 ⟧ C⟦ T2 ⟧.
+    Proof. fast_go. Qed.
+    Lemma cinterp_TOr T1 T2 : C⟦ TOr T1 T2 ⟧ ≡ cOr V⟦ T1 ⟧ V⟦ T2 ⟧.
+    Proof. go. Qed.
+    Lemma cinterp_TLater T1 : C⟦ TLater T1 ⟧ ≡ cLater V⟦ T1 ⟧.
+    Proof. go. Qed.
+    Lemma cinterp_TAll T1 T2 : C⟦ TAll T1 T2 ⟧ ≡ cAll V⟦ T1 ⟧ V⟦ T2 ⟧.
+    Proof. go. Qed.
+    Lemma cinterp_TMu T1 : C⟦ TMu T1 ⟧ ≡ cMu V⟦ T1 ⟧.
+    Proof. go. Qed.
+    Lemma cinterp_TVMem l T1 : C⟦ TVMem l T1 ⟧ ≡ cVMem l V⟦ T1 ⟧.
+    Proof. go. Qed.
+    Lemma cinterp_TPrim b : C⟦ TPrim b ⟧ ≡ cPrim b.
+    Proof. fast_go. Qed.
+    Lemma cinterp_TSing p : C⟦ TSing p ⟧ ≡ cSing p.
+    Proof. fast_go. Qed.
+    Lemma cinterp_TLam T1 : C⟦ TLam T1 ⟧ ≡ cLam V⟦ T1 ⟧.
+    Proof. go. Qed.
+    Lemma cinterp_TApp T1 p : C⟦ TApp T1 p ⟧ ≡ cApp V⟦ T1 ⟧ p.
+    Proof. go. Qed.
+  End cinterp_lemmas.
+
+  Definition clr :=
+    (cinterp_TTop, cinterp_TBot, cinterp_TAnd,
+    cinterp_TOr, cinterp_TLater, cinterp_TAll, cinterp_TMu, cinterp_TVMem,
+    cinterp_kTTMem, cinterp_kTSel, cinterp_TPrim, cinterp_TSing, cinterp_TLam, cinterp_TApp).
+
+  Section interp_lemmas.
+    Ltac go := done.
+
+    Lemma interp_TTop : V⟦ TTop ⟧ ≡ oTop.
+    Proof. go. Qed.
+    Lemma interp_TBot : V⟦ TBot ⟧ ≡ oBot.
+    Proof. go. Qed.
+    Lemma interp_TAnd T1 T2 : V⟦ TAnd T1 T2 ⟧ ≡ oAnd V⟦ T1 ⟧ V⟦ T2 ⟧.
+    Proof. go. Qed.
+    Lemma interp_TOr T1 T2 : V⟦ TOr T1 T2 ⟧ ≡ oOr V⟦ T1 ⟧ V⟦ T2 ⟧.
+    Proof. go. Qed.
+    Lemma interp_TLater T1 : V⟦ TLater T1 ⟧ ≡ oLater V⟦ T1 ⟧.
+    Proof. go. Qed.
+    Lemma interp_TAll T1 T2 : V⟦ TAll T1 T2 ⟧ ≡ oAll V⟦ T1 ⟧ V⟦ T2 ⟧.
+    Proof. go. Qed.
+    Lemma interp_TMu T1 : V⟦ TMu T1 ⟧ ≡ oMu V⟦ T1 ⟧.
+    Proof. go. Qed.
+    Lemma interp_TVMem l T1 : V⟦ TVMem l T1 ⟧ ≡ oVMem l V⟦ T1 ⟧.
+    Proof. go. Qed.
+    Lemma interp_kTTMem l K1 : V⟦ kTTMem l K1 ⟧ ≡ oTMemK l K⟦ K1 ⟧.
+    Proof. go. Qed.
+    Lemma interp_kTSel n p l : V⟦ kTSel n p l ⟧ ≡ oSel p l.
+    Proof. go. Qed.
+    Lemma interp_TPrim b : V⟦ TPrim b ⟧ ≡ oPrim b.
+    Proof. go. Qed.
+    Lemma interp_TSing p : V⟦ TSing p ⟧ ≡ oSing p.
+    Proof. go. Qed.
+    Lemma interp_TLam T1 : V⟦ TLam T1 ⟧ ≡ oLam V⟦ T1 ⟧.
+    Proof. go. Qed.
+    Lemma interp_TApp T1 p : V⟦ TApp T1 p ⟧ ≡ oTApp V⟦ T1 ⟧ p.
+    Proof. go. Qed.
+  End interp_lemmas.
+
+  Definition vlr :=
+    (interp_TTop, interp_TBot, interp_TAnd,
+    interp_TOr, interp_TLater, interp_TAll, interp_TMu, interp_TVMem,
+    interp_kTTMem, interp_kTSel, interp_TPrim, interp_TSing, interp_TLam, interp_TApp).
 
   (** Binding lemmas for [V⟦ T ⟧] and [K⟦ T ⟧]. *)
   Lemma mut_interp_subst_compose_ind :

--- a/theories/Dot/semtyp_lemmas/tproj_lr.v
+++ b/theories/Dot/semtyp_lemmas/tproj_lr.v
@@ -106,7 +106,7 @@ Section type_proj_setoid_equality.
 
   Lemma oProjN_eq_2 A T args ρ v :
     oProj A T args ρ v ⊣⊢
-    ∃ w d ψ, ⌜w @ A ↘ d⌝ ∧ oClose T ρ w ∧ d ↗n ψ ∧ ▷ ψ args v.
+    ∃ w d ψ, ⌜w @ A ↘ d⌝ ∧ oClose T ρ w ∧ d ↗ ψ ∧ ▷ ψ args v.
   Proof.
     rewrite oProjN_eq; f_equiv => w.
     rewrite and_exist_l; f_equiv => ψ; rewrite and_exist_l; f_equiv => d.


### PR DESCRIPTION
Extracted from #379 with many cleanups (after #386).

These commits are adaptations outside the core changes, separated to shrink the main diff.