### PR TITLE
Add "persistent update" modality, and use it in DSub

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -25,6 +25,8 @@ theories/iris_extra/iris_prelude.v
 theories/iris_extra/lty.v
 theories/iris_extra/persistence.v
 theories/iris_extra/proofmode_extra.v
+theories/iris_extra/pupd.v
+theories/iris_extra/proofmode_pupd.v
 theories/iris_extra/saved_interp_dep.v
 theories/iris_extra/saved_interp_n.v
 theories/iris_extra/swap_later_impl.v

--- a/changelog.md
+++ b/changelog.md
@@ -27,6 +27,11 @@ https://github.com/Blaisorblade/dot-iris/pulls?q=is%3Apr+is%3Amerged+label%3Amaj
   Typing rules are essentially unchanged; however, type equality is extended with
   some more congruence rules, to ensure it remains reflexive.
 
+- (Ongoing) Restore support for non-persistent resources:
+  - https://github.com/Blaisorblade/dot-iris/pull/426 introduces a "persistent
+    update" modality (`<PB> P` that is `□ |==> □ P`), that can replace `|==>` when
+    non-persistent resources are available, and intuitionistic propositions must
+    be marked explicitly via `□`, and uses it in DSub.
 # v1.0
 
 Release accompanying the ICFP'20 paper.

--- a/changelog.md
+++ b/changelog.md
@@ -5,16 +5,16 @@ https://github.com/Blaisorblade/dot-iris/pulls?q=is%3Apr+is%3Amerged+label%3Amaj
 
 # master (Not yet released)
 
-- Prepend basic update modality to all judgments:
-https://github.com/Blaisorblade/dot-iris/pull/303
+- Prepend basic update modality (`|==>`) to all Dot judgments:
+  https://github.com/Blaisorblade/dot-iris/pull/303
 
-This enables updating ghost state to establish typing judgments;
-in our setting, that means only extending ghost state, since we ensure all our
-judgments are persistent.
+  This enables updating ghost state to establish typing judgments;
+  in our setting, that means only extending ghost state, since we ensure all our
+  judgments are persistent.
 
 - Support for sound type projections, in the style of Scala 2:
-https://github.com/Blaisorblade/dot-iris/pull/250
-https://github.com/Blaisorblade/dot-iris/pull/304
+  https://github.com/Blaisorblade/dot-iris/pull/250
+  https://github.com/Blaisorblade/dot-iris/pull/304
 
 - (Preliminary) support for higher-kinded types in the semantics (too many PRs to count):
   in short, semantic kinds are modeled as predicates on semantic types, and type

--- a/tests/dune
+++ b/tests/dune
@@ -2,5 +2,6 @@
 (coq.theory
  (name D_tests)
  (theories D)
+ (flags (:standard -w -undo-batch-mode))
 )
 

--- a/tests/test_proofmode_pupd.ref
+++ b/tests/test_proofmode_pupd.ref
@@ -1,0 +1,4 @@
+The command has indeed failed with message:
+Tactic failure: iApply: cannot apply (P' -∗ Q')%I.
+The command has indeed failed with message:
+Tactic failure: iPoseProof: "W" not found.

--- a/tests/test_proofmode_pupd.v
+++ b/tests/test_proofmode_pupd.v
@@ -1,0 +1,252 @@
+From D.iris_extra Require Import proofmode_pupd.
+
+Implicit Type (Σ : gFunctors) (E : coPset).
+
+Section test.
+  Context {PROP : bi}.
+  Implicit Type (P Q R : PROP).
+
+  Section test_bupd.
+    Context `{!BiBUpd PROP}.
+
+    Lemma PB_sep_curry_alt P Q : <PB> P -∗ <PB> Q -∗ <PB> (P ∗ Q).
+    Proof.
+      iIntros "#P #Q".
+      iApply (PB_bind with "P"); iIntros "!> {P}#$".
+      iApply (PB_bind with "Q"); iIntros "!> {Q}#$".
+      by [].
+    Qed.
+
+    (* #[global] Instance elim_pers_modal_int_bupd_int `{BiBUpd PROP} P Q :
+      ElimPersModal (pbupd P) (pbupd Q) (□ P) (□ Q).
+    Proof.
+      rewrite /ElimPersModal.
+      iIntros "#W #P !>". iMod "P" as "#P". iIntros "!> !>".
+      iApply ("W" with "P").
+    Qed. *)
+
+    (* Lemma foo' `{BiPositive PROP} P Q :
+      pbupd (P ∗ Q) ⊢ pbupd P ∗ pbupd Q.
+    Proof.
+      iIntros "#PQ".
+      rewrite -intuitionistically_sep. iModIntro.
+      iDestruct "PQ" as "[P Q]".
+      iApply sep_bupd. iModIntro.
+      iMod "P" as "#P". iMod "Q" as "#Q". *)
+
+    (* Meant to strip modalities from all premises, unlike [elim_pers_modal_wand]; but too restrictive. *)
+    (* #[global] Instance elim_pers_modal_wand_all P P' R Q Q' :
+      ElimPersModal (□ P) (pbupd Q) (□ P') (pbupd Q') →
+      ElimPersModal (□ P) (pbupd R -∗ pbupd Q) (□ P') (□ R -∗ pbupd Q').
+    Proof.
+      rewrite /ElimPersModal.
+      iIntros (W) "#W #P #R !>". iMod "R" as "#R".
+      iApply (W with "[] P") => {W}.
+      iIntros "!> {P} #P".
+      iApply ("W" with "P R").
+    Qed. *)
+
+    Lemma test_1 P1 Q :
+      □(□ P1 -∗ □ Q) -∗
+      pbupd P1 -∗ pbupd Q.
+      (* ElimPersModal (pbupd P1) (pbupd P2 -∗ pbupd Q) (□ P1) (□ P2 -∗ □ Q) *)
+    Proof.
+      iIntros "#W".
+      iApply elim_pers_modal; iIntros "!> #P1 !>!>".
+      by iApply "W".
+      all: fail.
+    Restart.
+    Proof.
+      rewrite -elim_pers_modal.
+      iIntros "#W !> #P1 !>!>".
+      by iApply "W".
+    Qed.
+
+    Lemma test_2 P1 P2 Q :
+      □(□ P1 -∗ □ P2 -∗ □ Q) -∗
+      pbupd P1 -∗ pbupd P2 -∗ pbupd Q.
+      (* ElimPersModal (pbupd P1) (pbupd P2 -∗ pbupd Q) (□ P1) (□ P2 -∗ □ Q) *)
+    Proof.
+      iIntros "#W".
+      iApply elim_pers_modal.
+      iIntros "!> #P1 #P2 !>!>".
+      by iApply "W".
+    Restart.
+    Proof.
+      rewrite -elim_pers_modal.
+      iIntros "#W !> #P1 #P2 !>!>".
+      by iApply "W".
+    Qed.
+
+    Lemma test_3 P1 P2 P3 Q :
+      □(□ P1 -∗ □ P2 -∗ □ P3 -∗ □ Q) -∗
+      pbupd P1 -∗ pbupd P2 -∗ pbupd P3 -∗ pbupd Q.
+      (* ElimPersModal (pbupd P1) (pbupd P2 -∗ pbupd Q) (□ P1) (□ P2 -∗ □ Q) *)
+    Proof.
+      iIntros "#W".
+      iApply elim_pers_modal; iIntros "!> #P1 #P2 #P3 !>!>".
+      by iApply "W".
+    Restart.
+    Proof.
+      rewrite -elim_pers_modal.
+      iIntros "#W !> #P1 #P2 #P3 !>!>".
+      by iApply "W".
+    Qed.
+
+    Lemma test_2'' (P P' R Q Q' : PROP) `{!Persistent P', !Affine P'} :
+      ElimPersModal P Q P' Q' →
+      ElimPersModal P (R -∗ Q) P' (R -∗ Q').
+    Proof.
+      rewrite /ElimPersModal.
+      iIntros (W) "#W P R".
+      iApply (W with "[R] P").
+      rewrite wand_curry (comm _ P' R) -wand_curry.
+      iSpecialize ("W" with "R").
+      Fail iApply "W".
+    Abort.
+
+    Section test_alt_setup.
+      #[local] Remove Hints elim_pers_modal_wand_noelim elim_pers_modal_wand_elim : typeclass_instances.
+
+      (* Variant of [elim_modal_wand]. Meant to only strip modalities from one premise. *)
+      #[local] Instance elim_pers_modal_wand P P' R Q Q' `{!Persistent R, !Affine R} :
+        ElimPersModal P Q P' Q' →
+        ElimPersModal P (R -∗ Q) P' (R -∗ Q') | 100.
+      Proof.
+        rewrite /ElimPersModal.
+        iIntros (W) "#W P #R".
+        iApply (W with "[] P").
+        rewrite wand_curry (comm _ P' R) -wand_curry.
+        iApply ("W" with "R").
+      Qed.
+
+      Lemma test_2_alt (P1 P2 Q : PROP) :
+        □(□ P1 -∗ □ P2 -∗ □ Q) -∗
+        pbupd P1 -∗ pbupd P2 -∗ pbupd Q.
+        (* ElimPersModal (pbupd P1) (pbupd P2 -∗ pbupd Q) (□ P1) (□ P2 -∗ □ Q) *)
+      Proof.
+        iIntros "#W".
+        iApply elim_pers_modal; iIntros "!> #P1".
+        iApply elim_pers_modal; iIntros "!> #P2".
+        iIntros "!> !>".
+        by iApply "W".
+      Restart.
+      Proof.
+        iIntros "#W #P1".
+        iApply (@elim_pers_modal _ (pbupd P2) (pbupd Q)).
+        iIntros "!> #P2 !>".
+        iMod "P1".
+        iApply ("W" with "P1 P2").
+      Restart.
+      Proof.
+        (* apply /elim_pers_modal_wand.
+        rewrite /ElimPersModal. *)
+        iIntros "#W #P1 #P2 !>".
+        iMod "P1" as "#P1".
+        iMod "P2" as "#P2".
+        iIntros "!> !>".
+        iApply ("W" with "P1 P2").
+      Qed.
+    End test_alt_setup.
+
+    Section misc_tests.
+      Context {Σ}.
+
+      Instance foo1 (p : bool) P Q : ElimModal True p false (□ |==> P) P (|==> Q) (|==> Q).
+      Proof.
+        rewrite /ElimModal/= intuitionistically_if_elim.
+        iIntros (_) "[#>A W]".
+        iApply ("W" with "A").
+      Qed.
+
+    (*
+      Instance foo2 (P Q : iProp Σ) : ElimModal True false false (□ |==> P) P (□ |==> Q) (□ |==> Q).
+      Proof.
+        rewrite /ElimModal/=.
+        iIntros (_) "[#A W]".
+        iApply ("W" with "[-]").
+      Qed. *)
+
+      Instance foo3 (P Q : iProp Σ) : ElimModal True false false (pbupd P) P (pbupd Q) (pbupd Q).
+      Proof.
+        rewrite /ElimModal/=.
+        iIntros (_) "[#A W] !>".
+        Fail iApply ("W" with "[-]").
+      Abort.
+
+      (*
+      Instance foo2 (P Q : iProp Σ) : ElimModal True false false (□ |==> □ P) P (□ |==> □ Q) (□ |==> □ Q).
+      Proof.
+        rewrite /ElimModal/=.
+        iIntros (_) "[#A W]".
+        iApply ("W" with "[-]").
+      Qed. *)
+
+    End misc_tests.
+  End test_bupd.
+
+  Section test_fupd.
+    Context `{!BiFUpd PROP} E.
+
+    Lemma test_fupd P Q :
+      □(□ P -∗ □ Q) -∗
+      pfupd E P -∗ pfupd E Q.
+    Proof.
+      iIntros "#W #P !>". iMod "P" as "#P". iIntros "!> !>".
+      iApply ("W" with "P").
+    Qed.
+
+    (* Lemma foo' `{BiPositive PROP} P Q :
+      pfupd E (P ∗ Q) ⊢ pfupd E P ∗ pfupd E Q.
+    Proof.
+      iIntros "#PQ".
+      rewrite -intuitionistically_sep. iModIntro.
+      iDestruct "PQ" as "[P Q]".
+      iApply sep_fupd. iModIntro.
+      iMod "P" as "#P". iMod "Q" as "#Q". *)
+
+    Lemma fupd_test_1 P1 Q :
+      □(□ P1 -∗ □ Q) -∗
+      pfupd E P1 -∗ pfupd E Q.
+    Proof.
+      iIntros "#W".
+      iApply elim_pers_modal; iIntros "!> #P1 !>!>".
+      by iApply "W".
+      all: fail.
+    Restart.
+    Proof.
+      rewrite -elim_pers_modal.
+      iIntros "#W !> #P1 !>!>".
+      by iApply "W".
+    Qed.
+
+    Lemma fupd_test_2 P1 P2 Q :
+      □(□ P1 -∗ □ P2 -∗ □ Q) -∗
+      pfupd E P1 -∗ pfupd E P2 -∗ pfupd E Q.
+    Proof.
+      iIntros "#W".
+      iApply elim_pers_modal.
+      iIntros "!> #P1 #P2 !>!>".
+      by iApply "W".
+    Restart.
+    Proof.
+      rewrite -elim_pers_modal.
+      iIntros "#W !> #P1 #P2 !>!>".
+      by iApply "W".
+    Qed.
+
+    Lemma fupd_test_3 P1 P2 P3 Q :
+      □(□ P1 -∗ □ P2 -∗ □ P3 -∗ □ Q) -∗
+      pfupd E P1 -∗ pfupd E P2 -∗ pfupd E P3 -∗ pfupd E Q.
+    Proof.
+      iIntros "#W".
+      iApply elim_pers_modal; iIntros "!> #P1 #P2 #P3 !>!>".
+      by iApply "W".
+    Restart.
+    Proof.
+      rewrite -elim_pers_modal.
+      iIntros "#W !> #P1 #P2 #P3 !>!>".
+      by iApply "W".
+    Qed.
+  End test_fupd.
+End test.

