### PR TITLE
Prepare for using guarded recursion (and fixing #385): later_sub_syn

### DIFF
--- a/theories/Dot/lr/unary_lr.v
+++ b/theories/Dot/lr/unary_lr.v
@@ -407,7 +407,7 @@ For now this uses mostly definitional equalities, but this will change when
 fixing [issue #365](https://github.com/Blaisorblade/dot-iris/issues/365).
 *)
 Definition lr := (@fmap_cons, @iterate_TLater_oLater).
-Ltac rw := rewrite /ietp /idstp /idtp /iptp /istpd ?lr /=.
+Ltac rw := rewrite /ietp /idstp /idtp /iptp /istpd ?lr; cbn.
 
 Import dlang_adequacy.
 

--- a/theories/Dot/lr/unary_lr.v
+++ b/theories/Dot/lr/unary_lr.v
@@ -325,6 +325,15 @@ Section misc_lemmas.
 
 End misc_lemmas.
 
+(** Tactic to reduce the syntactic judgments and logical relation.
+To use when proving syntactic typing lemmas, e.g. [Stp_Top] over [sStp_Top], or
+[Mu_Stp] over [sMu_Stp].
+For now this uses mostly definitional equalities, but this will change when
+fixing [issue #365](https://github.com/Blaisorblade/dot-iris/issues/365).
+*)
+Definition lr := (@fmap_cons, @iterate_TLater_oLater).
+Ltac rw := rewrite /ietp /idstp /idtp /iptp /istpd ?lr; cbn.
+
 Section path_repl_lemmas.
   Context `{!dlangG Σ}.
   Implicit Types (φ : vl -d> iPropO Σ).
@@ -399,15 +408,6 @@ End path_repl_lemmas.
 
 (** Backward compatibility. *)
 Notation "⟦ T ⟧" := (oClose V⟦ T ⟧).
-
-(** Tactic to reduce the syntactic judgments and logical relation.
-To use when proving syntactic typing lemmas, e.g. [Stp_Top] over [sStp_Top], or
-[Mu_Stp] over [sMu_Stp].
-For now this uses mostly definitional equalities, but this will change when
-fixing [issue #365](https://github.com/Blaisorblade/dot-iris/issues/365).
-*)
-Definition lr := (@fmap_cons, @iterate_TLater_oLater).
-Ltac rw := rewrite /ietp /idstp /idtp /iptp /istpd ?lr; cbn.
 
 Import dlang_adequacy.
 

--- a/theories/Dot/semtyp_lemmas/later_sub_sem.v
+++ b/theories/Dot/semtyp_lemmas/later_sub_sem.v
@@ -27,11 +27,19 @@ Section CtxSub.
   #[global] Instance : PreOrder s_ctx_sub.
   Proof. split; first done. by move => x y z H1 H2 ρ; rewrite (H1 _). Qed.
 
+  #[global] Instance s_ty_sub_proper : Proper (equiv ==> equiv ==> iff) s_ty_sub.
+  Proof.
+    rewrite /s_ty_sub => L1 L2 HL U1 U2 HU.
+    by setoid_rewrite HL; setoid_rewrite HU.
+  Qed.
+  #[global] Instance : Params (@s_ty_sub) 2 := {}.
+
   #[global] Instance : Proper (equiv ==> equiv ==> iff) s_ctx_sub.
   Proof.
     rewrite /s_ctx_sub => Γ1 Γ2 HΓ Δ1 Δ2 HΔ.
     by setoid_rewrite HΔ; setoid_rewrite HΓ.
   Qed.
+  #[global] Instance : Params (@s_ctx_sub) 2 := {}.
 
   #[global] Instance cons_s_ctx_sub_mono : Proper (s_ty_sub ==> s_ctx_sub ==> s_ctx_sub) cons.
   Proof. move => T1 T2 HlT Γ1 Γ2 Hl ρ. cbn. by rewrite (HlT _) (Hl _). Qed.

--- a/theories/Dot/syntyp_lemmas/later_sub_syn.v
+++ b/theories/Dot/syntyp_lemmas/later_sub_syn.v
@@ -165,22 +165,15 @@ Section CtxSub.
 
   (** Ordering of logical strength:
       unTLater T <: T <: TLater (unTLater T) <: TLater T. *)
+  Lemma ty_sub_TLater T : ⊨T T <: TLater T.
+  Proof. intros ?. auto. Qed.
+
   Lemma unTLater_ty_sub T : ⊨T unTLater T <: T.
   Proof. induction T => //=; by [ f_equiv | intros ?; auto ]. Qed.
-
-  Lemma ty_sub_TLater_unTLater T : ⊨T T <: TLater (unTLater T).
-  Proof.
-    induction T; try by [iIntros (??) "$"];
-      rewrite {1}IHT1 {1}IHT2 /=; intros ??;
-      [> iIntros "[$ $]" | iIntros "[$|$]"].
-  Qed.
 
   Lemma ty_sub_id T : ⊨T T <: T. Proof. done. Qed.
   Lemma ty_sub_trans T1 T2 T3 : ⊨T T1 <: T2 → ⊨T T2 <: T3 → ⊨T T1 <: T3.
   Proof. by intros ->. Qed.
-
-  Lemma ty_sub_TLater T : ⊨T T <: TLater T.
-  Proof. intros ?. auto. Qed.
 
   Lemma ty_sub_TLater_add T1 T2 :
     ⊨T T1 <: T2 →
@@ -195,8 +188,16 @@ Section CtxSub.
     ⊨T TOr (TLater T1) (TLater T2) <: TLater (TOr T1 T2).
   Proof. iIntros (??) "[$|$]". Qed.
 
-  #[local] Hint Resolve ty_sub_id ty_sub_TLater ty_sub_TLater_add ty_sub_TLater_unTLater
+  #[local] Hint Resolve ty_sub_id ty_sub_TLater ty_sub_TLater_add
     ty_distr_TAnd_TLater ty_distr_TOr_TLater unTLater_ty_sub : ctx_sub.
+
+  Lemma ty_sub_TLater_unTLater T : ⊨T T <: TLater (unTLater T).
+  Proof.
+    induction T; try by [iIntros (??) "$"];
+      rewrite {1}IHT1 {1}IHT2 /=; intros ??;
+      [> iIntros "[$ $]" | iIntros "[$|$]"].
+  Qed.
+  #[local] Hint Resolve ty_sub_TLater_unTLater : ctx_sub.
 
   (* Unused *)
   Lemma TLater_unTLater_ty_sub_TLater T :

--- a/theories/Dot/syntyp_lemmas/later_sub_syn.v
+++ b/theories/Dot/syntyp_lemmas/later_sub_syn.v
@@ -18,13 +18,12 @@ Section TypeEquiv.
     (∀ T1 T2 (H : |- T1 == T2), C⟦ T1 ⟧ ≡ C⟦ T2 ⟧) ∧
     (∀ K1 K2 (H : |-K K1 == K2), K⟦ K1 ⟧ ≡ K⟦ K2 ⟧).
   Proof.
-    apply: type_kind_eq_mut_ind;
-      cbn; rewrite /pty_interp; intros.
+    apply: type_kind_eq_mut_ind; intros *; rw; intros.
+    all: unfold pty_interp.
     by rewrite cAnd_olty2clty sTEq_oLaterN_oAnd.
     by rewrite sTEq_oLaterN_oOr.
     all: try reflexivity.
-    all: repeat no_eq_f_equiv.
-    all: try solve [assumption|symmetry; assumption].
+    all: repeat first [assumption | symmetry; assumption | no_eq_f_equiv].
     by etrans.
     by etrans.
   Qed.
@@ -114,13 +113,13 @@ Section CtxSub.
   Proof. apply: flip_proper_4. Qed.
 
   #[global] Instance TLater_mono : Proper (ty_sub ==> ty_sub) TLater.
-  Proof. by rewrite /ty_sub => ?? /= ->. Qed.
+  Proof. move=> T1 T2. by rewrite /ty_sub !vlr =>->. Qed.
   #[global] Instance TLater_flip_mono :
     Proper (flip ty_sub ==> flip ty_sub) TLater.
   Proof. apply: flip_proper_2. Qed.
 
-  Lemma fmap_TLater_oLater Γ : V⟦ TLater <$> Γ ⟧* = oLater <$> V⟦ Γ ⟧*.
-  Proof. elim: Γ => [//| T Γ IH]; cbn. by rewrite IH. Qed.
+  Lemma fmap_TLater_oLater Γ : V⟦ TLater <$> Γ ⟧* ≡ oLater <$> V⟦ Γ ⟧*.
+  Proof. elim: Γ => [//| T Γ IH]. rw. by rewrite IH. Qed.
 
   Lemma env_TLater_commute Γ ρ : G⟦ TLater <$> Γ ⟧ ρ ⊣⊢ ▷ G⟦ Γ ⟧ ρ.
   Proof. by rewrite -senv_TLater_commute fmap_TLater_oLater. Qed.
@@ -152,13 +151,13 @@ Section CtxSub.
   Proof. apply: flip_proper_2. Qed.
 
   #[global] Instance TAnd_mono : Proper (ty_sub ==> ty_sub ==> ty_sub) TAnd.
-  Proof. intros x y Hl x' y' Hl' ??. by rewrite /= (Hl _ _) (Hl' _ _). Qed.
+  Proof. intros x y Hl x' y' Hl' ??. by rewrite !vlr /= (Hl _ _) (Hl' _ _). Qed.
   #[global] Instance TAnd_flip_mono :
     Proper (flip ty_sub ==> flip ty_sub ==> flip ty_sub) TAnd.
   Proof. apply: flip_proper_3. Qed.
 
   #[global] Instance TOr_mono : Proper (ty_sub ==> ty_sub ==> ty_sub) TOr.
-  Proof. intros x y Hl x' y' Hl' ??. by rewrite /= (Hl _ _) (Hl' _ _). Qed.
+  Proof. intros x y Hl x' y' Hl' ??. by rewrite !vlr /= (Hl _ _) (Hl' _ _). Qed.
   #[global] Instance TOr_flip_mono :
     Proper (flip ty_sub ==> flip ty_sub ==> flip ty_sub) TOr.
   Proof. apply: flip_proper_3. Qed.
@@ -166,10 +165,10 @@ Section CtxSub.
   (** Ordering of logical strength:
       unTLater T <: T <: TLater (unTLater T) <: TLater T. *)
   Lemma ty_sub_TLater T : ⊨T T <: TLater T.
-  Proof. intros ?. auto. Qed.
+  Proof. intros ??. rewrite interp_TLater /=. auto. Qed.
 
   Lemma unTLater_ty_sub T : ⊨T unTLater T <: T.
-  Proof. induction T => //=; by [ f_equiv | intros ?; auto ]. Qed.
+  Proof. induction T => //=; [by f_equiv..|]. apply ty_sub_TLater. Qed.
 
   Lemma ty_sub_id T : ⊨T T <: T. Proof. done. Qed.
   Lemma ty_sub_trans T1 T2 T3 : ⊨T T1 <: T2 → ⊨T T2 <: T3 → ⊨T T1 <: T3.
@@ -193,9 +192,9 @@ Section CtxSub.
 
   Lemma ty_sub_TLater_unTLater T : ⊨T T <: TLater (unTLater T).
   Proof.
-    induction T; try by [iIntros (??) "$"];
-      rewrite {1}IHT1 {1}IHT2 /=; intros ??;
-      [> iIntros "[$ $]" | iIntros "[$|$]"].
+    induction T; simpl; auto with ctx_sub.
+    all: rewrite {1}IHT1 {1}IHT2 /=.
+    all: auto with ctx_sub.
   Qed.
   #[local] Hint Resolve ty_sub_TLater_unTLater : ctx_sub.
 

--- a/theories/Dot/syntyp_lemmas/later_sub_syn.v
+++ b/theories/Dot/syntyp_lemmas/later_sub_syn.v
@@ -181,11 +181,27 @@ Section CtxSub.
 
   Lemma ty_distr_TAnd_TLater T1 T2 :
     ⊨T TAnd (TLater T1) (TLater T2) <: TLater (TAnd T1 T2).
-  Proof. iIntros (??) "[$ $]". Qed.
+  Proof.
+    (* by rewrite /ty_sub !vlr rewrite sTEq_oLaterN_oAnd. *)
+    eapply s_ty_sub_proper. {
+      rewrite interp_TAnd.
+      by apply oAnd_proper; apply interp_TLater.
+    }
+    by rewrite interp_TLater interp_TAnd.
+    intros ??. by rewrite sTEq_oLaterN_oAnd.
+  Qed.
 
   Lemma ty_distr_TOr_TLater T1 T2 :
     ⊨T TOr (TLater T1) (TLater T2) <: TLater (TOr T1 T2).
-  Proof. iIntros (??) "[$|$]". Qed.
+  Proof.
+    (* by rewrite /ty_sub !vlr sTEq_oLaterN_oOr. *)
+    eapply s_ty_sub_proper. {
+      rewrite interp_TOr.
+      by apply oOr_proper; apply interp_TLater.
+    }
+    by rewrite interp_TLater interp_TOr.
+    intros ??. by rewrite sTEq_oLaterN_oOr.
+  Qed.
 
   #[local] Hint Resolve ty_sub_id ty_sub_TLater ty_sub_TLater_add
     ty_distr_TAnd_TLater ty_distr_TOr_TLater unTLater_ty_sub : ctx_sub.


### PR DESCRIPTION
Porting this file required some extra setoid wrangling. Last preparation MR before fixing #385.

Follow-up of #390, extracted from #379.