### PR TITLE
Progress using syntactic type members and path equivalence

### DIFF
--- a/theories/Dot/examples/sem/syntyp_lemmas/examples_lr_syn.v
+++ b/theories/Dot/examples/sem/syntyp_lemmas/examples_lr_syn.v
@@ -17,6 +17,9 @@ Set Default Proof Using "Type".
 Section Lemmas.
   Context `{HdotG : !dlangG Σ}.
 
+  (* Instance foo : subrelation (≡@{oltyO Σ}) (eq ==> eq ==> equiv)%signature.
+  Proof. solve_proper_ho. Qed. *)
+
   (** For https://github.com/lampepfl/dotty/blob/85962b19ddf4f1909189bf07b40f9a05849f9bbf/compiler/src/dotty/tools/dotc/core/TypeComparer.scala#L553. *)
   Lemma singleton_Mu_dotty_approx_0 {Γ p i T1 T2} `{SwapPropI Σ} :
     iterate TLater i (TAnd T1 (TSing (shift p))) :: Γ ⊨ T1, i <: T2, i -∗

--- a/theories/Dot/hkdot/hkdot_syn.v
+++ b/theories/Dot/hkdot/hkdot_syn.v
@@ -80,6 +80,8 @@ Section lemmas.
     iPoseProof (sK_HoSing with "HK") as "HK1".
     iDestruct (sT_New_Syn with "HK1") as "Hpn". fold vPack.
     iEval (rewrite sP_Val) in "Hpn".
+    (* iDestruct (sT_New_Singl_Syn with "HK") as "Hpn'"; iEval (rewrite sP_Val) in "Hpn'". *)
+    (* iDestruct (sKEq_New_Sel_Widen with "HK Hpn'") as "?". *)
     iApply (sKEq_New_Sel_Widen with "HK Hpn").
   Qed.
 End lemmas.

