### PR TITLE
Fix #385: Dot: Use guarded recursion to enable syntactic values in types

### DIFF
--- a/theories/Dot/examples/sem/from_pdot_mutual_rec_sem.v
+++ b/theories/Dot/examples/sem/from_pdot_mutual_rec_sem.v
@@ -249,7 +249,6 @@ Tactic Notation "lrSimpl" "in" constr(iSelP) :=
   iEval (rewrite vlr) in iSelP.
 
 #[local] Arguments iPPred_car : simpl never.
-#[local] Arguments pty_interp : simpl never.
 
 Lemma newTypeRef_semTyped Γ :
   ⊢ newTypeRefΓ Γ u⊨ newTypeRefBody : x1 @; "TypeRef".

--- a/theories/Dot/hkdot/hkdot.v
+++ b/theories/Dot/hkdot/hkdot.v
@@ -456,7 +456,7 @@ Implicit Types
 Notation "Γ s⊨X T1 <:[ i  ] T2" := (sstpd i Γ T1 T2) (at level 74, T1, T2 at next level).
 
 Section dot_types.
-  Context `{!dlangG Σ} `{HswapProp : SwapPropI Σ}.
+  Context `{!dlangG Σ} `{HswapProp : SwapPropI Σ} `{!RecTyInterp Σ}.
 
   (** Such substitution lemmas hold for all judgments. Note the mu type!
   XXX don't restrict to values. *)
@@ -685,7 +685,7 @@ End s_kind_ofe.
 Import defs_lr binding_lr examples_lr.
 
 Section derived.
-  Context `{Hdlang : !dlangG Σ} `{HswapProp : SwapPropI Σ}.
+  Context `{Hdlang : !dlangG Σ} `{HswapProp : SwapPropI Σ} `{!RecTyInterp Σ}.
   Opaque sSkd sstpiK sptp sstpd sstpi.
 
   Lemma sT_New Γ l σ s (K : sf_kind Σ) T :
@@ -880,7 +880,7 @@ Section derived.
 End derived.
 
 Section examples.
-  Context `{!dlangG Σ} `{HswapProp : SwapPropI Σ}.
+  Context `{!dlangG Σ} `{HswapProp : SwapPropI Σ} `{!RecTyInterp Σ}.
   Import DBNotation dot_lty.
 
   Definition oId := oLam (oSel x0 "A").
@@ -896,7 +896,7 @@ Section examples.
 End examples.
 
 Section dot_experimental_kinds.
-  Context `{!dlangG Σ} `{HswapProp : SwapPropI Σ}.
+  Context `{!dlangG Σ} `{HswapProp : SwapPropI Σ} `{!RecTyInterp Σ}.
 
   (** As an example, we can derive this variant at an interval kind of [sSngl_Stp_Sym] *)
   Lemma sSngl_KStp_Sym Γ p q T i L U :

--- a/theories/Dot/hkdot/sem_kind_dot.v
+++ b/theories/Dot/hkdot/sem_kind_dot.v
@@ -23,34 +23,45 @@ Implicit Types
 Notation oDTMemRaw rK := (Dlty (λI ρ d, ∃ ψ, d ↗ ψ ∧ rK ρ ψ)).
 
 (** [ D⟦ { A :: K } ⟧ ]. *)
-Definition oDTMemK `{!dlangG Σ} (K : sf_kind Σ) : dltyO Σ :=
+Definition oDTMemK `{!dlangG Σ} `[!RecTyInterp Σ] (K : sf_kind Σ) : dltyO Σ :=
   oDTMemRaw (λI ρ ψ, K ρ (packHoLtyO ψ) (packHoLtyO ψ)).
 #[global] Instance : Params (@oDTMemK) 2 := {}.
 
-Definition cTMemK `{!dlangG Σ} l (K : sf_kind Σ) : clty Σ := dty2clty l (oDTMemK K).
+Definition cTMemK `{!dlangG Σ} l `[!RecTyInterp Σ] (K : sf_kind Σ) : clty Σ := dty2clty l (oDTMemK K).
 #[global] Instance : Params (@cTMemK) 3 := {}.
 Notation oTMemK l K := (clty_olty (cTMemK l K)).
 