--- a/tests/test_proofmode_pupd.v
+++ b/tests/test_proofmode_pupd.v
@@ -2,6 +2,10 @@ From D.iris_extra Require Import proofmode_pupd.
 
 Implicit Type (Σ : gFunctors) (E : coPset).
 
+Ltac pupd :=
+  iApply elim_pers_modal; iModIntro (□ _)%I;
+  iApply (strip_pupd with "[-]").
+
 Section test.
   Context {PROP : bi}.
   Implicit Type (P Q R : PROP).
@@ -52,9 +56,9 @@ Section test.
       (* ElimPersModal (pbupd P1) (pbupd P2 -∗ pbupd Q) (□ P1) (□ P2 -∗ □ Q) *)
     Proof.
       iIntros "#W".
-      iApply elim_pers_modal; iIntros "!> #P1 !>!>".
+      pupd.
+      iIntros "#P1".
       by iApply "W".
-      all: fail.
     Restart.
     Proof.
       rewrite -elim_pers_modal.
@@ -68,9 +72,13 @@ Section test.
       (* ElimPersModal (pbupd P1) (pbupd P2 -∗ pbupd Q) (□ P1) (□ P2 -∗ □ Q) *)
     Proof.
       iIntros "#W".
-      iApply elim_pers_modal.
-      iIntros "!> #P1 #P2 !>!>".
+      pupd.
+      iIntros "#P1 #P2".
       by iApply "W".
+    Restart.
+      iIntros "#W".
+      pupd.
+      solve [iApply "W"].
     Restart.
     Proof.
       rewrite -elim_pers_modal.
@@ -84,7 +92,8 @@ Section test.
       (* ElimPersModal (pbupd P1) (pbupd P2 -∗ pbupd Q) (□ P1) (□ P2 -∗ □ Q) *)
     Proof.
       iIntros "#W".
-      iApply elim_pers_modal; iIntros "!> #P1 #P2 #P3 !>!>".
+      pupd.
+      iIntros "#P1 #P2 #P3".
       by iApply "W".
     Restart.
     Proof.
@@ -210,9 +219,14 @@ Section test.
       pfupd E P1 -∗ pfupd E Q.
     Proof.
       iIntros "#W".
-      iApply elim_pers_modal; iIntros "!> #P1 !>!>".
+      pupd.
+      iIntros "#P1".
       by iApply "W".
-      all: fail.
+    Restart.
+    Proof.
+      iIntros "#W".
+      pupd.
+      solve [iApply "W"].
     Restart.
     Proof.
       rewrite -elim_pers_modal.
@@ -225,8 +239,8 @@ Section test.
       pfupd E P1 -∗ pfupd E P2 -∗ pfupd E Q.
     Proof.
       iIntros "#W".
-      iApply elim_pers_modal.
-      iIntros "!> #P1 #P2 !>!>".
+      pupd.
+      iIntros "#P1 #P2".
       by iApply "W".
     Restart.
     Proof.
@@ -240,7 +254,8 @@ Section test.
       pfupd E P1 -∗ pfupd E P2 -∗ pfupd E P3 -∗ pfupd E Q.
     Proof.
       iIntros "#W".
-      iApply elim_pers_modal; iIntros "!> #P1 #P2 #P3 !>!>".
+      pupd.
+      iIntros "#P1 #P2 #P3".
       by iApply "W".
     Restart.
     Proof.

--- a/theories/DSub/fundamental.v
+++ b/theories/DSub/fundamental.v
@@ -23,18 +23,18 @@ Section swap_based_typing_lemmas.
     Γ ⊨ TAll T1 U1, i <: TAll T2 U2, i .
   Proof.
     rewrite iterate_S /=.
-    iIntros "#HsubT #HsubU /= %ρ %v #Hg".
+    iIntros "#HsubT #HsubU !> /= %ρ %v #Hg".
     unfold_interp.
     iDestruct 1 as (t) "#[Heq #HT1]". iExists t; iSplit => //.
     iIntros (w).
     iSpecialize ("HsubT" $! ρ w with "Hg").
-    rewrite -mlater_impl -mlaterN_impl !swap_later.
-    iIntros "#HwT2".
+    rewrite -!mlaterN_pers -mlater_impl -mlaterN_impl !swap_later.
+    iIntros "!> #HwT2".
     iSpecialize ("HsubT" with "HwT2").