--- a/theories/Dot/hkdot/hkdot_syn.v
+++ b/theories/Dot/hkdot/hkdot_syn.v
@@ -1,0 +1,92 @@
+From iris.proofmode Require Import tactics.
+From D Require Import iris_prelude.
+From D.Dot Require Import dot_lty dot_semtypes hkdot unary_lr.
+From D.Dot Require Import defs_lr binding_lr dsub_lr path_repl_lr sub_lr examples_lr.
+From D.Dot Require Import hoas ex_utils.
+From D.Dot Require Import sem_unstamped_typing.
+(* From D.Dot Require Import binding_lr_syn dsub_lr_syn path_repl_lr_syn sub_lr_syn
+  examples_lr_syn sem_unstamped_typing. *)
+
+Import SKindSyn HkDot.
+
+Section lemmas.
+  Context `{Hdlang : !dlangG Σ} `{HswapProp : SwapPropI Σ}.
+
+  (* XXX upstream. *)
+  #[global] Arguments dot_rec_ty_interp {_ _} /.
+
+  (* XXX can't upstream. *)
+  Transparent dm_to_type.
+  Lemma dm_to_type_syn_intro' d T ρ :
+    d = dtysyn T.|[ρ] → ⊢ d ↗ (λ args, V⟦ T ⟧ args ρ).
+  Proof. move->. iIntros "/= !> % !% %v". apply (interp_subst_ids T ρ). Qed.
+  Opaque dm_to_type.
+
+  Lemma sD_TypK_Abs_Syn {l Γ} T (K : sf_kind Σ) :
+    Γ s⊨ oLater V⟦ T ⟧ ∷[ 0 ] K -∗
+    Γ s⊨ { l := dtysyn T } : cTMemK l K.
+  Proof.
+    rewrite sdtp_eq'. iIntros ">#HTK !>" (ρ Hpid) "Hg /=".
+    iExists (λ args, V⟦ T ⟧ args ρ).
+    iDestruct (dm_to_type_syn_intro') as "-#$"; first done.
+    iApply ("HTK" with "Hg").
+  Qed.
+
+  Lemma sD_Typ_Syn {l Γ T} :
+    ⊢ Γ s⊨ { l := dtysyn T } : cTMem l (oLater V⟦ T ⟧) (oLater V⟦ T ⟧).
+  Proof.
+    iApply sD_TypK_Abs_Syn.
+    (* Many lemma permutations are possible here. *)
+    iApply sK_Sing_deriv.
+  Qed.
+
+  Lemma suD_Typ_Syn {l Γ T} :
+    ⊢ Γ su⊨ { l := dtysyn T } : cTMem l (oLater V⟦ T ⟧) (oLater V⟦ T ⟧).
+  Proof.
+    iModIntro. iExists (dtysyn T); iSplit; first done. iApply sD_Typ_Syn.
+  Qed.
+(* This is a decent warmup, but TODO: example type application! *)
+
+  Lemma sT_New_Syn Γ l (K : sf_kind Σ) T :
+    oLater (oTMemK l K) :: Γ s⊨ oLater V⟦T⟧ ∷[ 0 ] K -∗
+    Γ s⊨ vobj [ (l, dtysyn T) ] : oMu (oTMemK l K).
+  Proof.
+    rewrite -sT_Obj_I -sD_Sing'.
+    apply sD_TypK_Abs_Syn.
+  Qed.
+
+  Lemma sT_New_Singl_Syn n Γ l (K : s_kind Σ n) T :
+    oLater (oTMemK l (s_to_sf (ho_sing K (oLater V⟦T⟧)))) :: Γ s⊨ oLater V⟦T⟧ ∷[ 0 ] s_to_sf K -∗
+    Γ s⊨ vobj [ (l, dtysyn T) ] : oMu (oTMemK l (s_to_sf K)).
+  Proof using HswapProp.
+    iIntros "#HT".
+    iApply (sT_Sub (T1 := oMu _)).
+    { rewrite sK_HoIntv. iApply (sT_New_Syn with "HT"). }
+    iApply (sStp_Singl_Widen with "HT").
+  Qed.
+
+  (* Replacing [l] by [A], this rule looks like:
+
+     Γ, z : ▷ { A :: S_K(▷ V⟦ T ⟧ᶻ) } s⊨ ▷ V⟦ T ⟧ᶻ ∷ Kᶻ
+     ----------------------------------------------- (μ-<:-μ)
+     Γ s⊨ { A := T }.A <: ▷ V⟦ T ⟧ [ z := { A := T } ] ∷ K [ z := { A := T } ]
+  *)
+  Lemma sKEq_New_Sel_Syn {n Γ l T} {K : s_kind Σ n} :
+    let vPack := vobj [ (l, dtysyn T) ] in
+    oLater (oTMemK l (s_to_sf (ho_sing K (oLater V⟦T⟧)))) :: Γ s⊨ oLater V⟦T⟧ ∷[ 0 ] s_to_sf K -∗
+    Γ s⊨ oSel (pv vPack) l =[0] oLater V⟦T⟧ .sTp[ vPack /] ∷ s_to_sf K.|[ vPack /].
+  Proof using HswapProp.
+    iIntros (vPack) "#HK".
+    iPoseProof (sK_HoSing with "HK") as "HK1".
+    iDestruct (sT_New_Syn with "HK1") as "Hpn". fold vPack.
+    iEval (rewrite sP_Val) in "Hpn".
+    iApply (sKEq_New_Sel_Widen with "HK Hpn").
+  Qed.
+End lemmas.
+
+Section examples.
+  Context `{Hdlang : !dlangG Σ} `{HswapProp : SwapPropI Σ}.
+
+  (* fmap! *)
+
+End examples.

--- a/theories/Dot/hkdot/hkdot_syn.v
+++ b/theories/Dot/hkdot/hkdot_syn.v
@@ -1,3 +1,15 @@
+(** * Demonstrate semantic typing rules for applicative, syntactic type members.
+That is, these are type definitions that:
+- contain syntactic types (which avoid the need for stamping).
+- are interpreted using our logical relation
+- therefore, can be robustly given "applicative"-like semantics (as in storeless
+DOT in Amin's thesis).
+
+We can _almost_ get the rules of storeless DOT (and applicative semantics) even)
+even without syntactic type members, but not quite; stamping the same type twice
+will produce different stamps, ensuring generative semantics.
+*)
+
 From iris.proofmode Require Import tactics.
 From D Require Import iris_prelude.
 From D.Dot Require Import dot_lty dot_semtypes hkdot unary_lr.

--- a/theories/Dot/hkdot/path_equiv.v
+++ b/theories/Dot/hkdot/path_equiv.v
@@ -1,3 +1,5 @@
+(** * XXX Experiments on path equivalence. Compare and contrast with path_equiv2.v. *)
+
 From D Require Import iris_prelude proper lty lr_syn_aux.
 From D Require Import iris_extra.det_reduction.
 From D Require Import swap_later_impl.

--- a/theories/Dot/hkdot/path_equiv.v
+++ b/theories/Dot/hkdot/path_equiv.v
@@ -1,0 +1,232 @@
+From D Require Import iris_prelude proper lty lr_syn_aux.
+From D Require Import iris_extra.det_reduction.
+From D Require Import swap_later_impl.
+From D.Dot Require Import syn path_repl.
+From D.Dot Require Import dlang_inst path_wp.
+From D.pure_program_logic Require Import weakestpre.
+From D.Dot Require Import dot_lty dot_semtypes sem_kind_dot unary_lr.
+
+Implicit Types (Σ : gFunctors)
+         (v w : vl) (e : tm) (d : dm) (ds : dms) (p : path)
+         (ρ : env) (l : label) (T : ty) (K : kind).
+
+Definition dm_rel Σ := ∀ (args : astream) (ρ : env) (d1 d2 : dm), iProp Σ.
+Definition dms_rel Σ := ∀ (args : astream) (ρ : env) (ds1 ds2 : dms), iProp Σ.
+Definition vl_rel Σ := ∀ (args : astream) (ρ : env) (v1 v2 : vl), iProp Σ.
+
+(* Relational Semantic Path Typing. *)
+Definition rsptp `{!dlangG Σ} p1 p2 i Γ (RV : vl_rel Σ) : iProp Σ :=
+  |==> ∀ ρ, sG⟦Γ⟧* ρ →
+    ▷^i
+    path_wp p1.|[ρ] (λI w1,
+    path_wp p2.|[ρ] (λI w2,
+      oClose RV ρ w1 w2)).
+#[global] Arguments rsptp : simpl never.
+
+(** Relational Semantic Subtyping. *)
+Definition rsstpd `{!dlangG Σ} i Γ τ1 τ2 : iProp Σ :=
+  |==> ∀ ρ v1 v2,
+    sG⟦Γ⟧*ρ → ▷^i (oClose τ1 ρ v1 v2 → oClose τ2 ρ v1 v2).
+#[global] Arguments rsstpd : simpl never.
+
+(** Delayed subtyping. *)
+Notation "Γ rs⊨ T1 <:[ i  ] T2" := (rsstpd i Γ T1 T2) (at level 74, T1, T2 at next level).
+(** Path typing *)
+Notation "Γ rs⊨p p1 ~ p2 : τ , i" := (rsptp p1 p2 i Γ τ) (at level 74, p1, p1, τ, i at next level).
+
+Section foo.
+  Context `{HdotG : !dlangG Σ}.
+  Implicit Types (RD : dm_rel Σ) (RDS : dms_rel Σ) (RV : vl_rel Σ) (SK : sf_kind Σ).
+
+  Definition rlift_dm_dms l RD : dms_rel Σ := λI args ρ ds1 ds2,
+    ∃ d1 d2, ⌜ dms_lookup l ds1 = Some d1 ∧ dms_lookup l ds2 = Some d2 ⌝ ∧
+    RD args ρ d1 d2.
+  Definition rlift_dm_vl l RD : vl_rel Σ := λI args ρ v1 v2,
+    ∃ d1 d2, ⌜ v1 @ l ↘ d1 ∧ v2 @ l ↘ d2 ⌝ ∧
+    RD args ρ d1 d2.
+
+  (* Fixpoint ty_le (T : ty) (args : astream) (ρ1 ρ2 : env) (v1 v2 : vl) : iProp Σ :=
+    match T with
+    | TTop => True
+    | TBot => False
+    | TAnd T1 T2 =>
+      ty_le T1 args ρ1 ρ2 v1 v2 ∧
+      ty_le T2 args ρ1 ρ2 v1 v2
+    | TOr T1 T2 =>
+      ty_le T1 args ρ1 ρ2 v1 v2 ∨
+      ty_le T2 args ρ1 ρ2 v1 v2
+    | TLater T =>
+      ▷ ty_le T args ρ1 ρ2 v1 v2
+    | TPrim b => ⌜ v1 = v2 ⌝
+    | TAll _ _ => False
+    | TMu T =>
+      ty_le T args (v1 .: ρ1) (v2 .: ρ2) v1 v2
+    | _ => False
+    end. *)
+(* Print hoLty
+Print hoD *)
+
+  Definition rDVMem RV : dm_rel Σ := λI args ρ d1 d2,
+    ∃ pmem1 pmem2, ⌜d1 = dpt pmem1⌝ ∧ ⌜d2 = dpt pmem2⌝ ∧
+    path_wp pmem1 (λI w1, path_wp pmem2 (λI w2, RV args ρ w1 w2)).
+
+  Definition rDTMem SK : dm_rel Σ := λI args ρ d1 d2,
+    ∃ ψ1 ψ2, d1 ↗ ψ1 ∧ d2 ↗ ψ2 ∧
+    (* Only one env here! *)
+    SK ρ (packHoLtyO ψ1) (packHoLtyO ψ2).
+
+  Definition rDAnd RD1 RD2 : dm_rel Σ := λI args ρ d1 d2,
+    RD1 args ρ d1 d2 ∧ RD2 args ρ d1 d2.
+
+  #[global] Instance rVTop : Top (vl_rel Σ) := λI args ρ v1 v2, True.
+  #[global] Instance rVBot : Bottom (vl_rel Σ) := λI args ρ v1 v2, False.
+  Definition rVAnd RV1 RV2 : vl_rel Σ := λI args ρ v1 v2, RV1 args ρ v1 v2 ∧ RV2 args ρ v1 v2.
+  Definition rVOr RV1 RV2 : vl_rel Σ := λI args ρ v1 v2, RV1 args ρ v1 v2 ∨ RV2 args ρ v1 v2.
+  Definition rVLater RV : vl_rel Σ := λI args ρ v1 v2, ▷ RV args ρ v1 v2.
+  Definition rVAll RV1 RV2 : vl_rel Σ := ⊥.
+
+  (* NOTE We use the "smaller" value! *)
+  Definition rVMu1 RV : vl_rel Σ := λI args ρ v1 v2,
+    RV args (v1 .: ρ) v1 v2.
+  Class QuasiRefl RV : Prop :=
+  { quasi_refl_l args ρ v1 v2 : RV args ρ v1 v2 ⊢ RV args ρ v1 v1
+  ; quasi_refl_r args ρ v1 v2 : RV args ρ v1 v2 ⊢ RV args ρ v2 v2;
+  }.
+  Instance rVMu1_qper RV : QuasiRefl RV → QuasiRefl (rVMu1 RV).
+  Proof.
+    rewrite /rVMu1/=.
+    constructor; intros.
+    apply: quasi_refl_l.
+    Fail apply: quasi_refl_r.
+  Abort.
+
+  Definition close RV : olty Σ := (* XXX better name *)
+    Olty (λI args ρ v, RV args ρ v v).
+
+  Lemma rsMu_Stp_Mu1 {Γ RV1 RV2 i} `{!SwapPropI Σ} `{!QuasiRefl RV1} :
+    oLaterN i (close RV1) :: Γ rs⊨ RV1 <:[i] RV2 -∗
+    Γ rs⊨ rVMu1 RV1 <:[i] rVMu1 RV2.
+  Proof.
+    iIntros ">#Hstp !>" (ρ v1 v2) "Hg".
+    iApply mlaterN_impl. iIntros "#HT1".
+    iApply ("Hstp" $! (v1 .: ρ) _ _ with "[$Hg] HT1").
+    iNext i.
+    rewrite /rVMu1/=.
+    iApply (quasi_refl_l with "HT1").
+  Qed.
+
+  (* NOTE We use both values! *)
+  Definition rVMu RV : vl_rel Σ := λI args ρ v1 v2,
+    RV args (v1 .: ρ) v1 v2 ∧
+    RV args (v2 .: ρ) v1 v2.
+
+  #[global] Instance rVMu_qper RV : QuasiRefl RV → QuasiRefl (rVMu RV).
+  Proof using HdotG.
+    rewrite /rVMu/=.
+    constructor; intros; iIntros "[L R]".
+    iSplit; by iApply quasi_refl_l.
+    iSplit; by iApply quasi_refl_r.
+  Qed.
+
+  Lemma rsMu_Stp_Mu {Γ RV1 RV2 i} `{!SwapPropI Σ} `{!QuasiRefl RV1} :
+    oLaterN i (close RV1) :: Γ rs⊨ RV1 <:[i] RV2 -∗
+    Γ rs⊨ rVMu RV1 <:[i] rVMu RV2.
+  Proof.
+    iIntros ">#Hstp !>" (ρ v1 v2) "Hg".
+    iApply mlaterN_impl. iIntros "#[HT1 HT2]".
+    rewrite /rVMu/=; iSplit; iApply ("Hstp" $! (_ .: ρ) _ _ with "[$Hg]") => //.
+    all: iNext i; asimpl.
+    iApply (quasi_refl_l with "HT1").
+    iApply (quasi_refl_r with "HT2").
+  Qed.
+  #[global] Program Instance hsubst_vl_rel : HSubst vl (vl_rel Σ) :=
+    λ sb RV args ρ, RV args (sb >> ρ).
+
+  (* Doesn't typecheck. *)
+  (* Lemma rVMu_shift RV : rVMu (shift RV) ≡ RV.
+  Proof. move=> args ρ v. by rewrite /= (hoEnvD_weaken_one T args _ v). Qed. *)
+  Lemma rsMu_Stp {Γ RV i} `{!QuasiRefl RV} :
+    ⊢ Γ rs⊨ rVMu (shift RV) <:[i] RV.
+  Proof.
+    rewrite /rVMu /=.
+    iIntros "!>" (???) "#Hg !> /= #[HT _]".
+    (* by rewrite rVMu_shift. *)
+    by rewrite/hsubst /hsubst_vl_rel; asimpl.
+  Qed.
+
+  Lemma rsStp_Mu {Γ RV i} `{!QuasiRefl RV} :
+    ⊢ Γ rs⊨ RV <:[i] rVMu (shift RV).
+  Proof.
+    rewrite /rVMu /=.
+    iIntros "!>" (???) "#Hg !> /= HT".
+    (* by rewrite rVMu_shift; iFrame. *)
+    by rewrite/hsubst /hsubst_vl_rel; asimpl; iFrame.
+  Qed.
+
+  Definition rVVMem l RV : vl_rel Σ := λI args ρ v1 v2,
+    rlift_dm_vl l (rDVMem RV) args ρ v1 v2.
+  Definition rVTMem l SK : vl_rel Σ := λI args ρ v1 v2,
+    rlift_dm_vl l (rDTMem SK) args ρ v1 v2.
+
+  Definition vl_sel' vp l ψ : iProp Σ := ∃ d, ⌜vp @ l ↘ d⌝ ∧ d ↗ ψ.
+  (**
+  XXX
+  The sensible thing for parametricity needs two environments... but for type equivalence?
+  What does it mean that "v1 and v2 are related at type p.A"?
+  So we need to save a relation with each type :-(
+  *)
+  Definition rVSel p l : vl_rel Σ := λI args ρ v1 v2,
+    ∃ ψ,
+      path_wp p.|[ρ] (λI vp, vl_sel' vp l ψ) ∧
+      ψ args v1 ∧ ψ args v2.
+
+  Definition rVPrim b : vl_rel Σ := λI args ρ v1 v2,
+    ⌜ v1 = v2 ⌝ ∧ oPrim b args ρ v1.
+  Definition rVSing p : vl_rel Σ := λI args ρ v1 v2,
+    oSing p args ρ v1 ∧ oSing p args ρ v2.
+  Definition rVLam RV : vl_rel Σ := λI args ρ v1 v2,
+    RV (atail args) (ahead args .: ρ) v1 v2.
+  Definition rVApp RV p : vl_rel Σ := λI args ρ v1 v2,
+    path_wp p.|[ρ] (λI w, RV (acons w args) ρ v1 v2).
+
+  (* Path-refinement, half of path equality. With 1 environment! *)
+  Fixpoint ty_le (T : ty) : vl_rel Σ :=
+    match T with
+    | TTop => rVTop
+    | TBot => rVBot
+    | TAnd T1 T2 =>
+      rVAnd (ty_le T1) (ty_le T2)
+    | TOr T1 T2 =>
+      rVOr (ty_le T1) (ty_le T2)
+    | TLater T =>
+      rVLater (ty_le T)
+    | TAll T1 T2 =>
+      rVAll (ty_le T1) (ty_le T2)
+    | TMu T =>
+      rVMu (ty_le T)
+    | TVMem l T =>
+      rVVMem l (ty_le T)
+    | kTTMem l K =>
+      rVTMem l K⟦ K ⟧
+    | kTSel _ p l => rVSel p l
+    | TPrim b => rVPrim b
+    | TSing p => rVSing p
+    | TLam T => rVLam (ty_le T)
+    | TApp T p => rVApp (ty_le T) p
+    end.
+
+  (* By induction, both values better be in V⟦ T ⟧ args ρ. *)
+  (* Fixpoint ty_le_dm (T : ty) (args : astream) (ρ : env) (d1 d2 : dm) {struct T} : iProp Σ :=
+    match T with
+    | TTop => True
+    | TAnd T1 T2 =>
+      ty_le_dm T1 args ρ d1 d2 ∧
+      ty_le_dm T2 args ρ d1 d2
+    | TVMem l T =>
+    | kTTMem l K =>
+    | _ => False
+    end
+    with *)
+
+
+End foo.

--- a/theories/Dot/hkdot/path_equiv2.v
+++ b/theories/Dot/hkdot/path_equiv2.v
@@ -104,7 +104,8 @@ Definition rsstpd `{!dlangG Σ} i Γ (RV1 RV2 : vl_rel Σ) : iProp Σ :=
 (** Delayed subtyping. *)
 Notation "Γ rs⊨ T1 <:[ i  ] T2" := (rsstpd i Γ T1 T2) (at level 74, T1, T2 at next level).
 (** Path typing *)
-Notation "Γ rs⊨p p1 ~ p2 : τ , i" := (rsptp p1 p2 i Γ τ) (at level 74, p1, p1, τ, i at next level).
+Notation "Γ rs⊨p p1 == p2 : τ , i" := (rsptp p1 p2 i Γ τ)
+  (at level 74, p1, p2, τ, i at next level).
 
 Section foo.
   Context `{HdotG : !dlangG Σ}.

--- a/theories/Dot/hkdot/path_equiv2.v
+++ b/theories/Dot/hkdot/path_equiv2.v
@@ -581,6 +581,38 @@ Print hoD *)
     iApply (sf_kind_proper with "(HT Hg)") => args v /=;
       f_equiv; symmetry; exact: Hγφ.
   Qed.
+
+  Lemma rD_TypK_Abs {Γ} T1 T2 SK s1 s2 σ1 σ2 l :
+    s1 ↝[ σ1 ] T1 -∗
+    s2 ↝[ σ2 ] T2 -∗
+    Γ rs⊨ oLater T1 <::[ 0 ] oLater T2 ∷ SK -∗
+    (* WEIRD, the [=] symbol should be for the symmetric closure! *)
+    Γ rs⊨ { l := dtysem σ1 s1 = dtysem σ2 s2 } : rCTMemK l SK.
+  Proof.
+    rewrite rsdtp_eq'.
+    iDestruct 1 as (φ1 Hγφ1) "#Hγ1".
+    iDestruct 1 as (φ2 Hγφ2) "#Hγ2".
+    iIntros ">#HT !>" (?? Hpid1 Hpid2) "#Hg".
+    iExists (hoEnvD_inst σ1.|[ρ1] φ1), (hoEnvD_inst σ2.|[ρ2] φ2).
+    do 2 (iSplit; [by iApply dm_to_type_intro|]).
+    iApply (sf_kind_proper with "(HT Hg)") => args v /=; f_equiv; symmetry.
+    exact: Hγφ1.
+    exact: Hγφ2.
+  Qed.
+
+  Lemma rK_Sel {Γ} l (SK : sf_kind Σ) p1 p2 i :
+    Γ rs⊨p p1 == p2 : rVTMemK l SK, i -∗
+    (* Γ rs⊨ oSel p1 l =[ i ] oSel p2 l ∷ SK. *)
+    Γ rs⊨ oSel p1 l <::[ i ] oSel p2 l ∷ SK.
+  Proof.
+    iIntros ">#Hp !> %ρ1 %ρ2 Hg". iSpecialize ("Hp" with "Hg"); iNext i.
+    rewrite path_wp_eq; iDestruct "Hp" as (v1 Hal1%alias_paths_pv_eq_1) "Hp".
+    rewrite path_wp_eq; iDestruct "Hp" as (v2 Hal2%alias_paths_pv_eq_1) "Hp".
+    iDestruct "Hp" as (d1 d2 [Hl1 Hl2] ψ1 ψ2) "(#Hl1 & #Hl2 & HK)".
+    iApply (sf_kind_sub_internal_proper with "[] [] HK").
+    all: by iApply oSel_equiv_intro.
+  Qed.
+
   #[global, program] Instance rCTop : Top (crel.t Σ) :=
     CRel ⊤ ⊤.
   Solve All Obligations with eauto.

--- a/theories/Dot/hkdot/path_equiv2.v
+++ b/theories/Dot/hkdot/path_equiv2.v
@@ -181,7 +181,7 @@ Print hoD *)
     ∃ pmem1 pmem2, ⌜d1 = dpt pmem1⌝ ∧ ⌜d2 = dpt pmem2⌝ ∧
     path_wp pmem1 (λI w1, path_wp pmem2 (λI w2, RV anil anil ρ1 ρ2 w1 w2)).
 
-  Definition rDTMem SK : dm_rel Σ := λI ρ1 ρ2 d1 d2,
+  Definition rDTMemK SK : dm_rel Σ := λI ρ1 ρ2 d1 d2,
     ∃ ψ1 ψ2, d1 ↗ ψ1 ∧ d2 ↗ ψ2 ∧
     (* Only one env here! *)
     SK ρ1 (packHoLtyO ψ1) (packHoLtyO ψ2).
@@ -293,8 +293,8 @@ Print hoD *)
 
   Definition rVVMem l RV : vl_relO Σ := λI args1 args2 ρ1 ρ2 v1 v2,
     rlift_dm_vl l (rDVMem RV) args1 args2 ρ1 ρ2 v1 v2.
-  Definition rVTMem l SK : vl_relO Σ := λI args1 args2 ρ1 ρ2 v1 v2,
-    rlift_dm_vl l (rDTMem SK) args1 args2 ρ1 ρ2 v1 v2.
+  Definition rVTMemK l SK : vl_relO Σ := λI args1 args2 ρ1 ρ2 v1 v2,
+    rlift_dm_vl l (rDTMemK SK) args1 args2 ρ1 ρ2 v1 v2.
 
 From D.Dot Require Import hkdot.
 Import HkDot.
@@ -307,17 +307,17 @@ Import HkDot.
   (* Lemma rVTy_intro l Γ i SK s σ T :
     let v := vobj [(l, dtysem σ s)] in
     s ↝[ σ ] T -∗
-    Γ rs⊨p pv v == pv v : rVTMem l SK, i. *)
+    Γ rs⊨p pv v == pv v : rVTMemK l SK, i. *)
   Lemma rVTy_intro l Γ i SK s σ T :
     let v := vobj [(l, dtysem σ s)] in
     s ↝[ σ ] T -∗
-    Γ rs⊨p pv v == pv v : rVMu (rVTMem l (sf_sngl (oLater T))), i.
+    Γ rs⊨p pv v == pv v : rVMu (rVTMemK l (sf_sngl (oLater T))), i.
   Proof.
     intros v.
     rewrite /rsptp.
     iDestruct 1 as (φ Hγφ) "#Hγ".
     iIntros "!>" (??) "#Hg !> /=".
-    rewrite !path_wp_pv_eq /= /rVTMem /rlift_dm_vl /rDTMem /=.
+    rewrite !path_wp_pv_eq /= /rVTMemK /rlift_dm_vl /rDTMemK /=.
     iExists _, _; iSplit; first iIntros "!%".
     {
       split; red; eexists; split_and! => //;
@@ -344,18 +344,18 @@ Import HkDot.
 
   (* Lemma rVTy_intro l Γ i SK (T : ty) :
     let p := pv (vobj [(l, dtysyn T)]) in
-    ⊢ Γ rs⊨p p == p : rVTMem l SK, i.
+    ⊢ Γ rs⊨p p == p : rVTMemK l SK, i.
   Proof.
     rewrite /rsptp.
     iIntros "!>" (??) "#Hg !> /=".
     rewrite !path_wp_pv_eq /=.
-    rewrite /rVTMem /rlift_dm_vl.
+    rewrite /rVTMemK /rlift_dm_vl.
     iExists _, _; iSplit; first iIntros "!%".
     {
       split; red; eexists; split_and! => //;
         apply dms_lookup_head.
     }
-    unfold rDTMem.
+    unfold rDTMemK.
     iExists (hoEnvD_inst (σ.|[ρ]) φ). iSplit.
     by iApply (dm_to_type_intro with "Hγ").
     by iSplit; iIntros (v) "#H"; iNext; rewrite /= (Hγφ _ _). *)
@@ -410,7 +410,7 @@ Import HkDot.
     | TVMem l T =>
       rVVMem l (ty_le T)
     | kTTMem l K =>
-      rVTMem l K⟦ K ⟧
+      rVTMemK l K⟦ K ⟧
     | kTSel _ p l => rVSel p l
     | TPrim b => rVPrim b
     | TSing p => rVSing p

--- a/theories/Dot/hkdot/path_equiv2.v
+++ b/theories/Dot/hkdot/path_equiv2.v
@@ -11,8 +11,6 @@ Import HkDot.
 (* Import last to override side effects. *)
 From D Require Import proper.
 
-Ltac cbv_decide := by apply: bool_decide_unpack; cbv.
-
 (*
 TODO:
 focus on types we need for path equivalence, aka the arguments of type functions:

--- a/theories/Dot/hkdot/path_equiv2.v
+++ b/theories/Dot/hkdot/path_equiv2.v
@@ -578,8 +578,8 @@ Print hoD *)
     iIntros ">#HT !>" (?? Hpid1 Hpid2) "#Hg".
     iExists (hoEnvD_inst σ.|[ρ1] φ), (hoEnvD_inst σ.|[ρ2] φ).
     do 2 (iDestruct (dm_to_type_intro with "Hγ") as "-#$"; first done).
-    iApply (sf_kind_proper with "(HT Hg)") => args v /=.
-    all: by rewrite (Hγφ args _ _).
+    iApply (sf_kind_proper with "(HT Hg)") => args v /=;
+      f_equiv; symmetry; exact: Hγφ.
   Qed.
   #[global, program] Instance rCTop : Top (crel.t Σ) :=
     CRel ⊤ ⊤.

--- a/theories/Dot/hkdot/path_equiv2.v
+++ b/theories/Dot/hkdot/path_equiv2.v
@@ -296,6 +296,70 @@ Print hoD *)
   Definition rVTMem l SK : vl_relO Σ := λI args1 args2 ρ1 ρ2 v1 v2,
     rlift_dm_vl l (rDTMem SK) args1 args2 ρ1 ρ2 v1 v2.
 
+From D.Dot Require Import hkdot.
+Import HkDot.
+
+  (* Lemma rD_TypK_Abs {Γ} T (K : sf_kind Σ) s σ l :
+    Γ rs⊨ oLater T ∷[ 0 ] K -∗
+    s ↝[ σ ] T -∗
+    Γ rs⊨ { l := dtysem σ s } : cTMemK l K. *)
+
+  (* Lemma rVTy_intro l Γ i SK s σ T :
+    let v := vobj [(l, dtysem σ s)] in
+    s ↝[ σ ] T -∗
+    Γ rs⊨p pv v == pv v : rVTMem l SK, i. *)
+  Lemma rVTy_intro l Γ i SK s σ T :
+    let v := vobj [(l, dtysem σ s)] in
+    s ↝[ σ ] T -∗
+    Γ rs⊨p pv v == pv v : rVMu (rVTMem l (sf_sngl (oLater T))), i.
+  Proof.
+    intros v.
+    rewrite /rsptp.
+    iDestruct 1 as (φ Hγφ) "#Hγ".
+    iIntros "!>" (??) "#Hg !> /=".
+    rewrite !path_wp_pv_eq /= /rVTMem /rlift_dm_vl /rDTMem /=.
+    iExists _, _; iSplit; first iIntros "!%".
+    {
+      split; red; eexists; split_and! => //;
+        apply dms_lookup_head.
+    }
+    cbn.
+    set σ1 := σ.|[up ρ1].|[v.[ρ1]/].
+    set σ2 := σ.|[up ρ2].|[v.[ρ2]/].
+    iExists (hoEnvD_inst σ1 φ), (hoEnvD_inst σ2 φ).
+    do 2 (iSplit; [by iApply (dm_to_type_intro with "Hγ")|]).
+    (* by iSplit; iIntros (w) "#H"; iNext; rewrite /= (Hγφ _ _). *)
+    repeat iSplit; iIntros (w) "#H /="; iNext.
+    all: rewrite /= {}/σ1 {}/σ2.
+    all: rewrite /= ?(Hγφ _ _) //=.
+    { asimpl. iApply "H". }
+    admit.
+    admit.
+    (* Both goals suffer from an environment mismatch.
+    But they might follow if we know that T has kind K... which would require T
+    to respect the relation between environments!
+    In turn, we must check that all types respect all the relational semantics.
+    *)
+  Admitted.
+
+  (* Lemma rVTy_intro l Γ i SK (T : ty) :
+    let p := pv (vobj [(l, dtysyn T)]) in
+    ⊢ Γ rs⊨p p == p : rVTMem l SK, i.
+  Proof.
+    rewrite /rsptp.
+    iIntros "!>" (??) "#Hg !> /=".
+    rewrite !path_wp_pv_eq /=.
+    rewrite /rVTMem /rlift_dm_vl.
+    iExists _, _; iSplit; first iIntros "!%".
+    {
+      split; red; eexists; split_and! => //;
+        apply dms_lookup_head.
+    }
+    unfold rDTMem.
+    iExists (hoEnvD_inst (σ.|[ρ]) φ). iSplit.
+    by iApply (dm_to_type_intro with "Hγ").
+    by iSplit; iIntros (v) "#H"; iNext; rewrite /= (Hγφ _ _). *)
+
   Definition vl_sel' vp l ψ : iProp Σ := ∃ d, ⌜vp @ l ↘ d⌝ ∧ d ↗ ψ.
   (**
   XXX

--- a/theories/Dot/hkdot/path_equiv2.v
+++ b/theories/Dot/hkdot/path_equiv2.v
@@ -298,8 +298,8 @@ End judgments.
 (** Delayed subtyping. *)
 Notation "Γ rs⊨ T1 <:[ i  ] T2" := (rsstpd i Γ T1 T2) (at level 74, T1, T2 at next level).
 (** Path typing *)
-Notation "Γ rs⊨p p1 == p2 : τ , i" := (rsptp p1 p2 i Γ τ)
-  (at level 74, p1, p2, τ, i at next level).
+Notation "Γ rs⊨p p1 = p2 : τ , i" := (rsptp p1 p2 i Γ τ)
+  (at level 64, p1, p2, τ, i at next level).
 (** Single-definition typing *)
 Notation "Γ rs⊨ {  l := d1 = d2  } : T" := (rsdtp l d1 d2 Γ T) (at level 64, d1, d2, l, T at next level).
 (** Multi-definition typing *)
@@ -601,7 +601,7 @@ Print hoD *)
   Qed.
 
   Lemma rK_Sel {Γ} l (SK : sf_kind Σ) p1 p2 i :
-    Γ rs⊨p p1 == p2 : rVTMemK l SK, i -∗
+    Γ rs⊨p p1 = p2 : rVTMemK l SK, i -∗
     (* Γ rs⊨ oSel p1 l =[ i ] oSel p2 l ∷ SK. *)
     Γ rs⊨ oSel p1 l <::[ i ] oSel p2 l ∷ SK.
   Proof.
@@ -652,7 +652,7 @@ Print hoD *)
 
   Lemma rP_Obj_I Γ RC ds1 ds2 :
     rVLater (c2v RC) :: Γ rs⊨ds ds1 = ds2 : RC -∗
-    Γ rs⊨p pv (vobj ds1) == pv (vobj ds2) : rVMu (c2v RC), 0.
+    Γ rs⊨p pv (vobj ds1) = pv (vobj ds2) : rVMu (c2v RC), 0.
   Proof.
     iIntros ">(%Hwf1 & %Hwf2 & #Hds) !> %ρ1 %ρ2 #Hg /=".
     rewrite !path_wp_pv_eq /=. iLöb as "IH".
@@ -665,12 +665,12 @@ Print hoD *)
   (* Lemma rVTy_intro l Γ i SK s σ T :
     let v := vobj [(l, dtysem σ s)] in
     s ↝[ σ ] T -∗
-    Γ rs⊨p pv v == pv v : rVTMemK l SK, i. *)
+    Γ rs⊨p pv v = pv v : rVTMemK l SK, i. *)
   Lemma rVTy_intro' l Γ SK s σ T :
     let v := vobj [(l, dtysem σ s)] in
     s ↝[ σ ] T -∗
     rVLater (rVTMemK l (sf_sngl (oLater T))) :: Γ rs⊨ oLater T ∷[ 0 ] sf_sngl (oLater T) -∗
-    Γ rs⊨p pv v == pv v : rVMu (rVTMemK l (sf_sngl (oLater T))), 0.
+    Γ rs⊨p pv v = pv v : rVMu (rVTMemK l (sf_sngl (oLater T))), 0.
   Proof.
     iIntros (v) "#Hs #HK".
     iApply rP_Obj_I.
@@ -709,7 +709,7 @@ Print hoD *)
 
   (* Lemma rVTy_intro l Γ i SK (T : ty) :
     let p := pv (vobj [(l, dtysyn T)]) in
-    ⊢ Γ rs⊨p p == p : rVTMemK l SK, i.
+    ⊢ Γ rs⊨p p = p : rVTMemK l SK, i.
   Proof.
     rewrite /rsptp.
     iIntros "!>" (??) "#Hg !> /=".

--- a/theories/Dot/hkdot/path_equiv2.v
+++ b/theories/Dot/hkdot/path_equiv2.v
@@ -628,6 +628,13 @@ Print hoD *)
     Γ rs⊨p oApp T p1 = oApp T p2 : rVTMemK l SK, i -∗
     Γ rs⊨ oSel p1 l <::[ i ] oSel p2 l ∷ SK -∗ *)
 
+  (**
+    Γ rs⊨p p1 =^i p2 : S
+    Γ rs⊨ T ∷^i Π (x : S). K
+    ------------ ------------
+    Γ rs⊨ T p1 <::^i T p2 ∷ K (x := p1).
+      (* [SK] must respect [p1 = p2]? *)
+  *)
   Lemma oTApp_respects_eq {Γ} l (SK : sf_kind Σ) p1 p2 i RC T :
     Γ rs⊨p p1 = p2 : RC, i -∗
     Γ rs⊨ T ∷[ i ] sf_kpi (close RC) SK -∗

--- a/theories/Dot/hkdot/path_equiv2.v
+++ b/theories/Dot/hkdot/path_equiv2.v
@@ -1,3 +1,5 @@
+(** * XXX Experiments on path equivalence. Compare and contrast with path_equiv.v. *)
+
 From iris.algebra Require Import list.
 From D.pure_program_logic Require Import weakestpre.
 From D Require Import iris_prelude lr_syn_aux lty.

--- a/theories/Dot/hkdot/path_equiv2.v
+++ b/theories/Dot/hkdot/path_equiv2.v
@@ -334,6 +334,39 @@ Print hoD *)
     all: by rewrite (Hγφ args _ _).
   Qed.
 
+  Lemma rD_Nil Γ :
+    ⊢ Γ rs⊨ds [] = [] : ⊤.
+  Proof. by iModIntro; repeat iSplit; last iIntros "**". Qed.
+
+  Definition rDSAnd RDS1 RDS2 : dms_rel Σ := λI ρ1 ρ2 ds1 ds2,
+    RDS1 ρ1 ρ2 ds1 ds2 ∧ RDS2 ρ1 ρ2 ds1 ds2.
+
+  (* TODO: We really need the type records here. *)
+  Lemma rD_Cons Γ d1 d2 ds1 ds2 l (RD1 : dm_relO Σ) RDS2 :
+    dms_hasnt ds1 l →
+    dms_hasnt ds2 l →
+    Γ rs⊨ { l := d1 = d2 } : rlift_dm_dms l RD1 -∗
+    Γ rs⊨ds ds1 = ds2 : RDS2 -∗
+    Γ rs⊨ds (l, d1) :: ds1 = (l, d2) :: ds2 : rDSAnd (rlift_dm_dms l RD1) RDS2.
+  Proof.
+    (* rewrite !sdtp_eq; *)
+    rewrite /rsdstp.
+    iIntros (Hlds1 Hlds2) ">(% & % & #HT1) >(% & % & #HT2) !>"; repeat iSplit.
+    1-2: by iIntros "!%"; cbn; constructor => //; by rewrite -dms_hasnt_notin_eq.
+    iIntros (ρ1 ρ2 [Hpid1 Hpids1]%path_includes_split [Hpid2 Hpids2]%path_includes_split) "#Hg".
+    iSpecialize ("HT1" $! _ _ Hpid1 Hpid2 with "Hg").
+    iDestruct ("HT2" $! _  _ Hpids1 Hpids2 with "Hg") as "{HT2} HT2".
+    iSplit. {
+      rewrite /rlift_dm_dms.
+      iDestruct "HT1" as (d1' d2' [Hd1' Hd2']) "HT1".
+      iExists d1', d2'. iFrame "HT1". iIntros "!%".
+      move: Hd1' Hd2' => /=.
+      by case_decide; intros; simplify_eq.
+    }
+    (* iApply (clty_mono with "HT2"). exact: dms_hasnt_subst. *)
+  Admitted.
+
+
   (* Lemma rVTy_intro l Γ i SK s σ T :
     let v := vobj [(l, dtysem σ s)] in
     s ↝[ σ ] T -∗

--- a/theories/Dot/hkdot/path_equiv2.v
+++ b/theories/Dot/hkdot/path_equiv2.v
@@ -56,7 +56,7 @@ Arguments crel_mixin.Mk {Σ _ _}.
 Module crel.
   Record t {Σ} := Mk {
     to_dms :> dms_rel Σ;
-    to_vl : vl_relO Σ;
+    to_vl :> vl_relO Σ;
     mixin : crel_mixin.pred to_dms to_vl;
   }.
   #[global] Arguments t : clear implicits.
@@ -67,7 +67,7 @@ Module crel.
   #[global] Instance : Params (@to_vl) 1 := {}.
 End crel.
 Add Printing Constructor crel.t.
-Notation c2v := crel.to_vl.
+Coercion crel.to_vl : crel.t >-> ofe_car.
 Coercion crel.to_dms : crel.t >-> dms_rel.
 Notation CRel RDS RV := (crel.Mk RDS RV (crel_mixin.Mk _ _ _)).
 
@@ -537,13 +537,13 @@ Print hoD *)
   Definition rCTMemK l SK : crel.t Σ :=
     rlift_dm_c l (rDTMemK SK).
 
-  Notation rVVMem l RV := (c2v (rCVMem l RV)).
-  Notation rVTMemK l SK := (c2v (rCTMemK l SK)).
+  Notation rVVMem l RV := (crel.to_vl (rCVMem l RV)).
+  Notation rVTMemK l SK := (crel.to_vl (rCTMemK l SK)).
 
   #[program] Definition rCAnd RC1 RC2 : crel.t Σ :=
     CRel
       (λI ρ1 ρ2 ds1 ds2, RC1 ρ1 ρ2 ds1 ds2 ∧ RC2 ρ1 ρ2 ds1 ds2)
-      (rVAnd (c2v RC1) (c2v RC2)).
+      (rVAnd RC1 RC2).
   Next Obligation. intros. by rewrite /= -!crel_def2defs_head. Qed.
   Next Obligation. intros. by rewrite /= -!crel_mono. Qed.
   Next Obligation. intros. by rewrite /rVAnd -!crel_commute. Qed.
@@ -629,8 +629,8 @@ Print hoD *)
     Γ rs⊨ oSel p1 l <::[ i ] oSel p2 l ∷ SK -∗ *)
 
   Lemma oTApp_respects_eq {Γ} l (SK : sf_kind Σ) p1 p2 i RC T :
-    Γ rs⊨p p1 = p2 : c2v RC, i -∗
-    Γ rs⊨ T ∷[ i ] sf_kpi (close $ c2v RC) SK -∗
+    Γ rs⊨p p1 = p2 : RC, i -∗
+    Γ rs⊨ T ∷[ i ] sf_kpi (close RC) SK -∗
     Γ rs⊨ oTApp T p1 <::[ i ] oTApp T p2 ∷
       (* [SK] must respect [p1 = p2]? *)
       SK .sKp[ p1 /].
@@ -650,9 +650,9 @@ Print hoD *)
     3: {
       iClear "HT".
       (* Unprovable: does not match ["Hp"].
-        Provable if [c2v RC] is contravariant in last argument (so, if v2 = v1
+        Provable if [to_vl RC] is contravariant in last argument (so, if v2 = v1
         symmetrically), but rather change ["HT"]? sf_kpi should take [RC] not
-        [close $ c2v RC]. *)
+        [close $ to_vl RC]. *)
       admit.
     }
     (* XXX bump Iris *)
@@ -705,8 +705,8 @@ Print hoD *)
   Proof. by rewrite rD_Sing rCAnd_rCTop. Qed.
 
   Lemma rP_Obj_I Γ RC ds1 ds2 :
-    rVLater (c2v RC) :: Γ rs⊨ds ds1 = ds2 : RC -∗
-    Γ rs⊨p pv (vobj ds1) = pv (vobj ds2) : rVMu (c2v RC), 0.
+    rVLater RC :: Γ rs⊨ds ds1 = ds2 : RC -∗
+    Γ rs⊨p pv (vobj ds1) = pv (vobj ds2) : rVMu RC, 0.
   Proof.
     iIntros ">(%Hwf1 & %Hwf2 & #Hds) !> %ρ1 %ρ2 #Hg /=".
     rewrite !path_wp_pv_eq /=. iLöb as "IH".

--- a/theories/Dot/hkdot/path_equiv2.v
+++ b/theories/Dot/hkdot/path_equiv2.v
@@ -215,6 +215,47 @@ Section env_rstyped.
 End env_rstyped.
 
 (* XXX we use [ρ1] asymmetrically, matching the [rDTMemK]. But this can't work! *)
+
+(*
+Alternative...
+[L1 ρ1] ... [U2 ρ2] doesn't work because variables might contain interval kinds...
+
+Pi (x : S) K
+
+Either the kinds in the variables coincide, or you get ...
+
+Γ = A :: *, B :: A .. A
+
+Γ ⊢ B .. B wf
+
+Here,
+ρ1 = A = A1, B = ???
+ρ2 = A = A2, B = ???
+
+Should B's kind be A1...A2, A2...A1, or B = A1 = A2?
+
+Maybe for our path equality we can assume A1 = A2 and be done, because:
+- we're doing equality not subtyping really
+- we're doing equality not parametricity really
+
+BTW all the constructions of parametricity don't necessarily work for orders,
+because they don't necessarily give transitivity.
+
+Symmetry but not transitivity is problematic.
+
+To get:
+⊢ {A = S1, B = S2} = { A = T1, B = T2 } :: { A :: * }
+
+we need S1 = T1, and (ideally) nothing about S2 and T2 (if this is a problem we
+don't need to care).
+
+Sandro proposes a non-type-directed equality!!!??? ^W ^W ^W
+(or rather type-directed on the most specialized)
+
+In a syntactic relation...
+Equality of paths should compare all members, each in a type-directed way...
+Here: S1 = T2 at the appropriate kind and S2 = T2 at the appropriate kind?
+ *)
 Notation rsstpiK_env i T1 T2 K ρ1 ρ2 := (▷^i K ρ1 (envApply T1 ρ1) (envApply T2 ρ2))%I.
 Notation rsstpiK' i Γ T1 T2 K := (∀ ρ1 ρ2, rG⟦Γ⟧* ρ1 ρ2 → rsstpiK_env i T1 T2 K ρ1 ρ2)%I.
 Definition rsstpiK `{!dlangG Σ} i Γ T1 T2 (K : sf_kind Σ) : iProp Σ :=

--- a/theories/Dot/hkdot/path_equiv2.v
+++ b/theories/Dot/hkdot/path_equiv2.v
@@ -210,8 +210,8 @@ Print hoD *)
   Definition rDAnd RD1 RD2 : dm_rel Σ := λI ρ1 ρ2 d1 d2,
     RD1 ρ1 ρ2 d1 d2 ∧ RD2 ρ1 ρ2 d1 d2.
 
-  #[global] Instance rVTop : Top (vl_relO Σ) := λI args1 args2 ρ1 ρ2 v1 v2, True.
-  #[global] Instance rVBot : Bottom (vl_relO Σ) := λI args1 args2 ρ1 ρ2 v1 v2, False.
+  Definition rVTop : vl_relO Σ := ⊤.
+  Definition rVBot : vl_relO Σ := ⊥.
   Definition rVAnd RV1 RV2 : vl_relO Σ := λI args1 args2 ρ1 ρ2 v1 v2, RV1 args1 args2 ρ1 ρ2 v1 v2 ∧ RV2 args1 args2 ρ1 ρ2 v1 v2.
   Definition rVOr RV1 RV2 : vl_relO Σ := λI args1 args2 ρ1 ρ2 v1 v2, RV1 args1 args2 ρ1 ρ2 v1 v2 ∨ RV2 args1 args2 ρ1 ρ2 v1 v2.
   Definition rVAll RV1 RV2 : vl_relO Σ := ⊥.

--- a/theories/Dot/hkdot/path_equiv2.v
+++ b/theories/Dot/hkdot/path_equiv2.v
@@ -24,8 +24,8 @@ Implicit Types
   (ρ : env) (l : label).
 Implicit Types (K : kind).
 
-Definition dm_rel Σ := ∀ (args1 args2 : astream) (ρ1 ρ2 : env) (d1 d2 : dm), iProp Σ.
-Definition dms_rel Σ := ∀ (args1 args2 : astream) (ρ1 ρ2 : env) (ds1 ds2 : dms), iProp Σ.
+Definition dm_rel Σ := ∀ (ρ1 ρ2 : env) (d1 d2 : dm), iProp Σ.
+Definition dms_rel Σ := ∀ (ρ1 ρ2 : env) (ds1 ds2 : dms), iProp Σ.
 Definition vl_rel Σ := ∀ (args1 args2 : astream) (ρ1 ρ2 : env) (v1 v2 : vl), iProp Σ.
 Definition vl_relO Σ := astream -d> astream -d> env -d> env -d> vl -d> vl -d> iPropO Σ.
 Definition rsCtxO Σ : ofe := listO (vl_relO Σ).
@@ -119,12 +119,12 @@ Section foo.
   Implicit Types (RD : dm_rel Σ) (RDS : dms_rel Σ) (RV : vl_relO Σ).
   Implicit Types (T : olty Σ) (SK : sf_kind Σ).
 
-  Definition rlift_dm_dms l RD : dms_rel Σ := λI args1 args2 ρ1 ρ2 ds1 ds2,
+  Definition rlift_dm_dms l RD : dms_rel Σ := λI ρ1 ρ2 ds1 ds2,
     ∃ d1 d2, ⌜ dms_lookup l ds1 = Some d1 ∧ dms_lookup l ds2 = Some d2 ⌝ ∧
-    RD args1 args2 ρ1 ρ2 d1 d2.
+    RD ρ1 ρ2 d1 d2.
   Definition rlift_dm_vl l RD : vl_relO Σ := λI args1 args2 ρ1 ρ2 v1 v2,
     ∃ d1 d2, ⌜ v1 @ l ↘ d1 ∧ v2 @ l ↘ d2 ⌝ ∧
-    RD args1 args2 ρ1 ρ2 d1 d2.
+    RD ρ1 ρ2 d1 d2.
 
   (* Fixpoint ty_le (T : ty) (args1 args2 : astream) (ρ1 ρ2 : env) (v1 v2 : vl) : iProp Σ :=
     match T with
@@ -147,17 +147,17 @@ Section foo.
 (* Print hoLty
 Print hoD *)
 
-  Definition rDVMem RV : dm_rel Σ := λI args1 args2 ρ1 ρ2 d1 d2,
+  Definition rDVMem RV : dm_rel Σ := λI ρ1 ρ2 d1 d2,
     ∃ pmem1 pmem2, ⌜d1 = dpt pmem1⌝ ∧ ⌜d2 = dpt pmem2⌝ ∧
-    path_wp pmem1 (λI w1, path_wp pmem2 (λI w2, RV args1 args2 ρ1 ρ2 w1 w2)).
+    path_wp pmem1 (λI w1, path_wp pmem2 (λI w2, RV anil anil ρ1 ρ2 w1 w2)).
 
-  Definition rDTMem SK : dm_rel Σ := λI args1 args2 ρ1 ρ2 d1 d2,
+  Definition rDTMem SK : dm_rel Σ := λI ρ1 ρ2 d1 d2,
     ∃ ψ1 ψ2, d1 ↗ ψ1 ∧ d2 ↗ ψ2 ∧
     (* Only one env here! *)
     SK ρ1 (packHoLtyO ψ1) (packHoLtyO ψ2).
 
-  Definition rDAnd RD1 RD2 : dm_rel Σ := λI args1 args2 ρ1 ρ2 d1 d2,
-    RD1 args1 args2 ρ1 ρ2 d1 d2 ∧ RD2 args1 args2 ρ1 ρ2 d1 d2.
+  Definition rDAnd RD1 RD2 : dm_rel Σ := λI ρ1 ρ2 d1 d2,
+    RD1 ρ1 ρ2 d1 d2 ∧ RD2 ρ1 ρ2 d1 d2.
 
   #[global] Instance rVTop : Top (vl_relO Σ) := λI args1 args2 ρ1 ρ2 v1 v2, True.
   #[global] Instance rVBot : Bottom (vl_relO Σ) := λI args1 args2 ρ1 ρ2 v1 v2, False.

--- a/theories/Dot/hkdot/path_equiv2.v
+++ b/theories/Dot/hkdot/path_equiv2.v
@@ -225,11 +225,31 @@ Print hoD *)
   Lemma rsStp_Refl {Γ RV i} :
     ⊢ Γ rs⊨ RV <:[i] RV.
   Proof. iIntros "!>" (????) "#Hg !> /= #$". Qed.
+
+  (*
+  Goal ∃ r : relation (vl_rel Σ),
+    Proper (respectful (≡@{vl_relO Σ}) (respectful r (flip impl))) equiv.
+    unfold vl_rel.
+    progress unfold vl_relO.
+    Fail progress unfold vl_rel.
+  eexists.
+      Set Typeclasses Debug Verbosity 3.
+  (* simple apply trans_co_eq_inv_impl_morphism. *)
+  typeclasses eauto. *)
+
   Lemma rsMu_Stp {Γ RV i} :
     ⊢ Γ rs⊨ rVMu (shift RV) <:[i] RV.
   Proof.
     (* XXX Very slow! *)
     (* rewrite rVMu_shift. apply rsStp_Refl. *)
+(*
+    eapply bi_emp_valid_proper.
+    apply rsstpd_proper; [done|..|done].
+    simple apply (rVMu_shift RV).
+    simple apply rsStp_Refl. *)
+
+    (* Set Debug Tactic Unification. *)
+
     iIntros "!>" (????) "#Hg !> /= #HT".
     iApply "HT".
   Qed.


### PR DESCRIPTION
Alpha-quality experiments, explicitly marked as such.

In this MR, I use #385 to prove new typing rules. Separately I also experiment with #396.