-Definition oDTMemAnyKind `{!dlangG Σ} : dltyO Σ := Dlty (λI ρ d,
+Definition oDTMemAnyKind `{!dlangG Σ} `{!RecTyInterp Σ} : dltyO Σ := Dlty (λI ρ d,
   ∃ (ψ : hoD Σ), d ↗ ψ).
-Definition cTMemAnyKind `{!dlangG Σ} l : clty Σ := dty2clty l oDTMemAnyKind.
+Definition cTMemAnyKind `{!dlangG Σ} l `{!RecTyInterp Σ} : clty Σ := dty2clty l oDTMemAnyKind.
 Notation oTMemAnyKind l := (clty_olty (cTMemAnyKind l)).
 
 Section TMem_Proper.
-  Context `{!dlangG Σ}.
+  Context `{HdotG : !dlangG Σ}.
 
-  #[global] Instance oDTMemK_ne : NonExpansive (oDTMemK (Σ := Σ)).
-  Proof. solve_proper_ho. Qed.
-  #[global] Instance oDTMemK_proper : Proper1 (oDTMemK (Σ := Σ)) :=
-    ne_proper _.
-  #[global] Instance cTMemK_ne l : NonExpansive (cTMemK (Σ := Σ) l).
-  Proof. solve_proper_ho. Qed.
-  #[global] Instance cTMemK_proper l : Proper1 (cTMemK (Σ := Σ) l) :=
-    ne_proper _.
+  #[global] Instance oDTMemK_contractive n :
+    Proper (dist_later n ==> dist n ==> dist n) (oDTMemK (Σ := Σ)).
+  Proof. solve_contractive_ho. Qed.
+  (* Both contractive and nonexpansive, since [contractive_ne_2] is not an
+  instance. *)
+  #[global] Instance oDTMemK_ne : NonExpansive2 (oDTMemK (Σ := Σ)) :=
+    contractive_ne_R _.
+  #[global] Instance oDTMemK_proper : Proper2 (oDTMemK (Σ := Σ)) :=
+    ne_proper_2 _.
+
+  #[global] Instance cTMemK_contractive l n :
+    Proper (dist_later n ==> dist n ==> dist n) (cTMemK (Σ := Σ) l).
+  Proof. solve_contractive_ho. Qed.
+  (* Both contractive and nonexpansive, since [contractive_ne_2] is not an
+  instance. *)
+  #[global] Instance cTMemK_ne l : NonExpansive2 (cTMemK (Σ := Σ) l) :=
+    contractive_ne_R _.
+  #[global] Instance cTMemK_proper l : Proper2 (cTMemK (Σ := Σ) l) :=
+    ne_proper_2 _.
 End TMem_Proper.
 
 Section TMem_lemmas.
-  Context `{HdotG : !dlangG Σ}.
+  Context `{HdotG : !dlangG Σ} `{!RecTyInterp Σ}.
 
   Lemma cTMemK_eq l (K : sf_kind Σ) d ρ :
     cTMemK l K ρ [(l, d)] ⊣⊢ oDTMemK K ρ d.
@@ -77,13 +88,13 @@ Definition dot_intv_type_pred `{!dlangG Σ} (L U : oltyO Σ) ρ ψ : iProp Σ :=
 #[global] Instance : Params (@dot_intv_type_pred) 2 := {}.
 
 (** [ D⟦ { A :: τ1 .. τ2 } ⟧ ]. *)
-Definition oDTMem `{!dlangG Σ} L U : dltyO Σ := oDTMemK (sf_kintv L U).
-Definition oDTMem_eq `{!dlangG Σ} L U : oDTMem L U = oDTMemK (sf_kintv L U) := reflexivity _.
+Definition oDTMem `{!dlangG Σ} `[!RecTyInterp Σ] L U : dltyO Σ := oDTMemK (sf_kintv L U).
+Definition oDTMem_eq `{!dlangG Σ} `{!RecTyInterp Σ} L U : oDTMem L U = oDTMemK (sf_kintv L U) := reflexivity _.
 #[global] Instance : Params (@oDTMem) 2 := {}.
 
-#[global] Arguments oDTMem {Σ _} L U ρ : rename.
+#[global] Arguments oDTMem {Σ _ _} L U ρ : rename.
 
