### PR TITLE
Use explicit persistence again

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -32,6 +32,7 @@ https://github.com/Blaisorblade/dot-iris/pulls?q=is%3Apr+is%3Amerged+label%3Amaj
     update" modality (`<PB> P` that is `□ |==> □ P`), that can replace `|==>` when
     non-persistent resources are available, and intuitionistic propositions must
     be marked explicitly via `□`, and uses it in DSub.
+  - https://github.com/Blaisorblade/dot-iris/pull/421 ports Dot to these changes.
 # v1.0
 
 Release accompanying the ICFP'20 paper.

--- a/tests/test_used_axioms.ref
+++ b/tests/test_used_axioms.ref
@@ -7,6 +7,7 @@ FunctionalExtensionality.functional_extensionality_dep
   : ∀ (A : Type) (B : A → Type) (f g : ∀ x : A, B x),
       (∀ x : A, f x = g x) → f = g
 Axioms:
+ProofIrrelevance.proof_irrelevance : ∀ (P : Prop) (p1 p2 : P), p1 = p2
 FunctionalExtensionality.functional_extensionality_dep
   : ∀ (A : Type) (B : A → Type) (f g : ∀ x : A, B x),
       (∀ x : A, f x = g x) → f = g

--- a/theories/Dot/examples/sem/no_russell_paradox.v
+++ b/theories/Dot/examples/sem/no_russell_paradox.v
@@ -40,7 +40,7 @@ Section Russell.
     rewrite oTMem_unfold. iIntros "#Hs".
     iExists _; iSplit. by iExists _; iSplit.
     iExists _; iSplit. by iApply dm_to_type_intro.
-    by repeat iSplit; iIntros "% **".
+    by iIntros "!>"; repeat iSplit; iIntros "% **".
   Qed.
 
   Lemma later_not_UAU : Hs ⊢ uAu v -∗ ▷ False.
@@ -68,7 +68,7 @@ Section Russell.
         eauto using objLookupIntro.
       }
       + by iApply (dm_to_type_intro with "Hs").
-      + iIntros "!>!>". rewrite /uAu/= path_wp_pv_eq. iApply "HnotVAV".
+      + iIntros "!>!>!>". rewrite /uAu/= path_wp_pv_eq. iApply "HnotVAV".
     - iIntros "#Hvav".
       by iDestruct (later_not_UAU with "Hs Hvav") as "#>[]".
   Qed.

--- a/theories/Dot/hkdot/hkdot.v
+++ b/theories/Dot/hkdot/hkdot.v
@@ -158,22 +158,22 @@ Section gen_lemmas.
   Proof. iIntros "[$ $]". Qed.
 
   Lemma sf_star_eq ρ T1 T2 :
-    sf_star ρ T1 T2 ⊣⊢ oClose T1 ⊆@{Σ} oClose T2.
+    sf_star ρ T1 T2 ⊣⊢ □ (oClose T1 ⊆@{Σ} oClose T2).
   Proof.
     iSplit; first by iIntros "(_ & $ & _)".
-    iIntros "#$"; iSplit;
+    iIntros "#$ !>"; iSplit;
       iIntros (v); [iIntros "[]" | iIntros "_ //"].
   Qed.
 
   Lemma ksubtyping_equiv' i Γ T1 T2 :
-    sstpiK' i Γ T1 T2 sf_star ⊣⊢
-    ∀ ρ, sG⟦ Γ ⟧* ρ → ▷^i (oClose T1 ρ ⊆ oClose T2 ρ).
+    □ sstpiK' i Γ T1 T2 sf_star ⊣⊢
+    □ ∀ ρ, sG⟦ Γ ⟧* ρ → ▷^i (oClose T1 ρ ⊆ oClose T2 ρ).
   Proof.
     iSplit.
-    - iIntros "#Hsub %ρ #Hg".
+    - iIntros "#Hsub !> %ρ #Hg".
       iDestruct (sf_star_eq with "(Hsub Hg)") as "{Hsub Hg} #Hsub".
       iIntros "!>". iApply "Hsub".
-    - iIntros "#Hsub %ρ #Hg". rewrite sf_star_eq /=.
+    - iIntros "#Hsub !> %ρ #Hg". rewrite sf_star_eq /=.
       iSpecialize ("Hsub" with "Hg").
       by iNext.
   Qed.
@@ -269,8 +269,8 @@ Section gen_lemmas.
     Γ s⊨ oLam T1 <:[i] oLam T2 ∷ sf_kpi S K.
   Proof using HswapProp.
     pupd; iIntros "#HTK !> %ρ #Hg * /=" (arg).
