### PR TITLE
website: stop pinning old activesupport

### DIFF
--- a/website/Gemfile
+++ b/website/Gemfile
@@ -31,6 +31,3 @@ end
 
 # Performance-booster for watching directories on Windows
 gem "wdm", "~> 0.1.0", :install_if => Gem.win_platform?
-
-# Prevent dependabot downgrades (due to tzinfo upgrades)
-gem "activesupport", ">= 6.0.0"


### PR DESCRIPTION
This was a workaround anyway.