-Definition cTMem `{!dlangG Σ} l L U : clty Σ := dty2clty l (oDTMem L U).
+Definition cTMem `{!dlangG Σ} l `[!RecTyInterp Σ] L U : clty Σ := dty2clty l (oDTMem L U).
 #[global] Instance : Params (@cTMem) 3 := {}.
 
 Notation oTMem l L U := (clty_olty (cTMem l L U)).
@@ -91,21 +102,28 @@ Notation oTMem l L U := (clty_olty (cTMem l L U)).
 Section TMem_Proper.
   Context `{HdotG : !dlangG Σ}.
 
-  #[global] Instance oDTMem_ne : NonExpansive2 oDTMem.
-  Proof. move=> ? ??? ??? ??/=. solve_proper. Qed.
+  #[global] Instance oDTMem_contractive n :
+    Proper (dist_later n ==> dist n ==> dist n ==> dist n) (@oDTMem Σ HdotG).
+  Proof. solve_contractive_ho. Qed.
 
-  #[global] Instance oDTMem_proper : Proper2 oDTMem :=
-    ne_proper_2 _.
+  (* Not an instance: it'd break [solve_contractive] in [cTMem_contractive]. *)
+  Definition oDTMem_ne : NonExpansive3 (@oDTMem Σ HdotG) :=
+    contractive_ne_R _.
 
-  #[global] Instance cTMem_ne l : NonExpansive2 (cTMem l).
-  Proof. solve_proper. Qed.
+  #[global] Instance oDTMem_proper : Proper3 (@oDTMem Σ HdotG).
+  Proof. apply ne_proper_3, oDTMem_ne. Qed.
 
-  #[global] Instance cTMem_proper l : Proper2 (cTMem l) :=
-    ne_proper_2 _.
+  #[global] Instance cTMem_contractive n l : Proper (dist_later n ==> dist n ==> dist n ==> dist n) (cTMem l).
+  Proof. solve_contractive. Qed.
+
+  Definition cTMem_ne l : NonExpansive3 (cTMem l) :=
+    contractive_ne_R _.
+  #[global] Instance cTMem_proper l : Proper3 (cTMem l).
+  Proof. apply ne_proper_3, cTMem_ne. Qed.
 End TMem_Proper.
 
 Section sem_TMem.
-  Context `{HdotG : !dlangG Σ}.
+  Context `{HdotG : !dlangG Σ} `{!RecTyInterp Σ}.
   Implicit Types (τ : oltyO Σ).
 
   Lemma oDTMem_unfold L U : oDTMem L U ≡ oDTMemRaw (dot_intv_type_pred L U).

--- a/theories/Dot/lr/dot_lty.v
+++ b/theories/Dot/lr/dot_lty.v
@@ -297,16 +297,23 @@ Section path_repl.
   (* The reverse does not hold. *)
 End path_repl.
 
+Definition RecTyInterp Σ : Type := ty -d> hoEnvD Σ.
+Existing Class RecTyInterp.
+Typeclasses Transparent RecTyInterp.
+
 (** When a definition points to a semantic type. Inlined in paper. *)
-Definition dm_to_type `{HdotG : !dlangG Σ} d (ψ : hoD Σ) : iProp Σ :=
+Definition dm_to_type `{HdotG : !dlangG Σ} d (ψ : hoD Σ) {rinterp : RecTyInterp Σ} : iProp Σ :=
   match d with
   | dtysem σ s => s ↗n[ σ ] ψ
   | _ => False
   end.
+#[global] Instance dm_to_type_ne `{HdotG : !dlangG Σ} d n :
+  Proper (dist_later n ==> dist_later n ==> dist n) (dm_to_type d).
+Proof. solve_contractive_ho. Qed.
 Notation "d ↗ ψ" := (dm_to_type d ψ) (at level 20).
 
 Section dm_to_type.
-  Context `{HdotG : !dlangG Σ}.
+  Context `{HdotG : !dlangG Σ} `{rinterp : !RecTyInterp Σ}.
 
   Lemma dm_to_type_agree {d ψ1 ψ2} args v : d ↗ ψ1 -∗ d ↗ ψ2 -∗ ▷ (ψ1 args v ≡ ψ2 args v).
   Proof.

--- a/theories/Dot/lr/dot_lty.v
+++ b/theories/Dot/lr/dot_lty.v
@@ -305,11 +305,13 @@ Typeclasses Transparent RecTyInterp.
 Definition dm_to_type `{HdotG : !dlangG Σ} d (ψ : hoD Σ) {rinterp : RecTyInterp Σ} : iProp Σ :=
   match d with
   | dtysem σ s => s ↗n[ σ ] ψ
-  | _ => False
+  | dtysyn T => ▷ (∀ args, ψ args ≡ rinterp T args ids)
+  | dpt _ => False
   end.
 #[global] Instance dm_to_type_ne `{HdotG : !dlangG Σ} d n :
   Proper (dist_later n ==> dist_later n ==> dist n) (dm_to_type d).
 Proof. solve_contractive_ho. Qed.
+
 Notation "d ↗ ψ" := (dm_to_type d ψ) (at level 20).
 
 Section dm_to_type.
@@ -317,12 +319,17 @@ Section dm_to_type.
 
   Lemma dm_to_type_agree {d ψ1 ψ2} args v : d ↗ ψ1 -∗ d ↗ ψ2 -∗ ▷ (ψ1 args v ≡ ψ2 args v).
   Proof.
-    destruct d; simpl; [ | apply stamp_σ_to_type_agree | ]; by iIntros "[]".
+    destruct d; simpl; [ | apply stamp_σ_to_type_agree | by iIntros "[]" ].
+    iIntros "H1 H2 !>"; iRewrite ("H1" $! args); iRewrite ("H2" $! args). by [].
   Qed.
 
   Lemma dm_to_type_intro d s σ φ :
     d = dtysem σ s → s ↝n φ -∗ d ↗ hoEnvD_inst σ φ.
   Proof. move=>->/=. apply stamp_σ_to_type_intro. Qed.
+
+  Lemma dm_to_type_syn_intro d T :
+    d = dtysyn T → ⊢ d ↗ (λ args, rinterp T args ids).
+  Proof. move->. by iIntros "!>". Qed.
 
   #[global] Opaque dm_to_type.
 End dm_to_type.

--- a/theories/Dot/lr/dot_semtypes.v
+++ b/theories/Dot/lr/dot_semtypes.v
@@ -78,11 +78,34 @@ Section JudgEqs.
 End JudgEqs.
 
 (** ** gDOT semantic types. *)
-Definition vl_sel `{!dlangG Σ} vp l args v : iProp Σ :=
+Definition vl_sel `{!dlangG Σ} vp l args v `{!RecTyInterp Σ} : iProp Σ :=
   ∃ d ψ, ⌜vp @ l ↘ d⌝ ∧ d ↗ ψ ∧ packHoLtyO ψ args v.
 
-Definition oSel `{!dlangG Σ} p l : oltyO Σ :=
+Definition oSel `{!dlangG Σ} p l `{!RecTyInterp Σ} : oltyO Σ :=
   Olty (λI args ρ v, path_wp p.|[ρ] (λ vp, vl_sel vp l args v)).
+
+Section sel_types_lemmas.
+  Context `{HdotG : !dlangG Σ}.
+
+  #[global] Instance vl_sel_contractive vp l args v : Contractive (@vl_sel _ _ vp l args v).
+  Proof. solve_contractive_ho. Qed.
+  (* Deducible. *)
+  Definition vl_sel_ne vp l args v : NonExpansive (@vl_sel _ _ vp l args v) :=
+    contractive_ne _.
+  #[global] Instance vl_sel_proper vp l args v : Proper1 (@vl_sel _ _ vp l args v) :=
+    ne_proper _.
+
+  #[global] Instance oSel_contractive p l : Contractive (@oSel _ _ p l).
+  Proof.
+    move=> n ri1 ri2 Hri args ρ v /=.
+    f_equiv => w.
+    solve_contractive_ho.
+  Qed.
+  Definition oSel_ne p l : NonExpansive (@oSel _ _ p l) :=
+    contractive_ne _.
+  #[global] Instance oSel_proper p l : Proper1 (@oSel _ _ p l) :=
+    ne_proper _.
+End sel_types_lemmas.
 
 Section sem_types.
   Context `{HdotG : !dlangG Σ}.
@@ -147,7 +170,7 @@ Notation oTMemL l L U := (clty_olty (cTMemL l L U)).
 Notation oVMem l τ := (clty_olty (cVMem l τ)).
 
 Section misc_lemmas.
-  Context `{HdotG : !dlangG Σ}.
+  Context `{HdotG : !dlangG Σ} `{!RecTyInterp Σ}.
   Implicit Types (τ L T U : olty Σ).
 
   Lemma oSel_pv w l args ρ v :

--- a/theories/Dot/lr/unary_lr.v
+++ b/theories/Dot/lr/unary_lr.v
@@ -142,6 +142,7 @@ Section log_rel.
    with ty_interp (T : ty) : clty Σ :=
     let rec_ty : CTyInterp Σ := ty_interp in
     let rec_kind : SfKindInterp Σ := kind_interp in
+    let hrec : RecTyInterp Σ := pty_interp in
     match T with
     | kTTMem l K => cTMemK l K⟦ K ⟧
     | TVMem l T' => cVMem l V⟦ T' ⟧
@@ -163,6 +164,7 @@ Section log_rel.
 
   #[global] Instance dot_ty_interp : CTyInterp Σ := Reduce ty_interp.
   #[global] Instance dot_kind_interp : SfKindInterp Σ := Reduce kind_interp.
+  #[global] Instance dot_rec_ty_interp : RecTyInterp Σ := pty_interp.
 
   Section kinterp_lemmas.
     Lemma kinterp_kintv L U : K⟦ kintv L U ⟧ ≡ sf_kintv V⟦ L ⟧ V⟦ U ⟧.

--- a/theories/Dot/semtyp_lemmas/defs_lr.v
+++ b/theories/Dot/semtyp_lemmas/defs_lr.v
@@ -8,7 +8,7 @@ Set Suggest Proof Using.
 Set Default Proof Using "Type".
 
 Section Sec.
-  Context `{HdlangG : !dlangG Σ}.
+  Context `{HdotG : !dlangG Σ} `{!RecTyInterp Σ}.
 
   (** Lemmas about definition typing. *)
   Lemma sD_Path {Γ} T p l :

--- a/theories/Dot/semtyp_lemmas/dsub_lr.v
+++ b/theories/Dot/semtyp_lemmas/dsub_lr.v
@@ -13,7 +13,7 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 
 Section DStpLemmas.
-  Context `{HdotG : !dlangG Σ}.
+  Context `{HdotG : !dlangG Σ} `{!RecTyInterp Σ}.
 
   Lemma sstpd_delay_oLaterN `{!SwapPropI Σ} Γ i T1 T2 :
     Γ s⊨ oLaterN i T1 <:[0] oLaterN i T2 ⊣⊢

--- a/theories/Dot/semtyp_lemmas/tproj_lr.v
+++ b/theories/Dot/semtyp_lemmas/tproj_lr.v
@@ -78,7 +78,7 @@ End existentials.
   (model-level) existentials and normal DOT type members:
     [V[[T#A]](ρ) = { v | ∃ w ∈ V[[T]](ρ). v ∈ V[[w.A]](ρ) }].
 *)
-Definition oProj `{!dlangG Σ} A (T : oltyO Σ) : oltyO Σ :=
+Definition oProj `{!dlangG Σ} `{!RecTyInterp Σ} A (T : oltyO Σ) : oltyO Σ :=
   Olty (λI args ρ v,
   ∃ w,
   (* w ∈ T *)
@@ -90,11 +90,13 @@ Definition oProj `{!dlangG Σ} A (T : oltyO Σ) : oltyO Σ :=
 #[global] Instance : Params (@oProj) 3 := {}.
 
 Section type_proj_setoid_equality.
-  Context `{!dlangG Σ}.
+  Context `{!dlangG Σ} `{!RecTyInterp Σ}.
 
   Definition oProjN_oExists `{!dlangG Σ} A T :
     oProj A T ≡ oExists T (oSel (pv (ids 0)) A) := reflexivity _.
 
+  (* Note: we can skip contractiveness over [RecTyInterp], simply because [oProjN]
+  is not used when constructing the fixpoint. *)
   #[global] Instance oProjN_ne A : NonExpansive (oProj A).
   Proof. solve_proper_ho. Qed.
   #[global] Instance oProjN_proper A : Proper1 (oProj A) :=


### PR DESCRIPTION
Fix #385. The first commit is mostly boilerplate, abstracting over the type semantics more often. The second commit pulls the plug and switches to guarded recursion for syntactic type members (while preserving the existing support for semantic type members).

Follow-up of #392, extracted from #379.