-    rewrite -impl_laterN.
-    iIntros "Hs".
+    rewrite -mlaterN_pers -impl_laterN.
+    iIntros "!> Hs".
     iSpecialize ("HTK" $! (arg .: ρ) with "[$Hg $Hs]").
     by iApply (sf_kind_proper with "HTK").
   Qed.
@@ -289,7 +289,7 @@ Section gen_lemmas.
     pupd; iIntros "#HsubL #HsubU !> %ρ #Hg /=" (T1 T2).
     iPoseProof (ksubtyping_spec with "HsubL Hg") as "{HsubL} HsubL".
     iPoseProof (ksubtyping_spec with "HsubU Hg") as "{HsubU Hg} HsubU".
-    iNext i; iIntros "#(HsubL1 & $ & HsubU1)"; iSplit.
+    iNext i; iIntros "#(HsubL1 & $ & HsubU1) !>"; iSplit.
     iApply (subtype_trans with "HsubL HsubL1").
     iApply (subtype_trans with "HsubU1 HsubU").
   Qed.
@@ -309,7 +309,7 @@ Section gen_lemmas.
       iIntros "#HS2 %T1 %T2"; rewrite -mlaterN_impl; iIntros "HK1".
       iApply ("HsubK" $! (arg .: ρ) with "[$Hg $HS2] HK1").
     }
-    iIntros (T1 T2); iNext i. iIntros "#HTK1 * #HS".
+    iIntros (T1 T2); iNext i. iIntros "#HTK1 !> * #HS".
     iSpecialize ("HsubK" $! arg with "HS").
     iApply ("HsubK" with "(HTK1 (HsubS HS))").
   Qed.
@@ -352,7 +352,7 @@ Section gen_lemmas.
     (HU : ∀ arg args ρ, envApply U2 ρ (acons arg args) ≡ envApply U1 ρ (acons arg args)) :
     Γ s⊨ T1 <:[ i ] U1 ∷ sf_kpi S K ⊢ Γ s⊨ T2 <:[ i ] U2 ∷ sf_kpi S K.
   Proof.
-    apply sstpiK_mono_ctx; iIntros "%ρ #Hg #HK"; iNext i; iIntros "%arg #HS".
+    apply sstpiK_mono_ctx; iIntros "%ρ #Hg #HK"; iNext i; iIntros "!> %arg #HS".
     by iApply (sf_kind_proper with "(HK HS)") => args; rewrite /acurry.
   Qed.
 
