### PR TITLE
Tweak `ipwp_terminates` for later credits: don't rely on `bupd_plain`

### DIFF
--- a/theories/Dot/lr/dot_semtypes.v
+++ b/theories/Dot/lr/dot_semtypes.v
@@ -278,7 +278,7 @@ Section misc_lemmas.
   Proof. by rewrite sdtp_eq; properness; last apply dty2clty_singleton. Qed.
 
   Lemma ipwp_terminates {p T i} :
-    [] s⊨p p : T , i ⊢ ▷^i ⌜ terminates (path2tm p) ⌝.
+    [] s⊨p p : T , i ⊢ |==> ▷^i ⌜ terminates (path2tm p) ⌝.
   Proof.
     iIntros ">#H".
     iSpecialize ("H" $! ids with "[//]"); rewrite hsubst_id.

--- a/theories/Dot/lr/unary_lr.v
+++ b/theories/Dot/lr/unary_lr.v
@@ -460,7 +460,7 @@ Lemma ipwp_gs_adequacy Σ `{HdlangG : !dlangG Σ} `{!SwapPropI Σ} {p T i}
   (Hwp : ∀ `(Hdlang : !dlangG Σ) `(!SwapPropI Σ), ⊢ [] ⊨p p : T , i) :
   terminates (path2tm p).
 Proof.
-  eapply (@soundness (iResUR Σ) _ i).
+  apply (soundness (M := iResUR Σ) _ i).
   apply (bupd_plain_soundness _).
   iApply ipwp_terminates.
   iApply Hwp.


### PR DESCRIPTION
Usually one cannot `iMod` a basic update without one in the goal; this only
works thanks to `elim_modal_bupd_plain_goal`, which relies on `bupd_plain`.

Instead, we can just add a basic update to the goal. This is fine because the
only user is `ipwp_gs_adequacy`, which already accepts this basic update, and
eliminates it explicitly via `bupd_plain_soundness` (which also relies on
`bupd_plain`).

Another motivation is that later credits do not offer `bupd_plain` as is, only
`lc_soundness`, so this step would need adjusting if we used `le_upd` or fancy
updates. Hence, it's worth making this step explicit.