-    iAssert (▷ ▷^i (∀ v0, ⟦ U1 ⟧ (w .: ρ) v0 →
+    iAssert (□▷ ▷^i (∀ v0, ⟦ U1 ⟧ (w .: ρ) v0 →
         ⟦ U2 ⟧ (w .: ρ) v0))%I as "{HsubU} #HsubU". {
       iIntros (v0); rewrite -!mlaterN_impl -mlater_impl.
-      iIntros "#HUv0".
+      iIntros "!> #HUv0".
       iApply ("HsubU" $! (w .: ρ) v0 with "[# $Hg] HUv0").
       unfold_interp; rewrite iterate_TLater_later.
       by iApply (interp_weaken_one T2).
@@ -50,12 +50,12 @@ Section swap_based_typing_lemmas.
     Γ ⊨[i] TAll T1 U1 <: TAll T2 U2.
   Proof.
     rewrite iterate_S /=.
-    iIntros "#HsubT #HsubU /= %ρ #Hg %v".
+    iIntros "#HsubT #HsubU !> /= %ρ #Hg %v".
     rewrite -mlaterN_impl; unfold_interp.
     iDestruct 1 as (t) "#[Heq #HT1]"; iExists t; iFrame "Heq".
     iIntros (w).
-    rewrite -!laterN_later/= -!mlaterN_impl -!mlater_impl.
-    iIntros "#HwT2".
+    rewrite -!mlaterN_pers -!laterN_later/= -!mlaterN_impl -!mlater_impl.
+    iIntros "!> #HwT2".
     iSpecialize ("HsubT" with "Hg").
     iSpecialize ("HsubU" $! (w .: ρ) with "[# $Hg]"). {
       unfold_interp. rewrite iterate_TLater_later.
@@ -71,7 +71,7 @@ Section swap_based_typing_lemmas.
     Γ ⊨ U1, i <: U2, i -∗
     Γ ⊨ TTMem L1 U1, i <: TTMem L2 U2, i.
   Proof.
-    iIntros "#IHT #IHT1 /= %ρ %v #Hg".
+    iIntros "#IHT #IHT1 !> /= %ρ %v #Hg".
     unfold_interp.
     iDestruct 1 as (φ) "#[Hφl [HLφ #HφU]]".
     setoid_rewrite mlaterN_impl.
@@ -79,7 +79,7 @@ Section swap_based_typing_lemmas.
       iIntros "" (w);
       iSpecialize ("IHT" $! ρ w with "Hg");
       iSpecialize ("IHT1" $! ρ w with "Hg");
-      iNext; iIntros.
+      iNext; iIntros "!> **".
     - iApply "HLφ" => //. by iApply "IHT".
     - iApply "IHT1". by iApply "HφU".
   Qed.
@@ -99,7 +99,7 @@ Section Fundamental.
     - iInduction HT as [] "IHT".
       + by iApply Sub_Refl.
       + by iApply Sub_Trans.
-      + by iIntros "/= **".
+      + by iIntros "/= !> **".
       + by iApply Sub_Index_Incr.
       + by iApply Later_Sub.
       + by iApply Sub_Later.

--- a/theories/DSub/fundamental.v
+++ b/theories/DSub/fundamental.v
@@ -132,7 +132,7 @@ Proof.
   rewrite /safe; intros Htyp ?*.
   cut (adequate e (λ _, True)); first by intros [_ ?]; eauto.
   eapply (wp_adequacy (Σ := Σ) e) => /=.
-  iIntros "!>". iPoseProof (Htyp _ _) as "#Htyp".
+  iIntros "!>". iPoseProof (Htyp _ _) as "#>Htyp".
   iSpecialize ("Htyp" $! ids with "[//]"); rewrite hsubst_id /=.
   iApply (wp_wand with "Htyp"); by iIntros.
 Qed.

--- a/theories/DSub/fundamental.v
+++ b/theories/DSub/fundamental.v
@@ -23,7 +23,7 @@ Section swap_based_typing_lemmas.
     Γ ⊨ TAll T1 U1, i <: TAll T2 U2, i .
   Proof.
     rewrite iterate_S /=.
-    iIntros "#HsubT #HsubU !> /= %ρ %v #Hg".
+    pupd; iIntros "#HsubT #HsubU !> /= %ρ %v #Hg".
     unfold_interp.
     iDestruct 1 as (t) "#[Heq #HT1]". iExists t; iSplit => //.
     iIntros (w).
@@ -50,7 +50,7 @@ Section swap_based_typing_lemmas.
     Γ ⊨[i] TAll T1 U1 <: TAll T2 U2.
   Proof.
     rewrite iterate_S /=.
-    iIntros "#HsubT #HsubU !> /= %ρ #Hg %v".
+    pupd; iIntros "#HsubT #HsubU !> /= %ρ #Hg %v".
     rewrite -mlaterN_impl; unfold_interp.
     iDestruct 1 as (t) "#[Heq #HT1]"; iExists t; iFrame "Heq".
     iIntros (w).
@@ -71,7 +71,7 @@ Section swap_based_typing_lemmas.
     Γ ⊨ U1, i <: U2, i -∗
     Γ ⊨ TTMem L1 U1, i <: TTMem L2 U2, i.
   Proof.
-    iIntros "#IHT #IHT1 !> /= %ρ %v #Hg".
+    pupd; iIntros "#IHT #IHT1 !> /= %ρ %v #Hg".
     unfold_interp.
     iDestruct 1 as (φ) "#[Hφl [HLφ #HφU]]".
     setoid_rewrite mlaterN_impl.
@@ -99,7 +99,7 @@ Section Fundamental.
     - iInduction HT as [] "IHT".
       + by iApply Sub_Refl.
       + by iApply Sub_Trans.
-      + by iIntros "/= !> **".
+      + by pupd; iIntros "/= !> **".
       + by iApply Sub_Index_Incr.
       + by iApply Later_Sub.
       + by iApply Sub_Later.

--- a/theories/DSub/lr/semtyp_lemmas.v
+++ b/theories/DSub/lr/semtyp_lemmas.v
@@ -25,7 +25,7 @@ Section Sec.
     (*──────────────────────*)
     ⊢ Γ ⊨ tv (vvar x) : shiftN x T.
   Proof.
-    iIntros (Hx) "/= * #Hg".
+    iIntros (Hx) "/= !> * #Hg".
     by rewrite -wp_value' interp_env_lookup.
   Qed.
 
@@ -35,7 +35,7 @@ Section Sec.
     (*────────────────────────────────────────────────────────────*)
     Γ ⊨ tapp e1 e2 : T2.
   Proof.
-    iIntros "/= #He1 #Hv2" (vs) "#HG".
+    iIntros "/= #He1 #Hv2 !>" (vs) "#HG".
     smart_wp_bind (AppLCtx _) v "#Hr" "He1".
     smart_wp_bind (AppRCtx v) w "#Hw" "Hv2".
     unfold_interp. iDestruct "Hr" as (t ->) "#Hv".
@@ -49,7 +49,7 @@ Section Sec.
     (*────────────────────────────────────────────────────────────*)
     Γ ⊨ tapp e1 (tv v2) : T2.|[v2/].
   Proof.
-    iIntros "/= #He1 #Hv2Arg" (vs) "#HG".
+    iIntros "/= #He1 #Hv2Arg !>" (vs) "#HG".
     smart_wp_bind (AppLCtx _) v "#Hr" "He1".
     unfold_interp. iDestruct "Hr" as (t ->) "#HvFun".
     rewrite -wp_pure_step_later; last done. iNext.
@@ -64,9 +64,9 @@ Section Sec.
     (*─────────────────────────*)
     Γ ⊨ tv (vabs e) : TAll T1 T2.
   Proof.
-    iIntros "/= #HeT" (vs) "#HG".
+    iIntros "/= #HeT !>" (vs) "#HG".
     rewrite -wp_value'; unfold_interp. iExists _; iSplit; first done.
-    iNext; iIntros (v) "#Hv"; rewrite up_sub_compose.
+    iIntros "!> !>" (v) "#Hv"; rewrite up_sub_compose.
     iApply ("HeT" $! (v .: vs) with "[$HG]").
     by rewrite (interp_weaken_one T1 _ v).
   Qed.
@@ -77,7 +77,7 @@ Section Sec.
     (*───────────────────────────────*)
     Γ ⊨ iterate tskip i e : T2.
   Proof.
-    iIntros "/= * #HeT1 #Hsub" (vs) "#Hg".
+    iIntros "/= * #HeT1 #Hsub !>" (vs) "#Hg".
     rewrite tskip_subst -wp_bind.
     iApply (wp_wand with "(HeT1 Hg)").
     iIntros (v) "#HvT1".
@@ -92,7 +92,7 @@ Section Sec.
     (*───────────────────────────────*)
     Γ ⊨ iterate tskip i e : T2.
   Proof.
-    iIntros "/= * #HeT1 #Hsub". iIntros (vs) "#Hg".
+    iIntros "/= * #HeT1 #Hsub !>" (vs) "#Hg".
     rewrite tskip_subst tskip_n_to_fill -wp_bind.
     iApply (wp_wand with "(HeT1 Hg)").
     iIntros (v) "#HvT1".
@@ -108,11 +108,11 @@ Section Sec.
     Γ ⊨ L, 0 <: T, 1 -∗
     Γ ⊨ tv (vty T) : TTMem L U.
   Proof.
-    iIntros "#HTU #HLT /=" (vs) "#HG".
+    iIntros "#HTU #HLT /= !>" (vs) "#HG".
     rewrite -wp_value; unfold_interp.
     iExists _; iSplit. by iExists _.
-    iSplit; iIntros (v) "#H"; rewrite -interp_subst_ids.
-    - by iApply "HLT".
+    iModIntro; iSplit; iIntros (v) "#H"; rewrite -interp_subst_ids.
+    - iIntros "!>". by iApply "HLT".
     - by iApply "HTU".
   Qed.
 
@@ -121,10 +121,10 @@ Section Sec.
     Γ ⊨[0] L <: TLater T -∗
     Γ ⊨ tv (vty T) : TTMem L U.
   Proof.
-    iIntros "#HTU #HLT /= %ρ #HG".
+    iIntros "#HTU #HLT !> /= %ρ #HG".
     rewrite -wp_value; unfold_interp.
     iExists _; iSplit. by iExists _.
-    iSplit; iIntros (v) "#H"; rewrite -interp_subst_ids.
+    iModIntro; iSplit; iIntros (v) "#H"; rewrite -interp_subst_ids.
     - iSpecialize ("HLT" with "HG H"). unfold_interp. iApply "HLT".
     - iApply ("HTU" with "HG"). unfold_interp. iApply "H".
   Qed.
@@ -133,7 +133,7 @@ Section Sec.
     Γ ⊨ tv va : TTMem L U, i -∗
     Γ ⊨ L, i <: TSel va, i.
   Proof.
-    iIntros "/= #Hva" (vs v) "#Hg #HvL".
+    iIntros "/= #Hva !>" (vs v) "#Hg #HvL".
     iSpecialize ("Hva" with "Hg"). iNext i.
     rewrite wp_value_inv'; unfold_interp.
     iDestruct "Hva" as (φ) "#[H1 #[HLφ HφU]]".
@@ -145,7 +145,7 @@ Section Sec.
     Γ ⊨ tv va : TTMem L U, i -∗
     Γ ⊨[i] L <: TSel va.
   Proof.
-    iIntros "/= #Hva" (vs) "#Hg".
+    iIntros "/= #Hva !>" (vs) "#Hg".
     iSpecialize ("Hva" with "Hg"). iNext.
     iIntros (v) "#HvL".
     rewrite wp_value_inv'; unfold_interp.
@@ -158,7 +158,7 @@ Section Sec.
     Γ ⊨ tv va : TTMem L U, i -∗
     Γ ⊨ TSel va, i <: U, i.
   Proof.
-    iIntros "/= #Hva" (vs v) "#Hg #Hφ".
+    iIntros "/= #Hva !>" (vs v) "#Hg #Hφ".
     iSpecialize ("Hva" with "Hg").
     rewrite wp_value_inv'; unfold_interp.
     iDestruct "Hva" as (φ) "#[HT0 #[HLφ HφU]]".
@@ -166,59 +166,59 @@ Section Sec.
     iDestruct "Hφ" as (φ1) "[HT1 #Hφ1v]".
     (* To conclude, show that both types fetched from va coincide - but later! *)
     iPoseProof (vl_has_semtype_agree with "HT0 HT1") as "Hag".
-    iNext i. iNext. by iRewrite ("Hag" $! v).
+    iNext i. iModIntro. iNext. by iRewrite ("Hag" $! v).
   Qed.
 
   Lemma T_Nat_I n :
     ⊢ Γ ⊨ tv (vint n) : TInt.
   Proof.
-    iIntros "/= %ρ _". rewrite -wp_value; unfold_interp. by iExists n.
+    iIntros "/= !> %ρ _". rewrite -wp_value; unfold_interp. by iExists n.
   Qed.
 
   Lemma Sub_Index_Incr T U i j :
     Γ ⊨ T, i <: U, j -∗
     Γ ⊨ T, S i <: U, S j.
-  Proof. iIntros "/= #Hsub ** !>". by iApply "Hsub". Qed.
+  Proof. iIntros "/= #Hsub !> ** !>". by iApply "Hsub". Qed.
 
   Lemma DTyp_Sub_Typ L1 L2 U1 U2 i :
     Γ ⊨[i] L2 <: L1 -∗
     Γ ⊨[i] U1 <: U2 -∗
     Γ ⊨[i] TTMem L1 U1 <: TTMem L2 U2.
   Proof.
-    iIntros "#HsubL #HsubU /= %ρ #Hg %v".
+    iIntros "#HsubL #HsubU !> /= %ρ #Hg %v".
     iSpecialize ("HsubL" with "Hg"); iSpecialize ("HsubU" with "Hg").
     unfold_interp. iNext.
     iDestruct 1 as (φ) "#[Hφl [#HLφ #HφU]]".
     iExists φ; repeat iSplitL; first done;
-      iIntros (w) "#Hw".
+      iIntros "!> %w #Hw".
     - iApply "HLφ". by iApply "HsubL".
     - iApply "HsubU". by iApply "HφU".
   Qed.
 
   Lemma Sub_Top T i :
     ⊢ Γ ⊨ T, i <: TTop, i.
-  Proof. by iIntros "/= **"; unfold_interp. Qed.
+  Proof. by iIntros "!> /= **"; unfold_interp. Qed.
 
   Lemma DSub_Top T i :
     ⊢ Γ ⊨[i] T <: TTop.
   Proof.
-    iIntros "/= ** !> **". by unfold_interp.
+    iIntros "!> /= ** !> **". by unfold_interp.
   Qed.
 
   Lemma Bot_Sub T i :
     ⊢ Γ ⊨ TBot, i <: T, i.
-  Proof. by iIntros "/= ** !>"; unfold_interp. Qed.
+  Proof. by iIntros "!> /= ** !>"; unfold_interp. Qed.
 
   Lemma DBot_Sub T i :
     ⊢ Γ ⊨[i] TBot <: T.
-  Proof. by iIntros "/= ** !> **"; unfold_interp. Qed.
+  Proof. by iIntros "!> /= ** !> **"; unfold_interp. Qed.
 
   Lemma Later_Sub T i :
     ⊢ Γ ⊨ TLater T, i <: T, S i.
-  Proof. by iIntros "/= **"; unfold_interp; iNext. Qed.
+  Proof. by iIntros "!> /= **"; unfold_interp; iNext. Qed.
 
   Lemma Sub_Later T i :
     ⊢ Γ ⊨ T, S i <: TLater T, i.
-  Proof. by iIntros "/= ** !>"; unfold_interp. Qed.
+  Proof. by iIntros "!> /= ** !>"; unfold_interp. Qed.
 
 End Sec.

--- a/theories/DSub/lr/semtyp_lemmas.v
+++ b/theories/DSub/lr/semtyp_lemmas.v
@@ -25,7 +25,7 @@ Section Sec.
     (*──────────────────────*)
     ⊢ Γ ⊨ tv (vvar x) : shiftN x T.
   Proof.
-    iIntros (Hx) "/= !> * #Hg".
+    intros Hx. pupd; iIntros "/= !> * #Hg".
     by rewrite -wp_value' interp_env_lookup.
   Qed.
 
@@ -35,7 +35,7 @@ Section Sec.
     (*────────────────────────────────────────────────────────────*)
     Γ ⊨ tapp e1 e2 : T2.
   Proof.
-    iIntros "/= #He1 #Hv2 !>" (vs) "#HG".
+    pupd; iIntros "/= #He1 #Hv2 !>" (vs) "#HG".
     smart_wp_bind (AppLCtx _) v "#Hr" "He1".
     smart_wp_bind (AppRCtx v) w "#Hw" "Hv2".
     unfold_interp. iDestruct "Hr" as (t ->) "#Hv".
@@ -49,7 +49,7 @@ Section Sec.
     (*────────────────────────────────────────────────────────────*)
     Γ ⊨ tapp e1 (tv v2) : T2.|[v2/].
   Proof.
-    iIntros "/= #He1 #Hv2Arg !>" (vs) "#HG".
+    pupd; iIntros "/= #He1 #Hv2Arg !>" (vs) "#HG".
     smart_wp_bind (AppLCtx _) v "#Hr" "He1".
     unfold_interp. iDestruct "Hr" as (t ->) "#HvFun".
     rewrite -wp_pure_step_later; last done. iNext.
@@ -64,7 +64,7 @@ Section Sec.
     (*─────────────────────────*)
     Γ ⊨ tv (vabs e) : TAll T1 T2.
   Proof.
-    iIntros "/= #HeT !>" (vs) "#HG".
+    pupd; iIntros "/= #HeT !>" (vs) "#HG".
     rewrite -wp_value'; unfold_interp. iExists _; iSplit; first done.
     iIntros "!> !>" (v) "#Hv"; rewrite up_sub_compose.
     iApply ("HeT" $! (v .: vs) with "[$HG]").
@@ -77,7 +77,7 @@ Section Sec.
     (*───────────────────────────────*)
     Γ ⊨ iterate tskip i e : T2.
   Proof.
-    iIntros "/= * #HeT1 #Hsub !>" (vs) "#Hg".
+    pupd; iIntros "/= * #HeT1 #Hsub !>" (vs) "#Hg".
     rewrite tskip_subst -wp_bind.
     iApply (wp_wand with "(HeT1 Hg)").
     iIntros (v) "#HvT1".
@@ -92,7 +92,7 @@ Section Sec.
     (*───────────────────────────────*)
     Γ ⊨ iterate tskip i e : T2.
   Proof.
-    iIntros "/= * #HeT1 #Hsub !>" (vs) "#Hg".
+    pupd; iIntros "/= * #HeT1 #Hsub !>" (vs) "#Hg".
     rewrite tskip_subst tskip_n_to_fill -wp_bind.
     iApply (wp_wand with "(HeT1 Hg)").
     iIntros (v) "#HvT1".
@@ -108,7 +108,7 @@ Section Sec.
     Γ ⊨ L, 0 <: T, 1 -∗
     Γ ⊨ tv (vty T) : TTMem L U.
   Proof.
-    iIntros "#HTU #HLT /= !>" (vs) "#HG".
+    pupd; iIntros "#HTU #HLT /= !>" (vs) "#HG".
     rewrite -wp_value; unfold_interp.
     iExists _; iSplit. by iExists _.
     iModIntro; iSplit; iIntros (v) "#H"; rewrite -interp_subst_ids.
@@ -121,7 +121,7 @@ Section Sec.
     Γ ⊨[0] L <: TLater T -∗
     Γ ⊨ tv (vty T) : TTMem L U.
   Proof.
-    iIntros "#HTU #HLT !> /= %ρ #HG".
+    pupd; iIntros "#HTU #HLT !> /= %ρ #HG".
     rewrite -wp_value; unfold_interp.
     iExists _; iSplit. by iExists _.
     iModIntro; iSplit; iIntros (v) "#H"; rewrite -interp_subst_ids.
@@ -133,7 +133,7 @@ Section Sec.
     Γ ⊨ tv va : TTMem L U, i -∗
     Γ ⊨ L, i <: TSel va, i.
   Proof.
-    iIntros "/= #Hva !>" (vs v) "#Hg #HvL".
+    pupd; iIntros "/= #Hva !>" (vs v) "#Hg #HvL".
     iSpecialize ("Hva" with "Hg"). iNext i.
     rewrite wp_value_inv'; unfold_interp.
     iDestruct "Hva" as (φ) "#[H1 #[HLφ HφU]]".
@@ -145,7 +145,7 @@ Section Sec.
     Γ ⊨ tv va : TTMem L U, i -∗
     Γ ⊨[i] L <: TSel va.
   Proof.
-    iIntros "/= #Hva !>" (vs) "#Hg".
+    pupd; iIntros "/= #Hva !>" (vs) "#Hg".
     iSpecialize ("Hva" with "Hg"). iNext.
     iIntros (v) "#HvL".
     rewrite wp_value_inv'; unfold_interp.
@@ -158,7 +158,7 @@ Section Sec.
     Γ ⊨ tv va : TTMem L U, i -∗
     Γ ⊨ TSel va, i <: U, i.
   Proof.
-    iIntros "/= #Hva !>" (vs v) "#Hg #Hφ".
+    pupd; iIntros "/= #Hva !>" (vs v) "#Hg #Hφ".
     iSpecialize ("Hva" with "Hg").
     rewrite wp_value_inv'; unfold_interp.
     iDestruct "Hva" as (φ) "#[HT0 #[HLφ HφU]]".
@@ -172,20 +172,20 @@ Section Sec.
   Lemma T_Nat_I n :
     ⊢ Γ ⊨ tv (vint n) : TInt.
   Proof.
-    iIntros "/= !> %ρ _". rewrite -wp_value; unfold_interp. by iExists n.
+    pupd; iIntros "/= !> %ρ _". rewrite -wp_value; unfold_interp. by iExists n.
   Qed.
 
   Lemma Sub_Index_Incr T U i j :
     Γ ⊨ T, i <: U, j -∗
     Γ ⊨ T, S i <: U, S j.
-  Proof. iIntros "/= #Hsub !> ** !>". by iApply "Hsub". Qed.
+  Proof. pupd; iIntros "/= #Hsub !> ** !>". by iApply "Hsub". Qed.
 
   Lemma DTyp_Sub_Typ L1 L2 U1 U2 i :
     Γ ⊨[i] L2 <: L1 -∗
     Γ ⊨[i] U1 <: U2 -∗
     Γ ⊨[i] TTMem L1 U1 <: TTMem L2 U2.
   Proof.
-    iIntros "#HsubL #HsubU !> /= %ρ #Hg %v".
+    pupd; iIntros "#HsubL #HsubU !> /= %ρ #Hg %v".
     iSpecialize ("HsubL" with "Hg"); iSpecialize ("HsubU" with "Hg").
     unfold_interp. iNext.
     iDestruct 1 as (φ) "#[Hφl [#HLφ #HφU]]".
@@ -197,28 +197,28 @@ Section Sec.
 
   Lemma Sub_Top T i :
     ⊢ Γ ⊨ T, i <: TTop, i.
-  Proof. by iIntros "!> /= **"; unfold_interp. Qed.
+  Proof. by pupd; iIntros "!> /= **"; unfold_interp. Qed.
 
   Lemma DSub_Top T i :
     ⊢ Γ ⊨[i] T <: TTop.
   Proof.
-    iIntros "!> /= ** !> **". by unfold_interp.
+    pupd; iIntros "!> /= ** !> **". by unfold_interp.
   Qed.
 
   Lemma Bot_Sub T i :
     ⊢ Γ ⊨ TBot, i <: T, i.
-  Proof. by iIntros "!> /= ** !>"; unfold_interp. Qed.
+  Proof. by pupd; iIntros "!> /= ** !>"; unfold_interp. Qed.
 
   Lemma DBot_Sub T i :
     ⊢ Γ ⊨[i] TBot <: T.
-  Proof. by iIntros "!> /= ** !> **"; unfold_interp. Qed.
+  Proof. by pupd; iIntros "!> /= ** !> **"; unfold_interp. Qed.
 
   Lemma Later_Sub T i :
     ⊢ Γ ⊨ TLater T, i <: T, S i.
-  Proof. by iIntros "!> /= **"; unfold_interp; iNext. Qed.
+  Proof. by pupd; iIntros "!> /= **"; unfold_interp; iNext. Qed.
 
   Lemma Sub_Later T i :
     ⊢ Γ ⊨ T, S i <: TLater T, i.
-  Proof. by iIntros "!> /= ** !>"; unfold_interp. Qed.
+  Proof. by pupd; iIntros "!> /= ** !>"; unfold_interp. Qed.
 
 End Sec.

--- a/theories/DSub/lr/unary_lr.v
+++ b/theories/DSub/lr/unary_lr.v
@@ -29,9 +29,7 @@ Implicit Types
  *)
 
 (* The only point of these instances is to select Σ uniquely. *)
-Class dsubSynG (Σ : gFunctors) := DsubSynG {
-   dsubSynG_persistent :> CmraPersistent (iResUR Σ);
-}.
+Class dsubSynG (Σ : gFunctors) := DsubSynG {}.
 
 From D.DSub Require Export rules.
 #[global] Instance dsubsynG_irisG `{!dsubSynG Σ} : irisGS dlang_lang Σ := {

--- a/theories/DSub/lr/unary_lr.v
+++ b/theories/DSub/lr/unary_lr.v
@@ -89,7 +89,7 @@ Section logrel.
   Definition interp_forall : envD Σ -> envD Σ -> envD Σ :=
     λI interp1 interp2 ρ v,
     ∃ t, ⌜ v = vabs t ⌝ ∧
-      ▷ ∀ w, interp1 ρ w → interp_expr interp2 (w .: ρ) t.|[w/].
+      □ ▷ ∀ w, interp1 ρ w → interp_expr interp2 (w .: ρ) t.|[w/].
   #[global] Arguments interp_forall /.
   #[local] Instance interp_forall_contractive n :
     Proper (dist_later n ==> dist_later n ==> dist n) interp_forall.
@@ -112,8 +112,8 @@ Section logrel.
     (ty -d> envD Σ) -> envD Σ -> envD Σ -> envD Σ :=
     λI rinterp interpL interpU ρ v,
     ∃ φ, v ↗[ rinterp ] φ ∧
-       ((∀ v, interpL ρ v → ▷ φ v) ∧
-          (∀ v, ▷ φ v → interpU ρ v)).
+       □ ((∀ v, interpL ρ v → □ ▷ φ v) ∧
+          (∀ v, □ ▷ φ v → interpU ρ v)).
   #[global] Arguments interp_tmem /.
   #[local] Instance interp_tmem_contractive n :
     Proper (dist_later n ==> dist n ==> dist n ==> dist n) interp_tmem.
@@ -121,7 +121,7 @@ Section logrel.
 
   Definition interp_sel : (ty -d> envD Σ) -d> vl -d> envD Σ :=
     λI rinterp w ρ v,
-    ∃ ϕ, w.[ρ] ↗[rinterp] ϕ ∧ ▷ ϕ v.
+    ∃ ϕ, w.[ρ] ↗[rinterp] ϕ ∧ □ ▷ ϕ v.
   #[global] Arguments interp_sel /.
   #[local] Instance interp_sel_contractive n :
     Proper (dist_later n ==> eq ==> dist n) interp_sel.
@@ -219,6 +219,10 @@ Section logrel_part2.
       properness; rewrite /= ?scons_up_swap ?subst_comp; trivial.
   Qed.
 
+  #[global] Instance interp_persistent T ρ v :
+    Persistent (⟦ T ⟧ ρ v).
+  Proof. move: v ρ; induction T => w ρ; unfold_interp; try apply _. Qed.
+
   (* XXX here we needn't add a variable to the scope of its own type. But that won't hurt. *)
   Fixpoint interp_env (Γ : ctx) (ρ : var → vl) : iProp Σ :=
     match Γ with
@@ -228,25 +232,33 @@ Section logrel_part2.
 
   Notation "G⟦ Γ ⟧" := (interp_env Γ).
 
+  #[global] Instance interp_env_persistent Γ ρ :
+    Persistent (G⟦ Γ ⟧ ρ).
+  Proof. elim: Γ ρ => [|τ Γ IHΓ] ρ /=; apply _. Qed.
+
   Definition ietp Γ T e : iProp Σ :=
-    ∀ ρ, G⟦Γ⟧ ρ → ⟦T⟧ₑ ρ (e.|[ρ]).
+    □ ∀ ρ, G⟦Γ⟧ ρ → ⟦T⟧ₑ ρ (e.|[ρ]).
   #[global] Arguments ietp /.
   Notation "Γ ⊨ e : T" := (ietp Γ T e) (at level 74, e, T at next level).
 
   Definition ietpi Γ T e i : iProp Σ :=
-    ∀ ρ, G⟦Γ⟧ ρ → ▷^i ⟦T⟧ₑ ρ (e.|[ρ]).
+    □ ∀ ρ, G⟦Γ⟧ ρ → ▷^i ⟦T⟧ₑ ρ (e.|[ρ]).
   #[global] Arguments ietpi /.
   Notation "Γ ⊨ e : T , i" := (ietpi Γ T e i) (at level 74, e, T at next level).
 
   (** Indexed Subtyping. Defined on closed values. We must require closedness
       explicitly, since closedness now does not follow from being well-typed later. *)
   Definition istpi Γ T1 T2 i j : iProp Σ :=
-    ∀ ρ v, G⟦Γ⟧ ρ → (▷^i ⟦T1⟧ ρ v) → ▷^j ⟦T2⟧ ρ v.
+    □ ∀ ρ v, G⟦Γ⟧ ρ → (▷^i ⟦T1⟧ ρ v) → ▷^j ⟦T2⟧ ρ v.
   #[global] Arguments istpi /.
 
   Definition delayed_ivstp Γ T1 T2 i : iProp Σ :=
-    ∀ ρ, G⟦Γ⟧ρ → ▷^i ∀v, ⟦T1⟧ ρ v → ⟦T2⟧ ρ v.
+    □ ∀ ρ, G⟦Γ⟧ρ → ▷^i ∀v, ⟦T1⟧ ρ v → ⟦T2⟧ ρ v.
   #[global] Arguments delayed_ivstp /.
+
+  #[global] Instance ietp_persistent Γ T e : Persistent (ietp Γ T e) := _.
+  #[global] Instance ietpi_persistent Γ T e i : Persistent (ietpi Γ T e i) := _.
+  #[global] Instance istpi_persistent Γ T1 T2 i j : Persistent (istpi Γ T1 T2 i j) := _.
 End logrel_part2.
 
 Notation "G⟦ Γ ⟧" := (interp_env Γ).
@@ -272,7 +284,7 @@ Section logrel_lemmas.
   Lemma semantic_typing_uniform_step_index Γ T e i :
     Γ ⊨ e : T -∗ Γ ⊨ e : T, i.
   Proof.
-    iIntros "#H %ρ #HΓ".
+    iIntros "#H !> %ρ #HΓ".
     iInduction i as [|i] "IHi". by iApply "H". iExact "IHi".
   Qed.
 
@@ -290,22 +302,22 @@ Section logrel_lemmas.
 
   Context {Γ}.
   Lemma Sub_Refl T i : ⊢ Γ ⊨ T, i <: T, i.
-  Proof. by iIntros "/= **". Qed.
+  Proof. by iIntros "!> /= **". Qed.
 
   Lemma Sub_Trans T1 T2 T3 i1 i2 i3 :
     Γ ⊨ T1, i1 <: T2, i2 -∗ Γ ⊨ T2, i2 <: T3, i3 -∗ Γ ⊨ T1, i1 <: T3, i3.
   Proof.
-    iIntros "#Hsub1 #Hsub2 /= * #Hg #HT".
+    iIntros "#Hsub1 #Hsub2 !> /= * #Hg #HT".
     iApply ("Hsub2" with "Hg (Hsub1 Hg [//])").
   Qed.
 
   Lemma DSub_Refl T i : ⊢ Γ ⊨[i] T <: T.
-  Proof. by iIntros "/= ** !> **". Qed.
+  Proof. by iIntros "/= !> ** !> **". Qed.
 
   Lemma DSub_Trans T1 T2 T3 i :
     Γ ⊨[i] T1 <: T2 -∗ Γ ⊨[i] T2 <: T3 -∗ Γ ⊨[i] T1 <: T3.
   Proof.
-    iIntros "#Hsub1 #Hsub2 /= * #Hg".
+    iIntros "#Hsub1 #Hsub2 !> /= * #Hg".
     iSpecialize ("Hsub1" with "Hg"); iSpecialize ("Hsub2" with "Hg").
     iIntros "!>" (v) "#HT". iApply "Hsub2". by iApply "Hsub1".
   Qed.

--- a/theories/DSub/lr/unary_lr.v
+++ b/theories/DSub/lr/unary_lr.v
@@ -1,4 +1,4 @@
-From D Require Export iris_prelude saved_interp_n proper.
+From D Require Export iris_prelude saved_interp_n proper proofmode_pupd.
 From D Require Import persistence.
 From D.DSub Require Import syn.
 From D.DSub Require Import ty_interp_subst_lemmas.
@@ -284,7 +284,7 @@ Section logrel_lemmas.
   Lemma semantic_typing_uniform_step_index Γ T e i :
     Γ ⊨ e : T -∗ Γ ⊨ e : T, i.
   Proof.
-    iIntros "#H !> %ρ #HΓ".
+    pupd. iIntros "#H !> %ρ #HΓ".
     iInduction i as [|i] "IHi". by iApply "H". iExact "IHi".
   Qed.
 
@@ -302,22 +302,22 @@ Section logrel_lemmas.
 
   Context {Γ}.
   Lemma Sub_Refl T i : ⊢ Γ ⊨ T, i <: T, i.
-  Proof. by iIntros "!> /= **". Qed.
+  Proof. pupd. by iIntros "!> /= **". Qed.
 
   Lemma Sub_Trans T1 T2 T3 i1 i2 i3 :
     Γ ⊨ T1, i1 <: T2, i2 -∗ Γ ⊨ T2, i2 <: T3, i3 -∗ Γ ⊨ T1, i1 <: T3, i3.
   Proof.
-    iIntros "#Hsub1 #Hsub2 !> /= * #Hg #HT".
+    pupd; iIntros "#Hsub1 #Hsub2 !> /= * #Hg #HT".
     iApply ("Hsub2" with "Hg (Hsub1 Hg [//])").
   Qed.
 
   Lemma DSub_Refl T i : ⊢ Γ ⊨[i] T <: T.
-  Proof. by iIntros "/= !> ** !> **". Qed.
+  Proof. pupd; by iIntros "/= !> ** !> **". Qed.
 
   Lemma DSub_Trans T1 T2 T3 i :
     Γ ⊨[i] T1 <: T2 -∗ Γ ⊨[i] T2 <: T3 -∗ Γ ⊨[i] T1 <: T3.
   Proof.
-    iIntros "#Hsub1 #Hsub2 !> /= * #Hg".
+    pupd; iIntros "#Hsub1 #Hsub2 !> /= * #Hg".
     iSpecialize ("Hsub1" with "Hg"); iSpecialize ("Hsub2" with "Hg").
     iIntros "!>" (v) "#HT". iApply "Hsub2". by iApply "Hsub1".
   Qed.

--- a/theories/DSub/lr/unary_lr.v
+++ b/theories/DSub/lr/unary_lr.v
@@ -237,23 +237,23 @@ Section logrel_part2.
   Proof. elim: Γ ρ => [|τ Γ IHΓ] ρ /=; apply _. Qed.
 
   Definition ietp Γ T e : iProp Σ :=
-    □ ∀ ρ, G⟦Γ⟧ ρ → ⟦T⟧ₑ ρ (e.|[ρ]).
+    <PB> ∀ ρ, G⟦Γ⟧ ρ → ⟦T⟧ₑ ρ (e.|[ρ]).
   #[global] Arguments ietp /.
   Notation "Γ ⊨ e : T" := (ietp Γ T e) (at level 74, e, T at next level).
 
   Definition ietpi Γ T e i : iProp Σ :=
-    □ ∀ ρ, G⟦Γ⟧ ρ → ▷^i ⟦T⟧ₑ ρ (e.|[ρ]).
+    <PB> ∀ ρ, G⟦Γ⟧ ρ → ▷^i ⟦T⟧ₑ ρ (e.|[ρ]).
   #[global] Arguments ietpi /.
   Notation "Γ ⊨ e : T , i" := (ietpi Γ T e i) (at level 74, e, T at next level).
 
   (** Indexed Subtyping. Defined on closed values. We must require closedness
       explicitly, since closedness now does not follow from being well-typed later. *)
   Definition istpi Γ T1 T2 i j : iProp Σ :=
-    □ ∀ ρ v, G⟦Γ⟧ ρ → (▷^i ⟦T1⟧ ρ v) → ▷^j ⟦T2⟧ ρ v.
+    <PB> ∀ ρ v, G⟦Γ⟧ ρ → (▷^i ⟦T1⟧ ρ v) → ▷^j ⟦T2⟧ ρ v.
   #[global] Arguments istpi /.
 
   Definition delayed_ivstp Γ T1 T2 i : iProp Σ :=
-    □ ∀ ρ, G⟦Γ⟧ρ → ▷^i ∀v, ⟦T1⟧ ρ v → ⟦T2⟧ ρ v.
+    <PB> ∀ ρ, G⟦Γ⟧ρ → ▷^i ∀v, ⟦T1⟧ ρ v → ⟦T2⟧ ρ v.
   #[global] Arguments delayed_ivstp /.
 
   #[global] Instance ietp_persistent Γ T e : Persistent (ietp Γ T e) := _.

--- a/theories/Dot/hkdot/path_equiv.v
+++ b/theories/Dot/hkdot/path_equiv.v
@@ -137,7 +137,7 @@ Print hoD *)
     iIntros ">#Hstp !>" (ρ v1 v2) "Hg".
     iApply mlaterN_impl. iIntros "#[HT1 HT2]".
     rewrite /rVMu/=; iSplit; iApply ("Hstp" $! (_ .: ρ) _ _ with "[$Hg]") => //.
-    all: iNext i; asimpl.
+    all: iNext i; cbn.
     iApply (quasi_refl_l with "HT1").
     iApply (quasi_refl_r with "HT2").
   Qed.

--- a/theories/Dot/lr/dot_lty.v
+++ b/theories/Dot/lr/dot_lty.v
@@ -219,6 +219,14 @@ Section dty2clty.
 End dty2clty.
 #[global] Instance : Params (@dty2clty) 3 := {}.
 
+Program Definition cAnd {Σ} (Tds1 Tds2 : clty Σ) : clty Σ :=
+  Clty (Dslty (λI ρ ds, Tds1 ρ ds ∧ Tds2 ρ ds)) (oAnd Tds1 Tds2).
+Next Obligation. intros. by rewrite /= -!clty_def2defs_head. Qed.
+Next Obligation. intros. by rewrite /= -!clty_mono. Qed.
+Next Obligation. intros. by rewrite /= -!clty_commute. Qed.
+
+#[global] Instance : Params (@cAnd) 1 := {}.
+
 Section DefsTypes.
   Context `{HdotG : !dlangG Σ}.
 
@@ -245,13 +253,7 @@ Section DefsTypes.
   #[global] Instance clty_bottom : Bottom (clty Σ) := olty2clty ⊥.
   #[global] Instance clty_inh : Inhabited (clty Σ) := populate ⊥.
 
-  Program Definition cAnd (Tds1 Tds2 : clty Σ) : clty Σ :=
-    Clty (Dslty (λI ρ ds, Tds1 ρ ds ∧ Tds2 ρ ds)) (oAnd Tds1 Tds2).
-  Next Obligation. intros. by rewrite /= -!clty_def2defs_head. Qed.
-  Next Obligation. intros. by rewrite /= -!clty_mono. Qed.
-  Next Obligation. intros. by rewrite /= -!clty_commute. Qed.
-
-  #[global] Instance cAnd_ne : NonExpansive2 cAnd.
+  #[global] Instance cAnd_ne : NonExpansive2 (cAnd (Σ := Σ)).
   Proof. split; rewrite /=; repeat f_equiv; solve_proper_ho. Qed.
   #[global] Instance cAnd_proper : Proper2 cAnd :=
     ne_proper_2 _.
@@ -265,8 +267,6 @@ Section DefsTypes.
     split; [intros ρ ds | intros args ρ v]; apply: (right_id _ bi_and).
   Qed.
 End DefsTypes.
-
-#[global] Instance : Params (@cAnd) 1 := {}.
 
 Implicit Types (T : ty).
 

--- a/theories/Dot/lr/path_wp.v
+++ b/theories/Dot/lr/path_wp.v
@@ -7,13 +7,11 @@ The defining equations are proven as lemmas [path_wp_pv_eq] and
 From D Require Import iris_prelude iris_extra.det_reduction.
 From D.Dot Require Import dlang_inst rules lr_syn_aux path_repl.
 From D.pure_program_logic Require Import lifting.
+From iris.bi Require Import fixpoint big_op.
 
 Implicit Types
          (L T U : ty) (v : vl) (e : tm) (d : dm) (ds : dms) (p : path)
-         (Γ : ctx) (ρ : env) (Pv : vl → Prop).
-
-Set Suggest Proof Using.
-Set Default Proof Using "Type".
+         (Γ : ctx) (ρ : env) (Pv : vl → Prop) (Σ : gFunctors).
 
 (** A simplified variant of weakest preconditions for path evaluation.
 The difference is that path evaluation is completely pure, and
@@ -22,9 +20,6 @@ vp ("Value from Path") and vq range over results of evaluating paths.
 Below, we define a version internal to Iris, following Iris's total weakest
 precondition. *)
 
-From iris.bi Require Import fixpoint big_op.
-(* From iris.program_logic Require Export weakestpre. *)
-Set Default Proof Using "Type".
 Import uPred.
 
 Canonical Structure pathO := leibnizO path.
@@ -301,18 +296,6 @@ Section path_wp_lemmas.
     iDestruct 1 as (v Hcl) "H". eauto.
   Qed.
 
-  Lemma path_wp_to_wp p φ :
-    path_wp p (λ v, φ v) -∗
-    WP (path2tm p) {{ v, φ v }}.
-  Proof.
-    rewrite path_wp_pure_exec; iDestruct 1 as (v [n Hex]) "H".
-    by wp_pure.
-  Qed.
-
-  Lemma path_wp_pure_to_wp {p v} (Hpwpp : path_wp_pure p (eq v)) :
-    ⊢ WP (path2tm p) {{ w, ⌜ v = w ⌝ }}.
-  Proof. rewrite -path_wp_to_wp. by iIntros "!%". Qed.
-
   #[global] Instance path_wp_timeless p Pv : Timeless (path_wp p (λI v, ⌜Pv v⌝)).
   Proof. rewrite path_wp_pureable. apply _. Qed.
 
@@ -322,4 +305,18 @@ Section path_wp_lemmas.
     rewrite path_wp_pure_exec; iDestruct 1 as (v [n Hp]) "_"; iIntros "!%".
     exact: PureExec_to_terminates.
   Qed.
+
+  Section wp.
+    Lemma path_wp_to_wp p φ :
+      path_wp p (λ v, φ v) -∗
+      WP (path2tm p) {{ v, φ v }}.
+    Proof.
+      rewrite path_wp_pure_exec; iDestruct 1 as (v [n Hex]) "H".
+      by wp_pure.
+    Qed.
+
+    Lemma path_wp_pure_to_wp {p v} (Hpwpp : path_wp_pure p (eq v)) :
+      ⊢ WP (path2tm p) {{ w, ⌜ v = w ⌝ }}.
+    Proof. rewrite -path_wp_to_wp. by iIntros "!%". Qed.
+  End wp.
 End path_wp_lemmas.

--- a/theories/Dot/lr/unary_lr.v
+++ b/theories/Dot/lr/unary_lr.v
@@ -384,7 +384,7 @@ Section path_repl_lemmas.
   Let fundamental_ty_path_repl_def p q T1 T2 := V⟦ T1 ⟧ ~sTpP[ p := q ]* V⟦ T2 ⟧.
   Let fundamental_kn_path_repl_def p q K1 K2 := K⟦ K1 ⟧ ~sKpP[ p := q ]* K⟦ K2 ⟧.
 
-  Local Lemma fundamental_ty_kn_mut_path_repl p q :
+  #[local] Lemma fundamental_ty_kn_mut_path_repl p q :
     (∀ T1 T2 (Hrew : T1 ~Tp[ p := q ] T2), fundamental_ty_path_repl_def p q T1 T2) ∧
     (∀ K1 K2 (Hrew : K1 ~Kp[ p := q ] K2), fundamental_kn_path_repl_def p q K1 K2).
   Proof.

--- a/theories/iris_extra/proofmode_extra.v
+++ b/theories/iris_extra/proofmode_extra.v
@@ -43,6 +43,13 @@ Lemma and2_exist_r {PROP : bi} {A} P Q R :
   (∃ a : A, P a ∧ Q a ∧ R) ⊣⊢@{PROP} (∃ a : A, P a ∧ Q a) ∧ R.
 Proof. rewrite (and_exist_r R); apply bi.exist_proper => d; exact: assoc. Qed.
 
+Lemma forall_intuitionistically {A} `{BiAffine PROP, BiPersistentlyForall PROP} (Φ : A → PROP) :
+  (∀ x, □ Φ x) ⊣⊢ □ ∀ x, Φ x.
+Proof.
+  iSplit; last iApply intuitionistically_forall.
+  iIntros "#H !> %". by iApply "H".
+Qed.
+
 Section proofmode_extra.
   Context {PROP : bi}.
   Implicit Types P Q R : PROP.
@@ -96,6 +103,15 @@ Section proofmode_extra.
     exact: strip_pure_laterN_wand.
   Qed.
 End proofmode_extra.
+
+From iris.base_logic Require Import bi.
+Section derived_swap_lemmas.
+  Context `{M : ucmra}.
+  Lemma mlater_pers (P: uPred M) : □ ▷ P ⊣⊢ ▷ □ P.
+  Proof. iSplit; by iIntros "#? !>!>". Qed.
+  Lemma mlaterN_pers (P: uPred M) i : □ ▷^i P ⊣⊢ ▷^i □ P.
+  Proof. iSplit; by iIntros "#? !>!>". Qed.
+End derived_swap_lemmas.
 
 From D.pure_program_logic Require Import lifting.
 From iris.program_logic Require Import language.

--- a/theories/iris_extra/proofmode_pupd.v
+++ b/theories/iris_extra/proofmode_pupd.v
@@ -1,0 +1,101 @@
+(** * Automation for the "persistent update" modalities.
+This reduces goal like [⊢ <PB> P1 -∗ <PB> P2 -∗ <PB> Q] to
+[⊢ □ P1 -* □ P2 -∗ □ Q], by running all ghost updates and (optionally)
+introducing the ghost update modality. Support for [<PF{E}>] works similarly, so
+we focus on [<PB>] in these docs.
+
+We use custom automation, because [iMod] and [ElimModal] do not allow performing
+ghost updates when the goal starts with the [□ |==>] modalities, so tactics like
+[iIntros "#>#P1 #>#P2"] do not work and cannot be supported via [ElimModal]
+instances.
+
+The fundamental reason is that [<PB>] is only a monad over intuitionistic propositions,
+so goals like
+<<
+  <PB> P1 -∗ <PB> P2 -∗ <PB> Q
+>>
+reduce to boxed wands like
+<<
+  □ (□ P1 -* □ P2 -∗ <PB> Q)
+>>
+but [ElimModal] does not allow generating boxed wands:
+<<
+Class ElimModal {PROP : bi} (φ : Prop) (p p' : bool) (P P' : PROP) (Q Q' : PROP) :=
+  elim_modal : φ → □?p P ∗ (□?p' P' -∗ Q') ⊢ Q.
+>>
+*)
+From D Require Export iris_prelude iris_extra.pupd.
+
+Implicit Type (Σ : gFunctors) (E : coPset).
+
+Class ElimPersModal {PROP : bi} (P Q P' Q' : PROP) :=
+  elim_pers_modal : (□(P' -∗ Q') ⊢ P -∗ Q).
+#[global] Hint Mode ElimPersModal + + + - - : typeclass_instances.
+#[global] Arguments elim_pers_modal {_}.
+
+Section instances.
+  Context {PROP : bi}.
+  Implicit Type (P Q R : PROP).
+
+  (* Fallback to allow skipping intuitionistic hypotheses *)
+  #[global] Instance elim_pers_modal_wand_noelim P Q Q' R R' `{!Persistent P, !Affine P} :
+    ElimPersModal Q R Q' R' →
+    ElimPersModal P (Q -∗ R) P (Q' -∗ R') | 50.
+  Proof.
+    rewrite /ElimPersModal.
+    iIntros (W) "#W #P Q".
+    iApply (W with "(W P) Q").
+  Qed.
+
+  Section bupd.
+    Context `{!BiBUpd PROP}.
+
+    #[global] Instance elim_pers_modal_int_bupd_int P R :
+      ElimPersModal (<PB> P) (<PB> R) (□ P) (<PB> R).
+    Proof.
+      rewrite /ElimPersModal.
+      iIntros "W P". iApply (PB_bind with "P W").
+    Qed.
+
+    (* Meant to strip modalities from all premises, unlike [elim_pers_modal_wand].
+    Alternative to [elim_pers_modal_wand_all] *)
+    #[global] Instance elim_pers_modal_wand_elim P Q R R' :
+      (∀ Q, ElimPersModal (<PB> Q) R (□ Q) R') →
+      ElimPersModal (<PB> P) (<PB> Q -∗ R) (□ P) (□ Q -∗ R').
+    Proof.
+      rewrite /ElimPersModal.
+      iIntros (W) "#W #P #Q".
+      iApply (W (P ∧ Q)%I). {
+        iIntros "!> {P Q} #[P Q]".
+        iApply ("W" with "P Q").
+      }
+      iApply (PB_and_curry with "P Q").
+    Qed.
+  End bupd.
+
+  Section fupd.
+    Context `{!BiFUpd PROP} E.
+
+    #[global] Instance elim_pers_modal_int_fupd_int P R :
+      ElimPersModal (<PF{E}> P) (<PF{E}> R) (□ P) (<PF{E}> R).
+    Proof.
+      rewrite /ElimPersModal.
+      iIntros "W P". iApply (PF_bind with "P W").
+    Qed.
+
+    (* Meant to strip modalities from all premises, unlike [elim_pers_modal_wand].
+    Alternative to [elim_pers_modal_wand_all] *)
+    #[global] Instance elim_pers_modal_fupd_wand_elim P Q R R' :
+      (∀ Q, ElimPersModal (<PF{E}> Q) R (□ Q) R') →
+      ElimPersModal (<PF{E}> P) (<PF{E}> Q -∗ R) (□ P) (□ Q -∗ R').
+    Proof.
+      rewrite /ElimPersModal.
+      iIntros (W) "#W #P #Q".
+      iApply (W (P ∧ Q)%I). {
+        iIntros "!> {P Q} #[P Q]".
+        iApply ("W" with "P Q").
+      }
+      iApply (PF_and_curry with "P Q").
+    Qed.
+  End fupd.
+End instances.

--- a/theories/iris_extra/proofmode_pupd.v
+++ b/theories/iris_extra/proofmode_pupd.v
@@ -130,4 +130,4 @@ Ltac pupd' :=
 Ltac strip :=
   iApply (strip_pupd with "[-]"); [].
 Ltac pupd :=
-  pupd'; strip.
+  try (pupd'; strip).

--- a/theories/iris_extra/proofmode_pupd.v
+++ b/theories/iris_extra/proofmode_pupd.v
@@ -124,3 +124,10 @@ Section instances.
     Proof. apply PF_return. Qed.
   End fupd.
 End instances.
+
+Ltac pupd' :=
+  try (iApply elim_pers_modal; []; iModIntro (□ _)%I).
+Ltac strip :=
+  iApply (strip_pupd with "[-]"); [].
+Ltac pupd :=
+  pupd'; strip.

--- a/theories/iris_extra/proofmode_pupd.v
+++ b/theories/iris_extra/proofmode_pupd.v
@@ -33,6 +33,11 @@ Class ElimPersModal {PROP : bi} (P Q P' Q' : PROP) :=
 #[global] Hint Mode ElimPersModal + + + - - : typeclass_instances.
 #[global] Arguments elim_pers_modal {_}.
 
+Class StripPUpd {PROP : bi} (P Q : PROP) :=
+  strip_pupd : P ⊢ Q.
+#[global] Hint Mode StripPUpd + - + : typeclass_instances.
+#[global] Arguments strip_pupd {_}.
+
 Section instances.
   Context {PROP : bi}.
   Implicit Type (P Q R : PROP).
@@ -46,6 +51,20 @@ Section instances.
     iIntros (W) "#W #P Q".
     iApply (W with "(W P) Q").
   Qed.
+
+  #[global] Instance strip_pupd_wand P Q R :
+    StripPUpd P Q →
+    StripPUpd (R -∗ P) (R -∗ Q).
+  Proof.
+    rewrite /StripPUpd.
+    iIntros (PQ) "RP R".
+    iApply (PQ with "(RP R)").
+  Qed.
+
+  #[global] Instance strip_pupd_box_mono P Q :
+    StripPUpd P Q →
+    StripPUpd (□ P) (□ Q) | 10.
+  Proof. apply bi.intuitionistically_mono'. Qed.
 
   Section bupd.
     Context `{!BiBUpd PROP}.
@@ -71,6 +90,9 @@ Section instances.
       }
       iApply (PB_and_curry with "P Q").
     Qed.
+
+    #[global] Instance strip_pbupd P : StripPUpd (□ P) (<PB> P).
+    Proof. apply PB_return. Qed.
   End bupd.
 
   Section fupd.
@@ -97,5 +119,8 @@ Section instances.
       }
       iApply (PF_and_curry with "P Q").
     Qed.
+
+    #[global] Instance strip_pfupd P : StripPUpd (□ P) (<PF{E}> P).
+    Proof. apply PF_return. Qed.
   End fupd.
 End instances.

--- a/theories/iris_extra/pupd.v
+++ b/theories/iris_extra/pupd.v
@@ -1,0 +1,94 @@
+(** Automation for the "Persistent Update" modality. *)
+From D Require Export iris_prelude.
+
+Implicit Type (Σ : gFunctors) (E : coPset).
+
+(** * "Persistent updates".
+[<PB> P] is an intuitionistic propositon that allows allocating persistent ghost
+state before proving [P].
+*)
+Notation pbupd P := (□ |==> □ P)%I.
+Notation pfupd E P := (□ |={E}=> □ P)%I.
+Notation "<PB> P" := (pbupd P) (at level 20, right associativity).
+Notation "<PF{ E }> P" := (pfupd E P) (at level 20, right associativity).
+
+Section persistent_updates.
+  Context {PROP : bi}.
+  Implicit Type (P Q R : PROP).
+
+  Section bupd.
+    Context `{!BiBUpd PROP}.
+
+    (* [<PB>] is a monad on the subcategory of intuitionistic propositions. *)
+    Lemma PB_return P : □ P -∗ <PB> P.
+    Proof. by iIntros "#$". Qed.
+
+    Lemma PB_bind P Q : <PB> P -∗ □ (□ P -∗ <PB> Q) -∗ <PB> Q.
+    Proof.
+      iIntros "#P #W !>". iMod "P" as "#P".
+      iApply ("W" with "P").
+    Qed.
+
+    Lemma PB_join P : <PB> <PB> P -∗ <PB> P.
+    Proof. iIntros "#P !>". by iMod "P". Qed.
+
+    (* [<PB>] distributes over conjunctions. *)
+
+    Lemma PB_sep_curry P Q : <PB> P -∗ <PB> Q -∗ <PB> (P ∗ Q).
+    Proof.
+      iIntros "#P #Q !>".
+      by iMod "P" as "#$"; iMod "Q" as "#$".
+    Qed.
+
+    Lemma PB_sep P Q : <PB> P ∗ <PB> Q -∗ <PB> (P ∗ Q).
+    Proof. iIntros "[P Q]". iApply (PB_sep_curry with "P Q"). Qed.
+
+    Lemma PB_and P Q : <PB> P ∧ <PB> Q -∗ <PB> (P ∧ Q).
+    Proof.
+      iIntros "[#P #Q] !>".
+      iMod "P" as "#P". iMod "Q" as "#Q".
+      by iFrame "#".
+    Qed.
+
+    Lemma PB_and_curry P Q : <PB> P -∗ <PB> Q -∗ <PB> (P ∧ Q).
+    Proof. iIntros "P Q". iApply PB_and. iFrame. Qed.
+  End bupd.
+
+  Section fupd.
+    Context `{!BiFUpd PROP} E.
+
+    (* [<PF{E}>] is a monad on the subcategory of intuitionistic propositions. *)
+    Lemma PF_return P : □ P -∗ <PF{E}> P.
+    Proof. by iIntros "#$". Qed.
+
+    Lemma PF_bind P Q : <PF{E}> P -∗ □ (□ P -∗ <PF{E}> Q) -∗ <PF{E}> Q.
+    Proof.
+      iIntros "#P #W !>". iMod "P" as "#P".
+      iApply ("W" with "P").
+    Qed.
+
+    Lemma PF_join P : <PF{E}> <PF{E}> P -∗ <PF{E}> P.
+    Proof. iIntros "#P !>". by iMod "P". Qed.
+
+    (* [<PF>] distributes over conjunctions. *)
+    Lemma PF_sep P Q : <PF{E}> P ∗ <PF{E}> Q -∗ <PF{E}> (P ∗ Q).
+    Proof.
+      iIntros "[#P #Q] !>".
+      iMod "P" as "#P". iMod "Q" as "#Q".
+      by iFrame "#".
+    Qed.
+
+    Lemma PF_sep_curry P Q : <PF{E}> P -∗ <PF{E}> Q -∗ <PF{E}> (P ∗ Q).
+    Proof. iApply wand_curry. iApply PF_sep. Qed.
+
+    Lemma PF_and P Q : <PF{E}> P ∧ <PF{E}> Q -∗ <PF{E}> (P ∧ Q).
+    Proof.
+      iIntros "[#P #Q] !>".
+      iMod "P" as "#P". iMod "Q" as "#Q".
+      by iFrame "#".
+    Qed.
+
+    Lemma PF_and_curry P Q : <PF{E}> P -∗ <PF{E}> Q -∗ <PF{E}> (P ∧ Q).
+    Proof. iIntros "P Q". iApply PF_and. iFrame. Qed.
+  End fupd.
+End persistent_updates.

--- a/theories/pure_program_logic/weakestpre.v
+++ b/theories/pure_program_logic/weakestpre.v
@@ -37,8 +37,8 @@ Definition wp_def `{irisGS Λ Σ} : Wp (iProp Σ) (expr Λ) (val Λ) stuckness :
   λ _ _, fixpoint wp_pre.
 Definition wp_aux : seal (@wp_def). Proof. by eexists. Qed.
 Definition wp' := wp_aux.(unseal).
-Global Arguments wp' {Λ Σ _}.
-Global Existing Instance wp'.
+#[global] Arguments wp' {Λ Σ _}.
+#[global] Existing Instance wp'.
 Lemma wp_eq `{irisGS Λ Σ} : wp = @wp_def Λ Σ _ _.
 Proof. by rewrite -wp_aux.(seal_eq). Qed.
 


### PR DESCRIPTION
- Here we introduce a "persistent update" modality (`<PB> P` that is `□ |==> □ P`), that can replace `|==>` when non-persistent resources are available, and intuitionistic propositions must be marked explicitly via `□`.
- We use this modality in DSub, to demonstrate this works in a complete proof. #421 uses this in Dot, but is still in rougher shape (for issues unrelated to `<PB>` itself, and related instead to persistence).