@@ -630,15 +630,16 @@ Section dot_types.
     iIntros (ρ Hpid) "Hg"; iExists (hoEnvD_inst (σ.|[ρ]) φ).
     iDestruct (dm_to_type_intro with "Hγ") as "-#$"; first done.
     iApply (sf_kind_proper' with "(HTK Hg)") => args v /=.
-    do 1!f_equiv; symmetry. exact: Hγφ.
+    rewrite -(bi.intuitionistic_intuitionistically (T _ _ _)).
+    do 2!f_equiv; symmetry. exact: Hγφ.
   Qed.
 
   Lemma oSel_equiv_intro ρ p v l d1 ψ1
     (Hal : alias_paths p.|[ρ] (pv v))
     (Hl1 : v ,, l ↘ d1) :
-    d1 ↗ ψ1 ⊢ hoLty_equiv (packHoLtyO ψ1) (envApply (oSel p l) ρ).
+    d1 ↗ ψ1 ⊢ □ hoLty_equiv (packHoLtyO ψ1) (envApply (oSel p l) ρ).
   Proof.
-    iIntros "#Hl1 %args %w".
+    iIntros "#Hl1 %args %w !>".
     rewrite /= alias_paths_elim_eq // path_wp_pv_eq.
     iSplit; first by iIntros "H"; iExists d1, ψ1; iFrame (Hl1) "Hl1".
     iDestruct 1 as (d2 ψ2 Hl2) "[Hl2 Hw]"; objLookupDet.
@@ -668,7 +669,7 @@ Section dot_types.
     iDestruct "Hal" as %Hal%alias_paths_simpl.
     iApply (sf_kind_sub_internal_proper with "[] [] HK").
     iApply hoLty_equiv_refl.
-    iIntros "%args %v"; rewrite -internal_eq_iff.
+    iIntros "%args %v !>"; rewrite -internal_eq_iff.
     iApply ("Hrepl" $! args ρ v Hal).
   Qed.
 
@@ -984,7 +985,7 @@ Section dot_experimental_kinds.
     iEval asimpl.
     iApply sf_kind_sub_trans.
     { iApply (sfkind_respects with "[] (HT [])").
-      { iIntros "% %". iSplit; iIntros "$". }
+      { iIntros "!> % %". iSplit; iIntros "$". }
       admit.
     }
   Abort.

--- a/theories/Dot/hkdot/hkdot_syn.v
+++ b/theories/Dot/hkdot/hkdot_syn.v
@@ -42,7 +42,8 @@ Section lemmas.
     iExists (λ args, V⟦ T ⟧ args ρ).
     iDestruct (dm_to_type_syn_intro') as "-#$"; first done.
     iApply (sfkind_respects with "[] (HTK Hg)").
-    iIntros "%%".
+    iIntros "!> %%".
+    rewrite /= bi.intuitionistic_intuitionistically.
     by iSplit; iIntros "$".
   Qed.
 

--- a/theories/Dot/hkdot/sem_kind_dot.v
+++ b/theories/Dot/hkdot/sem_kind_dot.v
@@ -82,7 +82,7 @@ End TMem_lemmas.
 (** ** Type members: derive special case for gDOT. *)
 (** Not a "real" kind, just a predicate over types. *)
 Definition dot_intv_type_pred `{!dlangG Σ} (L U : oltyO Σ) ρ ψ : iProp Σ :=
-  L anil ρ ⊆ packHoLtyO ψ anil ∧ packHoLtyO ψ anil ⊆ U anil ρ.
+  □(L anil ρ ⊆ packHoLtyO ψ anil ∧ packHoLtyO ψ anil ⊆ U anil ρ).
 #[global] Instance : Params (@dot_intv_type_pred) 2 := {}.
 
 (** [ D⟦ { A :: τ1 .. τ2 } ⟧ ]. *)
@@ -179,11 +179,11 @@ Definition _oTApp `{!dlangG Σ} (p : path) (T : oltyO Σ) : oltyO Σ :=
 (* Show a more natural ordering to the user. *)
 Notation oTApp T p := (_oTApp p T).
 
-Program Definition kpSubstOne `{!dlangG Σ} p (K : sf_kind Σ) : sf_kind Σ :=
+Program Definition kpSubstOne {Σ} p (K : sf_kind Σ) : sf_kind Σ :=
   SfKind
     (λI ρ T1 T2, path_wp p.|[ρ] (λ v, K (v .: ρ) T1 T2)).
 Next Obligation.
-  move=> Σ ? p K v m T1 T2 HT U1 U2 HU /=. f_equiv=>?. exact: sf_kind_sub_ne_2.
+  move=> Σ p K v m T1 T2 HT U1 U2 HU /=. f_equiv=>?. exact: sf_kind_sub_ne_2.
 Qed.
 Next Obligation.
   iIntros "* #Heq1 #Heq2 H". iApply (path_wp_wand with "H");

--- a/theories/Dot/lr/dot_semtypes.v
+++ b/theories/Dot/lr/dot_semtypes.v
@@ -162,7 +162,7 @@ Section sem_types.
   Definition oAll τ1 τ2 := olty0
     (λI ρ v,
     (∃ t, ⌜ v = vabs t ⌝ ∧
-     ∀ w, ▷ τ1 anil ρ w → ▷ sE⟦ τ2 ⟧ (w .: ρ) t.|[w/])).
+     □ ∀ w, ▷ τ1 anil ρ w → ▷ sE⟦ τ2 ⟧ (w .: ρ) t.|[w/])).
 
   #[global] Instance oAll_ne : NonExpansive2 oAll.
   Proof. solve_proper_ho. Qed.
@@ -192,7 +192,7 @@ Section misc_lemmas.
 
   Lemma oSel_pv w l args ρ v :
     oSel (pv w) l args ρ v ⊣⊢
-      ∃ d ψ, ⌜w.[ρ] ,, l ↘ d⌝ ∧ d ↗ ψ ∧ ▷ ψ args v.
+      ∃ d ψ, ⌜w.[ρ] ,, l ↘ d⌝ ∧ d ↗ ψ ∧ ▷ □ ψ args v.
   Proof. by rewrite /= path_wp_pv_eq. Qed.
 
   Lemma oVMem_eq l T anil ρ v :
@@ -242,21 +242,21 @@ Section misc_lemmas.
   Proof. apply (lift_sub_dty2cltyN 0). Qed.
 
   Lemma oDTMem_respects_sub L1 L2 U1 U2 ρ d :
-    L2 anil ρ ⊆ L1 anil ρ -∗
-    U1 anil ρ ⊆ U2 anil ρ -∗
+    □ (L2 anil ρ ⊆ L1 anil ρ) -∗
+    □ (U1 anil ρ ⊆ U2 anil ρ) -∗
     oDTMem L1 U1 ρ d -∗ oDTMem L2 U2 ρ d.
   Proof.
     rewrite !oDTMem_unfold.
     iIntros "#HsubL #HsubU"; iDestruct 1 as (φ) "#(Hφl & #HLφ & #HφU)".
     rewrite /= /dot_intv_type_pred.
-    iExists φ; iSplit; first done; iSplit; iIntros "%w #Hw".
+    iExists φ; iSplit; first done; iModIntro; iSplit; iIntros "%w #Hw".
     - iApply ("HLφ" with "(HsubL Hw)").
     - iApply ("HsubU" with "(HφU Hw)").
   Qed.
 
   Lemma oTMem_respects_sub L1 L2 U1 U2 ρ l :
-    L2 anil ρ ⊆ L1 anil ρ -∗
-    U1 anil ρ ⊆ U2 anil ρ -∗
+    □ (L2 anil ρ ⊆ L1 anil ρ) -∗
+    □ (U1 anil ρ ⊆ U2 anil ρ) -∗
     oTMem l L1 U1 anil ρ ⊆ oTMem l L2 U2 anil ρ.
   Proof.
     rewrite -lift_sub_dty2clty; iIntros "#HsubL #HsubU %d".

--- a/theories/Dot/semtyp_lemmas/binding_lr.v
+++ b/theories/Dot/semtyp_lemmas/binding_lr.v
@@ -16,7 +16,7 @@ Section LambdaIntros.
   Proof.
     rewrite Hctx; pupd; iIntros "#HeT !> %ρ #Hg /=".
     rewrite -wp_value'. iExists _; iSplit; first done.
-    iIntros "%v Hv"; rewrite up_sub_compose.
+    iIntros "!> %v Hv"; rewrite up_sub_compose.
     (* Factor ▷ out of [sG⟦ Γ ⟧* ρ] before [iNext]. *)
     rewrite senv_TLater_commute. iNext.
     iApply ("HeT" $! (v .: ρ) with "[Hv $Hg]").

--- a/theories/Dot/semtyp_lemmas/defs_lr.v
+++ b/theories/Dot/semtyp_lemmas/defs_lr.v
@@ -74,7 +74,7 @@ Section Sec.
     iIntros "!>" (ρ Hpid) "#Hg"; rewrite oDTMem_unfold /=.
     iExists (hoEnvD_inst (σ.|[ρ]) φ); iSplit.
     by iApply (dm_to_type_intro with "Hγ").
-    iSplit; iIntros "%v #H"; iNext; by iApply Hγφ.
+    iIntros "!>"; iSplit; iIntros "%v #H"; iNext; [iModIntro|]; by iApply Hγφ.
   Qed.
 
   Lemma sD_Typ_Abs {Γ} T L U s σ l :

--- a/theories/Dot/semtyp_lemmas/dsub_lr.v
+++ b/theories/Dot/semtyp_lemmas/dsub_lr.v
@@ -174,11 +174,11 @@ Section DStpLemmas.
     rewrite -!mlaterN_impl.
     iDestruct 1 as (t) "#[Heq #HT1]"; iExists t; iFrame "Heq".
     iIntros (w); iSpecialize ("HT1" $! w).
-    rewrite -!mlaterN_impl -!laterN_later.
-    iIntros "#HwT2".
+    rewrite -!mlaterN_pers mlater_impl -!mlaterN_impl.
+    iIntros "!> #HwT2".
     iSpecialize ("HsubT" with "Hg").
     iSpecialize ("HsubU" $! (w .: ρ) with "[$HwT2 $Hg]").
-    rewrite !mlaterN_impl.
+    rewrite -!laterN_later.
     iNext (i.+1). wp_wapply "(HT1 (HsubT HwT2))".
     iIntros (u) "#HuU1". iApply ("HsubU" with "HuU1").
   Qed.
@@ -207,7 +207,7 @@ Section DStpLemmas.
     pupd; iIntros "!> %ρ _ !> %v [#H1 #H2]".
     iDestruct "H1" as (t ?) "#H1"; iDestruct "H2" as (t' ->) "#H2"; simplify_eq.
     iExists t; iSplit; first done.
-    iIntros "%w #HS".
+    iIntros "!> %w #HS".
     (* Oh. Dreaded conjunction rule. Tho could we use a version
     for separating conjunction? *)
     iApply (wp_and with "(H1 HS) (H2 HS)").
@@ -219,7 +219,7 @@ Section DStpLemmas.
     pupd; iIntros "!> %ρ _ !> %v [#H1 #H2]".
     iDestruct "H1" as (t ?) "#H1"; iDestruct "H2" as (t' ->) "#H2"; simplify_eq.
     iExists t; iSplit; first done.
-    iIntros "%w #[HS|HS]"; [iApply ("H1" with "HS")|iApply ("H2" with "HS")].
+    iIntros "!> %w #[HS|HS]"; [iApply ("H1" with "HS")|iApply ("H2" with "HS")].
   Qed.
 
   (**
@@ -246,7 +246,7 @@ Section DStpLemmas.
     iDestruct "H1" as (ψ d Hl) "[Hdψ1 #[HLψ1 HψU1]]".
     iDestruct "H2" as (ψ' d' Hl') "[Hdψ2 #[HLψ2 HψU2]]". objLookupDet.
     iExists ψ, d. iFrame (Hl). iSplit; first done.
-    iSplit; iIntros (w) "Hw";
+    iIntros "!>"; iSplit; iIntros (w) "Hw";
       iDestruct (dm_to_type_agree anil w with "Hdψ1 Hdψ2") as "Hag".
     - iDestruct "Hw" as "[Hw|Hw]"; first iApply ("HLψ1" with "Hw").
       iSpecialize ("HLψ2" with "Hw").

--- a/theories/Dot/semtyp_lemmas/tproj_lr.v
+++ b/theories/Dot/semtyp_lemmas/tproj_lr.v
@@ -105,7 +105,7 @@ Section type_proj_setoid_equality.
 
   Lemma oProjN_eq_2 A T args ρ v :
     oProj A T args ρ v ⊣⊢
-    ∃ w d ψ, ⌜w ,, A ↘ d⌝ ∧ oClose T ρ w ∧ d ↗ ψ ∧ ▷ ψ args v.
+    ∃ w d ψ, ⌜w ,, A ↘ d⌝ ∧ oClose T ρ w ∧ d ↗ ψ ∧ ▷ □ ψ args v.
   Proof.
     rewrite oProjN_eq; f_equiv => w.
     rewrite and_exist_l; f_equiv => ψ; rewrite and_exist_l; f_equiv => d.

--- a/theories/iris_extra/dlang.v
+++ b/theories/iris_extra/dlang.v
@@ -24,7 +24,6 @@ Module Type LiftWp (Import VS : VlSortsSig).
   Class dlangG Σ `{InhabitedState dlang_lang} := DLangG {
     dlangG_savior :> savedHoSemTypeG Σ;
     dlangG_langdet :> LangDet dlang_lang;
-    dlangG_persistent (P : iProp Σ) :> Persistent P | 0;
   }.
 
   (** ** Instance of [irisGS] enable using the expression weakest precondition; this instance. *)
@@ -81,9 +80,6 @@ Module Type LiftWp (Import VS : VlSortsSig).
 
   Module dlang_adequacy.
     Definition dlangΣ := #[savedHoSemTypeΣ].
-
-    (* #[local], because [dlangG_persistent] is what should be used. *)
-    #[local] Instance CmraPersistent_dlang : CmraPersistent (iResUR dlangΣ) := CmraPersistent_iResUR _.
 
     #[local] Instance dlangG_dlangΣ
       `{InhabitedState dlang_lang} `{!LangDet dlang_lang} : dlangG dlangΣ.

--- a/theories/iris_extra/persistence.v
+++ b/theories/iris_extra/persistence.v
@@ -13,7 +13,7 @@ Class CmraPersistent (M : cmra) :=
 Section CmraPersistentLaws.
   #[local] Arguments uPred_holds {_} !_ _ _.
 
-  #[global] Instance CmraPersistent_Persistent {M : ucmra} `(!CmraPersistent M)
+  #[local] Instance CmraPersistent_Persistent {M : ucmra} `(!CmraPersistent M)
     (P : uPred M) : Persistent P.
   Proof.
     split => n x Hx Hpx; uPred.unseal.


### PR DESCRIPTION
Instead of proving (once and for all) that all our propositions are persistent, use the persistence modality explicitly. See #428 for motivation.

TODO:
- [x] add instances for `Persistent` and `IntoPersistent` for all judgments in the right places
- [ ] for path equivalences, add/start using types of _persistent_ relations (maybe by building on `iPPred` in `lty.v`, despite the asymmetry).