### PR TITLE
Some backward-compatible porting

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -13,6 +13,7 @@
 -arg -w -arg -deprecated-hint-rewrite-without-locality
 -arg -w -arg -deprecated-instance-without-locality
 -arg -w -arg -deprecated-typeclasses-transparency-without-locality
+-arg -w -arg -future-coercion-class-field
 
 theories/pure_program_logic/weakestpre.v
 theories/pure_program_logic/lifting.v

--- a/coq-dot-iris.opam
+++ b/coq-dot-iris.opam
@@ -7,7 +7,7 @@ synopsis: "Mechanization of gDOT in Iris"
 depends: [
   "coq" { (>= "8.15.0" & < "8.16~") }
   "coq-iris" { = "3.6.0" }
-  "coq-autosubst" { = "1.7" }
+  "coq-autosubst" { >= "1.7" | = "dev" }
 ]
 
 build: [

--- a/dune
+++ b/dune
@@ -17,4 +17,5 @@
     -w -deprecated-hint-rewrite-without-locality
     -w -deprecated-instance-without-locality
     -w -deprecated-typeclasses-transparency-without-locality
+    -w -future-coercion-class-field
     )))))

--- a/theories/asubst_base.v
+++ b/theories/asubst_base.v
@@ -122,7 +122,7 @@ Ltac solve_inv_fv_congruence :=
 (* asimpl is expensive, but sometimes needed when simplification does mistakes.
   It must also be done after injection because it might not rewrite under Hfv's
   binders. *)
-  by [ injection (Hfv ρ1 ρ2); trivial; by (idtac + asimpl; rewritePremises; reflexivity) |
+  by [ injection (Hfv ρ1 ρ2 HsEq); trivial; by (idtac + asimpl; rewritePremises; reflexivity) |
       rewrite ?(decomp_s _ ρ1) ?(decomp_s _ ρ2) ?(decomp_s_vl _ ρ1) ?(decomp_s_vl _ ρ2) (eq_n_s_heads HsEq); last lia;
       injection (Hfv _ _ (eq_n_s_tails HsEq)); by rewritePremises ].
 


### PR DESCRIPTION
From https://github.com/Blaisorblade/dot-iris/pull/421, https://github.com/Blaisorblade/dot-iris/pull/424, and the autosubst one is from test with 8.17.